### PR TITLE
Remove str_replace on $pick object, should make comparison between selec...

### DIFF
--- a/ui/admin/setup_edit_field.php
+++ b/ui/admin/setup_edit_field.php
@@ -16,7 +16,7 @@ foreach ( $field_settings[ 'field_types' ] as $field_type => $field_label ) {
         $no_advanced[] = $field_type;
 }
 
-    $pick_object = str_replace( '_', '-', trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_val', $field ), '-' ) );
+    $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_val', $field ), '-' );
 ?>
         <tr id="row-<?php echo $pods_i; ?>" class="pods-manage-row pods-field-<?php echo esc_attr(pods_var('name', $field)) . ( '--1' === $pods_i ? ' flexible-row' : ' pods-submittable-fields' ); ?>" valign="top" data-row="<?php echo $pods_i; ?>">
             <th scope="row" class="check-field pods-manage-sort">


### PR DESCRIPTION
...ted fields work in the setup form.

This str_replace causes select values to not show after a save, for
example pods-product_categories becomes pods-product-categories, when
compared in the select.php they are obviously not equal and won't appear
selected, quite nasty to track doesn't seem to affect anything else.
