### PR TITLE
Missing operator when comparing against a singular value in a Pods->find where clause

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1072,7 +1072,7 @@ class Pods {
                     if ( is_array( $where[ 'value' ] ) )
                         $where = $where[ 'key' ] . ' ' . $where[ 'compare' ] . ' ( "' . implode( '", "', $where[ 'value' ] ) . '" )';
                     else
-                        $where = $where[ 'key' ] . ' "' . (string) $where[ 'value' ] . '"';
+                        $where = $where[ 'key' ] . ' ' . $where[ 'compare' ] . ' "' . (string) $where[ 'value' ] . '"';
 
                     $params->where[ $k ] = apply_filters( 'pods_find_where_query', $where, $where_args );
                 }


### PR DESCRIPTION
When calling `Pods->find()` with a where clause involving a comparison against a singular value (i.e. not an array of values), the `$where['compare']` is not concatenated into the resulting SQL, producing an SQL parse error.

Code snippet to reproduce this bug in the current version:

``` php
$pod = pods('mypod');
$pod->find(array(
    'where' => array(
        'somefield' => 'somevalue'
    )
));
```

Expected result:
- The pod records with field `somefield` equal to `somevalue` are retrieved in `$pod`.

Actual result:
- An SQL parse error is thrown.

This one-line change fixes the error, resulting in valid SQL and proper record retrieval.
