### PR TITLE
Fixed comparison operators always set to default and fixed BETWEEN and NOT BETWEEN.

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -999,11 +999,13 @@ class Pods {
 
                         continue;
                     }
+                    
+                    $where[ 'compare' ] = strtoupper( $where[ 'compare' ] );
 
                     if ( !in_array( $where[ 'compare' ], array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN' ) ) )
                         $where[ 'compare' ] = '=';
 
-                    $where[ 'type' ] = strtotime( $where[ 'type' ] );
+                    $where[ 'type' ] = strtoupper( $where[ 'type' ] );
 
                     if ( !in_array( $where[ 'type' ], array( 'NUMERIC', 'BINARY', 'CHAR', 'DATE', 'DATETIME', 'DECIMAL', 'SIGNED', 'TIME', 'UNSIGNED' ) ) )
                         $where[ 'type' ] = 'CHAR';


### PR DESCRIPTION
This pull requests consists of two commits, and a third to fix up my tabs. :unamused:
1. For some reason, `strtotime()` was applied to `$where['compare']` in `Pods->find()`. Since comparison operators don't ever represent formatted date strings, this call always produced `false`. The next statement then reverts the operator to the default `=`, effectively rejecting all custom operator requests.
   
   I simply removed that line to get the desired behaviour.
2. Previously, operators accepting an array of values simply concatenated the array into a list of values, such as `("foo", "bar", "baz")`. This works for `IN` and `NOT IN`, but `BETWEEN` and `NOT BETWEEN` use a different syntax: `BETWEEN "foo" AND "bar"`.
   
   For this, I decided to overwrite `$where['value']` in order to produce the right syntax, although this means that plugins hooking into `pods_find_where_query` will now see a flattened value instead of the originally passed value in `$where_args['value']`. Alternatively you could store the flattened value in a local variable, or in a different member such as `$where_args['value_flat']`. I'm not really sure what is the 'best' solution, I don't know what the 'contract' for this specific hook is.
