### PR TITLE
Use 24-hour format for time pickers when configured in field.

### DIFF
--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -52,8 +52,10 @@ if ( false !== stripos( $args[ 'timeFormat' ], 'tt' ) )
 
 $html5_format = 'Y-m-d\TH:i:s';
 
-if ( 24 == pods_var( 'datetime_time_type', $options, 12 ) )
+if ( 24 == pods_var( 'datetime_time_type', $options, 12 ) ) {
     $args[ 'ampm' ] = false;
+    $args[ 'timeFormat' ] = str_replace( 'h', 'H', $args[ 'timeFormat' ] );
+}
 
 $date = PodsForm::field_method( 'datetime', 'createFromFormat', $format, (string) $value );
 $date_default = PodsForm::field_method( 'datetime', 'createFromFormat', 'Y-m-d H:i:s', (string) $value );

--- a/ui/fields/time.php
+++ b/ui/fields/time.php
@@ -42,8 +42,10 @@ if ( false !== stripos( $args[ 'timeFormat' ], 'tt' ) )
 
 $html5_format = '\TH:i:s';
 
-if ( 24 == pods_var( 'time_type', $options, 12 ) )
+if ( 24 == pods_var( 'time_type', $options, 12 ) ) {
     $args[ 'ampm' ] = false;
+    $args[ 'timeFormat' ] = str_replace( 'h', 'H', $args[ 'timeFormat' ] );
+}
 
 $date = PodsForm::field_method( 'time', 'createFromFormat', $format, (string) $value );
 $date_default = PodsForm::field_method( 'time', 'createFromFormat', 'H:i:s', (string) $value );


### PR DESCRIPTION
Previously, all date/time formats passed as options to jQuery Timepicker would have lower-case `h` as hour format character, indicating a 12-hour time format. This resulted in the time picker showing the time in 12-hour time format, regardless of the 24-hour format setting of the field.

This fix ensures that when the user chooses the 24-hour format for the field, all `h` format characters are replaced by `H`, similar to how it is handled in `format()` of `PodsField_DateTime` and `PodsField_Time`.
