### PR TITLE
Fixes custom SQL query rewriting in PodsData->build()

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1090,143 +1090,141 @@ class PodsData {
         	$params->orderby = implode( ', ', $params->orderby );
 
         // Rewrite
-        if ( true ) {
-            $sql = ' ' . trim( str_replace( array( "\n", "\r" ), ' ', $sql ) );
-            $sql = preg_replace( array(
-                    '/\sSELECT\sSQL_CALC_FOUND_ROWS\s/i',
-                    '/\sSELECT\s/i'
-                ),
-                array(
-                    ' SELECT ',
-                    ' SELECT SQL_CALC_FOUND_ROWS '
-                ),
-                $sql );
+        $sql = ' ' . trim( str_replace( array( "\n", "\r" ), ' ', $sql ) );
+        $sql = preg_replace( array(
+                '/\sSELECT\sSQL_CALC_FOUND_ROWS\s/i',
+                '/\sSELECT\s/i'
+            ),
+            array(
+                ' SELECT ',
+                ' SELECT SQL_CALC_FOUND_ROWS '
+            ),
+            $sql );
 
-            // Insert variables based on existing statements
-            if ( false === stripos( $sql, '%%SELECT%%' ) )
-                $sql = preg_replace( '/\sSELECT\sSQL_CALC_FOUND_ROWS\s/i', ' SELECT SQL_CALC_FOUND_ROWS %%SELECT%% ', $sql );
-            if ( false === stripos( $sql, '%%WHERE%%' ) )
-                $sql = preg_replace( '/\sWHERE\s(?!.*\sWHERE\s)/i', ' WHERE %%WHERE%% ', $sql );
-            if ( false === stripos( $sql, '%%GROUPBY%%' ) )
-                $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' GROUP BY %%GROUPBY%% ', $sql );
-            if ( false === stripos( $sql, '%%HAVING%%' ) )
-                $sql = preg_replace( '/\sHAVING\s(?!.*\sHAVING\s)/i', ' HAVING %%HAVING%% ', $sql );
-            if ( false === stripos( $sql, '%%ORDERBY%%' ) )
-                $sql = preg_replace( '/\sORDER BY\s(?!.*\sORDER BY\s)/i', ' ORDER BY %%ORDERBY%% ', $sql );
+        // Insert variables based on existing statements
+        if ( false === stripos( $sql, '%%SELECT%%' ) )
+            $sql = preg_replace( '/\sSELECT\sSQL_CALC_FOUND_ROWS\s/i', ' SELECT SQL_CALC_FOUND_ROWS %%SELECT%% ', $sql );
+        if ( false === stripos( $sql, '%%WHERE%%' ) )
+            $sql = preg_replace( '/\sWHERE\s(?!.*\sWHERE\s)/i', ' WHERE %%WHERE%% ', $sql );
+        if ( false === stripos( $sql, '%%GROUPBY%%' ) )
+            $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' GROUP BY %%GROUPBY%% ', $sql );
+        if ( false === stripos( $sql, '%%HAVING%%' ) )
+            $sql = preg_replace( '/\sHAVING\s(?!.*\sHAVING\s)/i', ' HAVING %%HAVING%% ', $sql );
+        if ( false === stripos( $sql, '%%ORDERBY%%' ) )
+            $sql = preg_replace( '/\sORDER BY\s(?!.*\sORDER BY\s)/i', ' ORDER BY %%ORDERBY%% ', $sql );
 
-            // Insert variables based on other existing statements
-            if ( false === stripos( $sql, '%%JOIN%%' ) ) {
-                if ( false !== stripos( $sql, ' WHERE ' ) )
-                    $sql = preg_replace( '/\sWHERE\s(?!.*\sWHERE\s)/i', ' %%JOIN%% WHERE ', $sql );
-                elseif ( false !== stripos( $sql, ' GROUP BY ' ) )
-                    $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' %%WHERE%% GROUP BY ', $sql );
-                elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
-                    $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%WHERE%% ORDER BY ', $sql );
-                else
-                    $sql .= ' %%JOIN%% ';
-            }
-            if ( false === stripos( $sql, '%%WHERE%%' ) ) {
-                if ( false !== stripos( $sql, ' GROUP BY ' ) )
-                    $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' %%WHERE%% GROUP BY ', $sql );
-                elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
-                    $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%WHERE%% ORDER BY ', $sql );
-                else
-                    $sql .= ' %%WHERE%% ';
-            }
-            if ( false === stripos( $sql, '%%GROUPBY%%' ) ) {
-                if ( false !== stripos( $sql, ' HAVING ' ) )
-                    $sql = preg_replace( '/\sHAVING\s(?!.*\sHAVING\s)/i', ' %%GROUPBY%% HAVING ', $sql );
-                elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
-                    $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%GROUPBY%% ORDER BY ', $sql );
-                else
-                    $sql .= ' %%GROUPBY%% ';
-            }
-            if ( false === stripos( $sql, '%%HAVING%%' ) ) {
-                if ( false !== stripos( $sql, ' ORDER BY ' ) )
-                    $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%HAVING%% ORDER BY ', $sql );
-                else
-                    $sql .= ' %%HAVING%% ';
-            }
-            if ( false === stripos( $sql, '%%ORDERBY%%' ) )
-                $sql .= ' %%ORDERBY%% ';
-            if ( false === stripos( $sql, '%%LIMIT%%' ) )
-                $sql .= ' %%LIMIT%% ';
-
-            // Replace variables
-            if ( 0 < strlen( $params->join ) )
-                $sql = str_ireplace( '%%JOIN%%', $params->join, $sql );
-            if ( 0 < strlen( $params->where ) ) {
-                if ( false !== stripos( $sql, ' WHERE ' ) ) {
-                    if ( false !== stripos( $sql, ' WHERE %%WHERE%% ' ) )
-                        $sql = str_ireplace( '%%WHERE%%', $params->where . ' AND ', $sql );
-                    else
-                        $sql = str_ireplace( '%%WHERE%%', ' AND ' . $params->where, $sql );
-                }
-                else
-                    $sql = str_ireplace( '%%WHERE%%', ' WHERE ' . $params->where, $sql );
-            }
-            if ( 0 < strlen( $params->groupby ) ) {
-                if ( false !== stripos( $sql, ' GROUP BY ' ) ) {
-                    if ( false !== stripos( $sql, ' GROUP BY %%GROUPBY%% ' ) )
-                        $sql = str_ireplace( '%%GROUPBY%%', $params->groupby . ', ', $sql );
-                    else
-                        $sql = str_ireplace( '%%GROUPBY%%', ', ' . $params->groupby, $sql );
-                }
-                else
-                    $sql = str_ireplace( '%%GROUPBY%%', ' GROUP BY ' . $params->groupby, $sql );
-            }
-            if ( 0 < strlen( $params->having ) && false !== stripos( $sql, ' GROUP BY ' ) ) {
-                if ( false !== stripos( $sql, ' HAVING ' ) ) {
-                    if ( false !== stripos( $sql, ' HAVING %%HAVING%% ' ) )
-                        $sql = str_ireplace( '%%HAVING%%', $params->having . ' AND ', $sql );
-                    else
-                        $sql = str_ireplace( '%%HAVING%%', ' AND ' . $params->having, $sql );
-                }
-                else
-                    $sql = str_ireplace( '%%HAVING%%', ' HAVING ' . $params->having, $sql );
-            }
-            if ( 0 < strlen( $params->orderby ) ) {
-                if ( false !== stripos( $sql, ' ORDER BY ' ) ) {
-                    if ( false !== stripos( $sql, ' ORDER BY %%ORDERBY%% ' ) )
-                        $sql = str_ireplace( '%%ORDERBY%%', $params->orderby . ', ', $sql );
-                    else
-                        $sql = str_ireplace( '%%ORDERBY%%', ', ' . $params->orderby, $sql );
-                }
-                else
-                    $sql = str_ireplace( '%%ORDERBY%%', ' ORDER BY ' . $params->orderby, $sql );
-            }
-            
-            // Produce totals query
-            $this->total_sql = $sql;
-            if ( 0 < strlen( $params->select ) ) {
-                if ( false !== stripos( $sql, '%%SELECT%% FROM ' ) )
-                    $sql = str_ireplace( '%%SELECT%%', $params->select . ', ', $sql );
-                else
-                    $sql = str_ireplace( '%%SELECT%%', $params->select, $sql );
-            }
-            if ( false !== stripos( $this->total_sql, '%%SELECT%% FROM ' ) ) {
-                $this->total_sql = str_ireplace( '%%SELECT%%', 'COUNT(*), ', $this->total_sql );
-            } else {
-                $this->total_sql = str_ireplace( '%%SELECT%%', 'COUNT(*)', $this->total_sql );
-            }
-            if ( 0 < $params->page && 0 < $params->limit ) {
-                $start = ( $params->page - 1 ) * $params->limit;
-                $end = $start + $params->limit;
-                $sql .= 'LIMIT ' . (int) $start . ', ' . (int) $end;
-            }
-
-            // Clear any unused variables
-            list($sql, $this->total_sql) = str_ireplace( array(
-                '%%SELECT%%',
-                '%%JOIN%%',
-                '%%WHERE%%',
-                '%%GROUPBY%%',
-                '%%HAVING%%',
-                '%%ORDERBY%%',
-                '%%LIMIT%%'
-            ), '', array($sql, $this->total_sql) );
-            $sql = str_replace( array( '``', '`' ), array( '  ', ' ' ), $sql );
+        // Insert variables based on other existing statements
+        if ( false === stripos( $sql, '%%JOIN%%' ) ) {
+            if ( false !== stripos( $sql, ' WHERE ' ) )
+                $sql = preg_replace( '/\sWHERE\s(?!.*\sWHERE\s)/i', ' %%JOIN%% WHERE ', $sql );
+            elseif ( false !== stripos( $sql, ' GROUP BY ' ) )
+                $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' %%WHERE%% GROUP BY ', $sql );
+            elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
+                $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%WHERE%% ORDER BY ', $sql );
+            else
+                $sql .= ' %%JOIN%% ';
         }
+        if ( false === stripos( $sql, '%%WHERE%%' ) ) {
+            if ( false !== stripos( $sql, ' GROUP BY ' ) )
+                $sql = preg_replace( '/\sGROUP BY\s(?!.*\sGROUP BY\s)/i', ' %%WHERE%% GROUP BY ', $sql );
+            elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
+                $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%WHERE%% ORDER BY ', $sql );
+            else
+                $sql .= ' %%WHERE%% ';
+        }
+        if ( false === stripos( $sql, '%%GROUPBY%%' ) ) {
+            if ( false !== stripos( $sql, ' HAVING ' ) )
+                $sql = preg_replace( '/\sHAVING\s(?!.*\sHAVING\s)/i', ' %%GROUPBY%% HAVING ', $sql );
+            elseif ( false !== stripos( $sql, ' ORDER BY ' ) )
+                $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%GROUPBY%% ORDER BY ', $sql );
+            else
+                $sql .= ' %%GROUPBY%% ';
+        }
+        if ( false === stripos( $sql, '%%HAVING%%' ) ) {
+            if ( false !== stripos( $sql, ' ORDER BY ' ) )
+                $sql = preg_replace( '/\ORDER BY\s(?!.*\ORDER BY\s)/i', ' %%HAVING%% ORDER BY ', $sql );
+            else
+                $sql .= ' %%HAVING%% ';
+        }
+        if ( false === stripos( $sql, '%%ORDERBY%%' ) )
+            $sql .= ' %%ORDERBY%% ';
+        if ( false === stripos( $sql, '%%LIMIT%%' ) )
+            $sql .= ' %%LIMIT%% ';
+
+        // Replace variables
+        if ( 0 < strlen( $params->join ) )
+            $sql = str_ireplace( '%%JOIN%%', $params->join, $sql );
+        if ( 0 < strlen( $params->where ) ) {
+            if ( false !== stripos( $sql, ' WHERE ' ) ) {
+                if ( false !== stripos( $sql, ' WHERE %%WHERE%% ' ) )
+                    $sql = str_ireplace( '%%WHERE%%', $params->where . ' AND ', $sql );
+                else
+                    $sql = str_ireplace( '%%WHERE%%', ' AND ' . $params->where, $sql );
+            }
+            else
+                $sql = str_ireplace( '%%WHERE%%', ' WHERE ' . $params->where, $sql );
+        }
+        if ( 0 < strlen( $params->groupby ) ) {
+            if ( false !== stripos( $sql, ' GROUP BY ' ) ) {
+                if ( false !== stripos( $sql, ' GROUP BY %%GROUPBY%% ' ) )
+                    $sql = str_ireplace( '%%GROUPBY%%', $params->groupby . ', ', $sql );
+                else
+                    $sql = str_ireplace( '%%GROUPBY%%', ', ' . $params->groupby, $sql );
+            }
+            else
+                $sql = str_ireplace( '%%GROUPBY%%', ' GROUP BY ' . $params->groupby, $sql );
+        }
+        if ( 0 < strlen( $params->having ) && false !== stripos( $sql, ' GROUP BY ' ) ) {
+            if ( false !== stripos( $sql, ' HAVING ' ) ) {
+                if ( false !== stripos( $sql, ' HAVING %%HAVING%% ' ) )
+                    $sql = str_ireplace( '%%HAVING%%', $params->having . ' AND ', $sql );
+                else
+                    $sql = str_ireplace( '%%HAVING%%', ' AND ' . $params->having, $sql );
+            }
+            else
+                $sql = str_ireplace( '%%HAVING%%', ' HAVING ' . $params->having, $sql );
+        }
+        if ( 0 < strlen( $params->orderby ) ) {
+            if ( false !== stripos( $sql, ' ORDER BY ' ) ) {
+                if ( false !== stripos( $sql, ' ORDER BY %%ORDERBY%% ' ) )
+                    $sql = str_ireplace( '%%ORDERBY%%', $params->orderby . ', ', $sql );
+                else
+                    $sql = str_ireplace( '%%ORDERBY%%', ', ' . $params->orderby, $sql );
+            }
+            else
+                $sql = str_ireplace( '%%ORDERBY%%', ' ORDER BY ' . $params->orderby, $sql );
+        }
+        
+        // Produce totals query
+        $this->total_sql = $sql;
+        if ( 0 < strlen( $params->select ) ) {
+            if ( false !== stripos( $sql, '%%SELECT%% FROM ' ) )
+                $sql = str_ireplace( '%%SELECT%%', $params->select . ', ', $sql );
+            else
+                $sql = str_ireplace( '%%SELECT%%', $params->select, $sql );
+        }
+        if ( false !== stripos( $this->total_sql, '%%SELECT%% FROM ' ) ) {
+            $this->total_sql = str_ireplace( '%%SELECT%%', 'COUNT(*), ', $this->total_sql );
+        } else {
+            $this->total_sql = str_ireplace( '%%SELECT%%', 'COUNT(*)', $this->total_sql );
+        }
+        if ( 0 < $params->page && 0 < $params->limit ) {
+            $start = ( $params->page - 1 ) * $params->limit;
+            $end = $start + $params->limit;
+            $sql .= 'LIMIT ' . (int) $start . ', ' . (int) $end;
+        }
+
+        // Clear any unused variables
+        list($sql, $this->total_sql) = str_ireplace( array(
+            '%%SELECT%%',
+            '%%JOIN%%',
+            '%%WHERE%%',
+            '%%GROUPBY%%',
+            '%%HAVING%%',
+            '%%ORDERBY%%',
+            '%%LIMIT%%'
+        ), '', array($sql, $this->total_sql) );
+        $sql = str_replace( array( '``', '`' ), array( '  ', ' ' ), $sql );
 
         return $sql;
     }


### PR DESCRIPTION
This fixes the handling of the `sql` parameter in `PodsData->build()`.

A quick overview of the fixes:
- The `sql` parameter was prematurely rejected, rendering most of the rewriting logic unused. This was caused by an incorrect check.
- Instead of treating the custom query as a 'special case', the default query is now the special case. When `sql` is null, a [default custom query](https://github.com/MattiasBuelens/pods/blob/cb9aaa96ea7462b124844282a2c5941edf635fd2/classes/PodsData.php#L1067) is used containing the default placements for all query parts.
- The `$this->total_sql` is now produced during the rewriting. It only differs from `$sql` in the `SELECT` and `LIMIT` clauses, so the handling of those two is postponed until the end of the process.
  - `$sql` receives the actual `$params->select` and `LIMIT`.
  - `$this->total_sql` receives `COUNT(*)` without a `LIMIT`.
- Since the rewriting logic was never actually used, it had a few bugs:
  - `$params->sql` instead of `$this->sql` has to be the source of the rewriting process.
  - The `/g` flag in `preg_replace` is unnecessary and deprecated.
  - A copy-paste typo caused `$params->having` being inserted in the `ORDER BY` clause.

This is a rewrite of #922 for the new 2.3 code base. The diffs are much better now as well! :wink:
