### PR TITLE
Fixed 24-hour time formats not being used in time pickers.

### DIFF
--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -28,6 +28,11 @@
         'hh_mm_ss' => 'hh:mm:ss'
     );
 
+    $time_format_24 = array(
+         'hh_mm' => 'HH:mm',
+         'hh_mm_ss' => 'HH:mm:ss'
+    );
+
     wp_enqueue_script( 'jquery-ui-datepicker' );
     wp_enqueue_script( 'jquery-ui-timepicker' );
     wp_enqueue_style( 'jquery-ui' );
@@ -61,7 +66,7 @@
 
     if ( 24 == pods_var( $form_field_type . '_time_type', $options, 12 ) ) {
         $args[ 'ampm' ] = false;
-        $args[ 'timeFormat' ] = $time_format[ pods_var( $form_field_type . '_format_24', $options, 'hh_mm', null, true ) ];
+        $args[ 'timeFormat' ] = $time_format_24[ pods_var( $form_field_type . '_time_format_24', $options, 'hh_mm', null, true ) ];
     }
 
     $date = PodsForm::field_method( 'datetime', 'createFromFormat', $format, (string) $value );

--- a/ui/fields/time.php
+++ b/ui/fields/time.php
@@ -12,6 +12,11 @@
         'hh_mm_ss' => 'hh:mm:ss'
     );
 
+    $time_format_24 = array(
+        'hh_mm' => 'HH:mm',
+        'hh_mm_ss' => 'HH:mm:ss'
+    );
+
     wp_enqueue_script( 'jquery-ui-datepicker' );
     wp_enqueue_script( 'jquery-ui-timepicker' );
     wp_enqueue_style( 'jquery-ui' );
@@ -32,7 +37,7 @@
     $method = 'timepicker';
 
     $args = array(
-        'timeFormat' => $time_format[ pods_var( $form_field_type . '_format', $options, 'h_mma', null, true ) ]
+        'timeFormat' => $time_format[ pods_var( $form_field_type . '_time_format', $options, 'h_mma', null, true ) ]
     );
 
     if ( false !== stripos( $args[ 'timeFormat' ], 'tt' ) )
@@ -42,7 +47,7 @@
 
     if ( 24 == pods_var( $form_field_type . '_type', $options, 12 ) ) {
         $args[ 'ampm' ] = false;
-        $args[ 'timeFormat' ] = $time_format[ pods_var( $form_field_type . '_format_24', $options, 'hh_mm', null, true ) ];
+        $args[ 'timeFormat' ] = $time_format_24[ pods_var( $form_field_type . '_time_format_24', $options, 'hh_mm', null, true ) ];
     }
 
     $date = PodsForm::field_method( 'time', 'createFromFormat', $format, (string) $value );


### PR DESCRIPTION
I noticed that 24-hour formats are no longer used in the time pickers for the date and time fields. This ensures that the proper formats are being selected.

It seems like this change was missed while splitting the time format options into `*_time_format` and `*_time_format_24`. In that sense, this is a revamp of #919.
