### PR TITLE
Fixed user avatars set in avatar field not being used by get_avatar.

### DIFF
--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -379,7 +379,7 @@ class PodsField_Avatar extends PodsField {
                 $avatar_field = false;
 
             if ( !empty( $avatar_field ) ) {
-                $user_avatar = get_user_meta( $_user_ID, $avatar_field . '.ID', true );
+                $user_avatar = get_user_meta( $_user_ID, $avatar_field, true );
 
                 if ( !empty( $user_avatar ) ) {
                     $attributes = array(


### PR DESCRIPTION
Pods was trying to use `$avatar_field . ".ID"` as meta key to retrieve the user's custom avatar from `get_user_meta`. However, `get_user_meta` does not interpret the dot as a property accessor but will simply try to look for a meta entry with that complete key. Of course, since there's no actual record named `avatar.ID` in the user meta table, it wouldn't find anything and revert to the default avatar.

By removing the `.ID` suffix, WordPress will correctly retrieve the meta record and deserialize its value as an object. From that point on, `pods_image_id_from_field` finds the `ID` property in the passed object so `pods_image` can produce the custom avatar's HTML. Basically, all the pieces were already in place, but they didn't quite fit yet.
