### PR TITLE
Thumbnails should be served over SSL if needed

### DIFF
--- a/ui/fields/plupload.php
+++ b/ui/fields/plupload.php
@@ -144,7 +144,10 @@ else
                                 continue;
 
                             $thumb = wp_get_attachment_image_src( $val, 'thumbnail', true );
-
+                            
+                            if( is_ssl() )
+                                $thumb[ 0 ] = str_replace( 'http://', 'https://', $thumb[ 0 ] );
+                            
                             $title = $attachment->post_title;
 
                             if ( 0 == $title_editable )


### PR DESCRIPTION
This may be a bigger issue that can fixed with a hook or filter, but this fixes it for plupload thumbs in public forms.
