### PR TITLE
Fix for UNION SELECT queries which are enclosed in parentheses

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1916,7 +1916,7 @@ class PodsData {
 
         if ( 'INSERT' == strtoupper( substr( $params->sql, 0, 6 ) ) || 'REPLACE' == strtoupper( substr( $params->sql, 0, 7 ) ) )
             $result = $wpdb->insert_id;
-        elseif ( 'SELECT' == strtoupper( substr( $params->sql, 0, 6 ) ) ) {
+        elseif ( preg_match( '/^[\s\r\n\(]*SELECT/', strtoupper( $params->sql ) ) ) {
             $result = (array) $wpdb->last_result;
 
             if ( !empty( $result ) && !empty( $params->results_error ) )


### PR DESCRIPTION
In UNION SELECT queries where additional processing must be performed
on the united data, the initial parentheses which are required to
encapsulate the subqueries correctly cause Pods's query detection at
line 1919 to fail. This pull request fixes issue pods-framework/pods#1303 allowing
for additional whitespace characters before the SELECT keyword.
