### PR TITLE
Corrections for E_STRICT errors in Pods

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1749,7 +1749,7 @@ class Pods {
     public function total () {
         $this->do_hook( 'total' );
 
-        $this->total =& $this->data->total();
+        $this->total = $this->data->total();
 
         return $this->total;
     }
@@ -1768,7 +1768,7 @@ class Pods {
     public function total_found () {
         $this->do_hook( 'total_found' );
 
-        $this->total_found =& $this->data->total_found();
+        $this->total_found = $this->data->total_found();
 
         return $this->total_found;
     }


### PR DESCRIPTION
The use of =& in Pods::total() and Pods::total_found() conflicts with PHP's strict usage, and also doesn't make any sense as the reference would be to the passed-by-value result of a generator function anyway. This removes the spurious reference operator and fixes the error.
