### PR TITLE
Add the ability for Pods pagination to use WordPress "list" option

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -2617,7 +2617,7 @@ class Pods implements Iterator {
 
         $pagination = $params->type;
 
-        if ( !in_array( $params->type, array( 'simple', 'advanced', 'paginate' ) ) )
+        if ( !in_array( $params->type, array( 'simple', 'advanced', 'paginate', 'list' ) ) )
             $pagination = 'advanced';
 
         ob_start();

--- a/ui/front/pagination/list.php
+++ b/ui/front/pagination/list.php
@@ -1,0 +1,18 @@
+<div class="pods-pagination-paginate <?php echo $params->class ?>">
+	<?php
+	$args = array(
+		'base' => $params->base,
+		'format' => $params->format,
+		'total' => $params->total,
+		'current' => $params->page,
+		'end_size' => $params->end_size,
+		'mid_size' => $params->mid_size,
+		'prev_next' => $params->prev_next,
+		'prev_text' => $params->prev_text,
+		'next_text' => $params->next_text,
+		'type' => 'list'
+	);
+
+	echo paginate_links( $args );
+	?>
+</div>


### PR DESCRIPTION
Add the ability for Pods pagination to use the WordPress "list" option of `paginate_links()`.

Basically a clone of the "paginate" option but adding in `'type' => 'list'` and changing the surrounding `<span>` to a `<div>`. This was mainly done for interaction with [Bootstrap pagination](http://twitter.github.io/bootstrap/components.html#pagination) abilities.
