### PR TITLE
Adds support for installation as a must-use plugin

### DIFF
--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -1075,7 +1075,7 @@ class PodsForm {
         $class_name = "PodsField_{$class_name}";
 
         $content_dir = realpath( WP_CONTENT_DIR );
-        $plugins_dir = realpath( WP_PLUGIN_DIR );
+        $plugins_dir = ( 0 === strpos( PODS_DIR, WPMU_PLUGIN_DIR ) ) ? realpath( WPMU_PLUGIN_DIR ) : realpath( WP_PLUGIN_DIR );
         $abspath_dir = realpath( ABSPATH );
 
         if ( !class_exists( $class_name ) ) {

--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -58,7 +58,7 @@ class PodsView {
         $pods_ui_dir = realpath( PODS_DIR . 'ui/' );
         $pods_components_dir = realpath( PODS_DIR . 'components/' );
         $content_dir = realpath( WP_CONTENT_DIR );
-        $plugins_dir = realpath( WP_PLUGIN_DIR );
+        $plugins_dir = ( 0 === strpos( PODS_DIR, WPMU_PLUGIN_DIR ) ) ? realpath( WPMU_PLUGIN_DIR ) : realpath( WP_PLUGIN_DIR );
         $abspath_dir = realpath( ABSPATH );
 
         $cache_key = sanitize_title(


### PR DESCRIPTION
Pods breaks if installed as a must-use plugin and activated using a proxy loader ([codex notes on this](http://codex.wordpress.org/Must_Use_Plugins)).

This fix detects how Pods is installed for instances when the regular plugins directory constant `WP_PLUGIN_DIR` is used.

The only instances left are in the Github Updater class (`includes/updater.php`), but those are not relevant since must-use plugins are not included in update checks.
