### PR TITLE
Specify the Page Template where any field should be displayed.

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -1382,7 +1382,14 @@ class PodsAdmin {
         $input_helpers = array(
             '' => '-- Select --'
         );
-
+        
+        $page_templates = array(
+            '' => '-- Select --'
+        );
+        foreach(get_page_templates() as $k=>$v){
+            $page_templates[$v] = $v;
+        }
+        
         if ( class_exists( 'Pods_Helpers' ) ) {
             $helpers = pods_api()->load_helpers( array( 'options' => array( 'helper_type' => 'input' ) ) );
 
@@ -1407,6 +1414,14 @@ class PodsAdmin {
                     'type' => 'pick',
                     'default' => '',
                     'data' => $input_helpers
+                ),
+                'input_helper_template' => array( 
+                    'name' => 'input_helper_template',
+                    'label' => __( 'Page Template', 'pods' ),
+                    'help' => __( 'Specify the template where you want the field to be displayed. By default it will be shown on every template' ),
+                    'type' => 'pick',
+                    'default' => '',
+                    'data' => $page_templates
                 )
             ),
             __( 'Values', 'pods' ) => array(

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -900,7 +900,10 @@ class PodsMeta {
                 $depends = PodsForm::dependencies( $field, 'pods-meta-' );
 
             do_action( 'pods_' . __METHOD__ . '_' . $field[ 'name' ], $post, $field, $pod );
+            
+            $current_page_template = get_post_meta(get_the_ID(),'_wp_page_template',true);
         ?>
+            <?php if(empty($field['options']['input_helper_template']) || $field['options']['input_helper_template'] == $current_page_template) { ?>
             <tr class="form-field pods-field <?php echo 'pods-form-ui-row-type-' . $field[ 'type' ] . ' pods-form-ui-row-name-' . Podsform::clean( $field[ 'name' ], true ); ?> <?php echo $depends; ?>">
                 <th scope="row" valign="top"><?php echo PodsForm::label( 'pods_meta_' . $field[ 'name' ], $field[ 'label' ], $field[ 'help' ], $field ); ?></th>
                 <td>
@@ -913,6 +916,7 @@ class PodsMeta {
                     <?php echo PodsForm::comment( 'pods_meta_' . $field[ 'name' ], $field[ 'description' ], $field ); ?>
                 </td>
             </tr>
+            <?php } ?>
         <?php
                 do_action( 'pods_' . __METHOD__ . '_' . $field[ 'name' ] . '_post', $post, $field, $pod );
             }


### PR DESCRIPTION
Currently all the fields inside the metabox are shown on all the page templates. But if we do not want the field to be displayed on any specific page template then there is no such customization I guess. 
I have added the code to selectively show a particular field in the selected page templates only.
