### PR TITLE
Cleans up deprecated CSS sprite images (removed in WP 3.5)

### DIFF
--- a/ui/css/pods-front.css
+++ b/ui/css/pods-front.css
@@ -14,7 +14,13 @@ a.button {
 	white-space: nowrap;
 	line-height: 15px;
 	padding: 3px 10px;
-	background: #f2f2f2 url(../../../../../wp-admin/images/white-grad.png) repeat-x scroll left top;
+	background: #f3f3f3;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#fefefe), to(#f4f4f4));
+	background-image: -webkit-linear-gradient(top, #fefefe, #f4f4f4);
+	background-image:    -moz-linear-gradient(top, #fefefe, #f4f4f4);
+	background-image:      -o-linear-gradient(top, #fefefe, #f4f4f4);
+	background-image:   linear-gradient(to bottom, #fefefe, #f4f4f4);
+	text-shadow: 0 1px 0 #fff;
 	border: 1px solid #bbb;
 	font-size: 12px;
 	color: #464646;
@@ -27,7 +33,19 @@ a.button:hover {
 }
 
 a.button:active {
-	background: #eee url(../../../../../wp-admin/images/white-grad-active.png) repeat-x scroll left top;
+	background: #eee;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#f4f4f4), to(#fefefe));
+	background-image: -webkit-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:    -moz-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:     -ms-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:      -o-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:   linear-gradient(to bottom, #f4f4f4, #fefefe);
+	border-color: #999;
+	color: #333;
+	text-shadow: 0 -1px 0 #fff;
+	-webkit-box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 );
+	box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 );
+	text-decoration: none;
 }
 
 .button-primary {
@@ -41,7 +59,18 @@ a.button:active {
 	line-height: 15px;
 	padding: 3px 8px;
 	border: 1px solid #298CBA;
-	background: #21759B url(../../../../../wp-admin/images/button-grad.png) repeat-x scroll left top;
+	background-color: #21759b;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+	background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+	background-image:    -moz-linear-gradient(top, #2a95c5, #21759b);
+	background-image:     -ms-linear-gradient(top, #2a95c5, #21759b);
+	background-image:      -o-linear-gradient(top, #2a95c5, #21759b);
+	background-image:   linear-gradient(to bottom, #2a95c5, #21759b);
+	border-bottom-color: #1e6a8d;
+	-webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+	box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+	text-decoration: none;
+	text-shadow: 0 1px 0 rgba(0,0,0,0.1);
 	font-size: 12px;
 	font-weight: bold;
 	color: #fff;
@@ -56,7 +85,13 @@ a.button:active {
 .button-primary:active {
 	border-color: #298CBA;
 	text-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0;
-	background: #21759B url(../../../../../wp-admin/images/button-grad-active.png) repeat-x scroll left top;
+	background: #eee;
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#f4f4f4), to(#fefefe));
+	background-image: -webkit-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:    -moz-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:     -ms-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:      -o-linear-gradient(top, #f4f4f4, #fefefe);
+	background-image:   linear-gradient(to bottom, #f4f4f4, #fefefe);
 	text-decoration: none;
 }
 

--- a/ui/css/pods-ui-list-table.css
+++ b/ui/css/pods-ui-list-table.css
@@ -60,9 +60,13 @@
 
     border: 1px solid #BBB;
     color: #464646;
-
-    background: #F2F2F2 url(/wp-admin/images/white-grad.png) repeat-x scroll left top;
-    text-shadow: rgba(255, 255, 255, 1) 0 1px 0;
+    background: #f3f3f3;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#fefefe), to(#f4f4f4));
+    background-image: -webkit-linear-gradient(top, #fefefe, #f4f4f4);
+    background-image:    -moz-linear-gradient(top, #fefefe, #f4f4f4);
+    background-image:      -o-linear-gradient(top, #fefefe, #f4f4f4);
+    background-image:   linear-gradient(to bottom, #fefefe, #f4f4f4);
+    text-shadow: 0 1px 0 #fff;
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a:hover {
@@ -71,7 +75,19 @@
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a:active {
-    background: #EEE url(/wp-admin/images/white-grad-active.png) repeat-x scroll left top;
+    background: #eee;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#f4f4f4), to(#fefefe));
+    background-image: -webkit-linear-gradient(top, #f4f4f4, #fefefe);
+    background-image:    -moz-linear-gradient(top, #f4f4f4, #fefefe);
+    background-image:     -ms-linear-gradient(top, #f4f4f4, #fefefe);
+    background-image:      -o-linear-gradient(top, #f4f4f4, #fefefe);
+    background-image:   linear-gradient(to bottom, #f4f4f4, #fefefe);
+    border-color: #999;
+    color: #333;
+    text-shadow: 0 -1px 0 #fff;
+    -webkit-box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 );
+    box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 );
+    text-decoration: none;
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a.current {
@@ -79,8 +95,20 @@
 
     font-weight: bold;
     color: white;
-    background: #21759B url(/wp-admin/images/button-grad.png) repeat-x scroll left top;
-    text-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0;
+    text-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0;*/
+    background-color: #21759b;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+    background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+    background-image:    -moz-linear-gradient(top, #2a95c5, #21759b);
+    background-image:     -ms-linear-gradient(top, #2a95c5, #21759b);
+    background-image:      -o-linear-gradient(top, #2a95c5, #21759b);
+    background-image:   linear-gradient(to bottom, #2a95c5, #21759b);
+    border-color: #21759b;
+    border-bottom-color: #1e6a8d;
+    -webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0,0,0,0.1);
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a.current:hover {
@@ -88,7 +116,19 @@
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a.current:active {
-    background: #21759B url(/wp-admin/images/button-grad-active.png) repeat-x scroll left top;
+    background-color: #21759b;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+    background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+    background-image:    -moz-linear-gradient(top, #2a95c5, #21759b);
+    background-image:     -ms-linear-gradient(top, #2a95c5, #21759b);
+    background-image:      -o-linear-gradient(top, #2a95c5, #21759b);
+    background-image:   linear-gradient(to bottom, #2a95c5, #21759b);
+    border-color: #21759b;
+    border-bottom-color: #1e6a8d;
+    -webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0,0,0,0.1);
 }
 
 .pods-ui-filter-bar-primary ul.subsubsub li a.current:hover,
@@ -167,8 +207,19 @@ body.branch-3-5 .pods-ui-filter-bar-primary p.search-box input.button {
     box-sizing: content-box;
 
     border: none;
-    background: #21759B url(/wp-admin/images/button-grad.png) repeat-x scroll left top;
-    text-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0;
+    background-color: #21759b;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+    background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+    background-image:    -moz-linear-gradient(top, #2a95c5, #21759b);
+    background-image:     -ms-linear-gradient(top, #2a95c5, #21759b);
+    background-image:      -o-linear-gradient(top, #2a95c5, #21759b);
+    background-image:   linear-gradient(to bottom, #2a95c5, #21759b);
+    border-color: #21759b;
+    border-bottom-color: #1e6a8d;
+    -webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0,0,0,0.1);
 }
 
 .pods-ui-filter-bar-secondary ul.subsubsub li.pods-ui-filter-bar-filter a {
@@ -180,7 +231,20 @@ body.branch-3-5 .pods-ui-filter-bar-primary p.search-box input.button {
 }
 
 .pods-ui-filter-bar-secondary ul.subsubsub li.pods-ui-filter-bar-filter:active {
-    background: #21759B url(/wp-admin/images/button-grad-active.png) repeat-x scroll left top;
+    background-color: #21759b;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#2a95c5), to(#21759b));
+    background-image: -webkit-linear-gradient(top, #2a95c5, #21759b);
+    background-image:    -moz-linear-gradient(top, #2a95c5, #21759b);
+    background-image:     -ms-linear-gradient(top, #2a95c5, #21759b);
+    background-image:      -o-linear-gradient(top, #2a95c5, #21759b);
+    background-image:   linear-gradient(to bottom, #2a95c5, #21759b);
+    border-color: #21759b;
+    border-bottom-color: #1e6a8d;
+    -webkit-box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    box-shadow: inset 0 1px 0 rgba(120,200,230,0.5);
+    color: #fff;
+    text-decoration: none;
+    text-shadow: 0 1px 0 rgba(0,0,0,0.1);
 }
 
 .pods-ui-filter-bar-secondary ul.subsubsub li.pods-ui-filter-bar-filter:hover a:hover,


### PR DESCRIPTION
References to old WP sprites are blowing up logs with 404 errors. PNGs have been removed from core since v3.5 or so. (See [ticket #20980](http://core.trac.wordpress.org/ticket/20980)).

New CSS mostly derived from [wp-includes/css/buttons.css](http://core.trac.wordpress.org/browser/branches/3.6/wp-includes/css/buttons.css).
