### PR TITLE
Fixes a PHP notice when trying to find related items on a custom post ty...

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1144,7 +1144,9 @@ class Pods implements Iterator {
 							$last_limit = $last_limit * count( $ids );
 
 							// Get related IDs
-							$ids = $this->api->lookup_related_items( $all_fields[ $pod ][ $field ][ 'id' ], $all_fields[ $pod ][ $field ][ 'pod_id' ], $ids, $all_fields[ $pod ][ $field ] );
+							if (isset($all_fields[ $pod ][ $field ][ 'id' ]) && isset($all_fields[ $pod ][ $field ][ 'pod_id' ])) {
+								$ids = $this->api->lookup_related_items( $all_fields[ $pod ][ $field ][ 'id' ], $all_fields[ $pod ][ $field ][ 'pod_id' ], $ids, $all_fields[ $pod ][ $field ] );
+							}
 
 							// No items found
 							if ( empty( $ids ) ) {


### PR DESCRIPTION
...pe that is defined outside of Pods. This works around not being able to find the field "pod_id". This should resolve #1821 on pods-framework/pods. This is patched on branch 2.4x instead of 2.3x of last commit. Oops.
