### PR TITLE
Added fields for before and after content to help print lists and tables.

### DIFF
--- a/classes/widgets/PodsWidgetList.php
+++ b/classes/widgets/PodsWidgetList.php
@@ -35,7 +35,9 @@ class PodsWidgetList extends WP_Widget {
             'cache_mode' => trim( pods_var_raw( 'cache_mode', $instance, 'none', null, true ) )
         );
 
+        $before_content = trim( pods_var_raw( 'before_content', $instance, '' ) );
         $content = trim( pods_var_raw( 'template_custom', $instance, '' ) );
+        $after_content = trim( pods_var_raw( 'after_content', $instance, '' ) );
 
         if ( 0 < strlen( $args[ 'name' ] ) && ( 0 < strlen( $args[ 'template' ] ) || 0 < strlen( $content ) ) ) {
             require PODS_DIR . 'ui/front/widgets.php';
@@ -59,6 +61,8 @@ class PodsWidgetList extends WP_Widget {
         $instance[ 'where' ] = pods_var_raw( 'where', $new_instance, '' );
         $instance[ 'expires' ] = (int) pods_var_raw( 'expires', $new_instance, ( 60 * 5 ) );
         $instance[ 'cache_mode' ] = pods_var_raw( 'cache_mode', $new_instance, 'none' );
+        $instance[ 'before_content' ] = pods_var_raw( 'before_content', $new_instance, '' );
+        $instance[ 'after_content' ] = pods_var_raw( 'after_content', $new_instance, '' );
 
         return $instance;
     }
@@ -76,6 +80,8 @@ class PodsWidgetList extends WP_Widget {
         $where = pods_var_raw( 'where', $instance, '' );
         $expires = (int) pods_var_raw( 'expires', $instance, ( 60 * 5 ) );
         $cache_mode = pods_var_raw( 'cache_mode', $instance, 'none' );
+        $before_content = pods_var_raw( 'before_content', $instance, '' );
+        $after_content = pods_var_raw( 'after_content', $instance, '' );
 
         require PODS_DIR . 'ui/admin/widgets/list.php';
     }

--- a/ui/admin/widgets/list.php
+++ b/ui/admin/widgets/list.php
@@ -73,9 +73,21 @@
     ?>
 
     <li>
+        <label for="<?php echo $this->get_field_id( 'before_content' ); ?>"> <?php _e( 'Before Content', 'pods' ); ?></label>
+
+        <input type="text" class="widefat" id="<?php echo $this->get_field_id( 'before_content' ); ?>" name="<?php echo $this->get_field_name( 'before_content' ); ?>" value="<?php echo esc_attr( $before_content ); ?>" />
+    </li>
+
+    <li>
         <label for="<?php echo $this->get_field_id( 'template_custom' ); ?>"> <?php _e( 'Custom Template', 'pods' ); ?></label>
 
         <textarea name="<?php echo $this->get_field_name( 'template_custom' ); ?>" id="<?php echo $this->get_field_id( 'template_custom' ); ?>" cols="10" rows="10" class="widefat"><?php echo esc_html( $template_custom ); ?></textarea>
+    </li>
+
+    <li>
+        <label for="<?php echo $this->get_field_id( 'after_content' ); ?>"> <?php _e( 'After Content', 'pods' ); ?></label>
+
+        <input type="text" class="widefat" id="<?php echo $this->get_field_id( 'after_content' ); ?>" name="<?php echo $this->get_field_name( 'after_content' ); ?>" value="<?php echo esc_attr( $after_content ); ?>" />
     </li>
 
     <li>

--- a/ui/front/widgets.php
+++ b/ui/front/widgets.php
@@ -4,6 +4,12 @@
     if ( !empty( $title ) )
         echo $before_title . $title . $after_title;
 
+    if ( !empty( $before_content ) )
+        echo $before_content;
+
     echo pods_shortcode( $args, ( isset( $content ) ? $content : null ) );
+
+    if ( !empty( $after_content ) )
+        echo $after_content;
 
     echo $after_widget;


### PR DESCRIPTION
This patch add two text fields to the list widget: before_content and after_content. All they do is allow you do add a snippet to be printed right before and after the content. This can be used to print ul tags so that you can print a list using the template.
