### PR TITLE
Corrected Missing Word in label

### DIFF
--- a/ui/admin/setup-add.php
+++ b/ui/admin/setup-add.php
@@ -137,7 +137,7 @@
                                     <div class="pods-depends-on pods-depends-on-create-pod-type pods-depends-on-create-pod-type-settings">
                                         <div class="pods-field-option">
                                             <?php
-                                                echo PodsForm::label( 'create_label_title', __( 'Page Title', 'pods' ), __( '<h6>Page Title</h6> This is the text that will at the top of your settings page.', 'pods' ) );
+                                                echo PodsForm::label( 'create_label_title', __( 'Page Title', 'pods' ), __( '<h6>Page Title</h6> This is the text that will appear at the top of your settings page.', 'pods' ) );
                                                 echo PodsForm::field( 'create_label_title', pods_var_raw( 'create_label_title', 'post' ), 'text', array( 'class' => 'pods-validate pods-validate-required', 'text_max_length' => 30 ) );
                                             ?>
                                         </div>


### PR DESCRIPTION
The sentence "This is the text that will at the top of your settings page." is missing a word. I assume you meant "appear" and added it.
