### PR TITLE
Set the correct parent_file to highlight the correct top level menu

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -533,8 +533,18 @@ class PodsAdmin {
 
                     break;
                 }
+            }  
+        }
+
+        if ( isset( $current_screen ) && ! empty( $current_screen->post_type ) ) {
+            global $submenu_file;
+            $components = PodsInit::$components->components;
+            foreach ( $components as $component => $component_data ) {
+                if ( ! empty( $component_data[ 'MenuPage' ] ) && $parent_file === $component_data[ 'MenuPage' ] ) {
+                    $parent_file = 'pods';
+                    $submenu_file = $component_data[ 'MenuPage' ];
+                }
             }
-            
         }
         
         return $parent_file;


### PR DESCRIPTION
This is a fix for issue #1909 and added a missing i

Is this the correct branch or should i use 3.0-unstable?

Added fix for #538 Components don't "hold their place" in the menu
