### PR TITLE
Corrected email field validation, fixes #1994

### DIFF
--- a/classes/fields/email.php
+++ b/classes/fields/email.php
@@ -183,13 +183,13 @@ class PodsField_Email extends PodsField {
         if ( is_array( $check ) )
             $errors = $check;
         else {
-            if ( 0 < strlen( $value ) && strlen( $check ) < 1 ) {
-                $label = pods_var( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
+            $label = pods_var( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
 
-                if ( 1 == pods_var( 'required', $options ) )
-                    $errors[] = sprintf( __( '%s is required', 'pods' ), $label );
-                else
-                    $errors[] = sprintf( __( 'Invalid e-mail provided for %s', 'pods' ), $label );
+            if ( 1 > strlen( $value ) && 1 == pods_var( 'required', $options ) ) {
+                $errors[] = sprintf( __( '%s is required', 'pods' ), $label );
+            }
+            else if(strlen( $check ) < 1){
+                $errors[] = sprintf( __( 'Invalid e-mail provided for %s', 'pods' ), $label );
             }
         }
 


### PR DESCRIPTION
$check returns an empty string when email is invalid, however, the conditional ignores this and assumes the email is empty, throwing the required error.
