### PR TITLE
corrected email field validation, fixes #1994

### DIFF
--- a/classes/Pods/Field/Email.php
+++ b/classes/Pods/Field/Email.php
@@ -183,13 +183,13 @@ class Pods_Field_Email extends Pods_Field {
         if ( is_array( $check ) )
             $errors = $check;
         else {
-            if ( 0 < strlen( $value ) && strlen( $check ) < 1 ) {
-                $label = pods_var( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
+            $label = pods_var( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
 
-                if ( 1 == pods_v( 'required', $options ) )
-                    $errors[] = sprintf( __( '%s is required', 'pods' ), $label );
-                else
-                    $errors[] = sprintf( __( 'Invalid e-mail provided for %s', 'pods' ), $label );
+            if ( 0 == strlen( $value ) && 1 == pods_var( 'required', $options ) ) {
+                $errors[] = sprintf( __( '%s is required', 'pods' ), $label );
+            }
+            else if(strlen( $check ) < 1){
+                $errors[] = sprintf( __( 'Invalid e-mail provided for %s', 'pods' ), $label );
             }
         }
 


### PR DESCRIPTION
$check returns an empty string when email is invalid, however, the conditional ignores this and assumes the email is empty, throwing the required error.
