### PR TITLE
Attempt at fixing  #2052

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -601,7 +601,8 @@ function pods_shortcode ( $tags, $content = null ) {
         'view' => null,
         'cache_mode' => 'none',
         'expires' => 0,
-		'shortcodes' => false
+		'shortcodes' => false,
+        'offset'    => null,
     );
 
     if ( !empty( $tags ) )
@@ -721,6 +722,11 @@ function pods_shortcode ( $tags, $content = null ) {
 			$params[ 'cache_mode' ] = $tags[ 'cache_mode' ];
 			$params[ 'expires' ] = (int) $tags[ 'expires' ];
 		}
+
+        if ( !is_null( $tags[ 'offset' ] ) ) {
+            $params[ 'offset' ] = $tags[ 'offset' ];
+        }
+
 
         $params = apply_filters( 'pods_shortcode_findrecords_params', $params );
 


### PR DESCRIPTION
This is my attempt to adding an offset parameter to pods shortcode. I added offset to $defaults, with a default value of null and added the offset value to $params passed to pods::find() if offset !is_null. Offset has no effect in the shortcode in my tests.

I tested with this shortcode `[pods name="cpt" offset="5" ]{@post_title}<br>[/pods]` It returned all 7 posts in the CPT called cpt.

I also did this as a test:
`<?php
$params = array( 'offset' => 5);
$pods = pods('cpt', $params );
echo $pods->total();
?>`
And the result was 2, which was  expected (7-5=2).
