### PR TITLE
Update Pods.php

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1192,6 +1192,8 @@ class Pods implements Iterator {
 								if ( !empty( $table[ 'where' ] ) )
 									$where = array_merge( $where, array_values( (array) $table[ 'where' ] ) );
 							}
+							
+							$params->params['where'] = '`t`.`post_status` IN ( "pending", "publish", "draft" )';
 
 							/**
 							 * @var $related_obj Pods


### PR DESCRIPTION
Explicitly set "where" clause for relationship fields. This allows the correct field values to be reported in the dashboard when the related post is "pending", "publish", or "draft". This should be implemented with a filter.
