### PR TITLE
Replace htmlentities() with esc_textarea()

### DIFF
--- a/components/Templates/includes/element-view_template.php
+++ b/components/Templates/includes/element-view_template.php
@@ -2,4 +2,4 @@
 /**
  * Frontier Template code editor metabox
  */
-?><textarea id="content" name="content"><?php if(isset($content)){ echo htmlentities( $content );} ?></textarea>
+?><textarea id="content" name="content"><?php if ( isset( $content ) ) { echo esc_textarea( $content ); } ?></textarea>


### PR DESCRIPTION
Function htmlentities() does not use UTF-8 encoding by default before PHP 5.4.
See #2159
