### PR TITLE
assign correct IDs to imported fields, in order to update them

### DIFF
--- a/components/Migrate-Packages/Migrate-Packages.php
+++ b/components/Migrate-Packages/Migrate-Packages.php
@@ -383,6 +383,11 @@ class Pods_Migrate_Packages extends
 						unset( $pod['fields'][ $k ]['id'] );
 					}
 
+                    if( isset( $existing_fields[ $field['name'] ] ) ) {
+                        if( $existing_field = pods_api()->load_field( array( 'name' => $field['name'], 'pod' => $pod[ 'name' ] ) ) )
+                            $pod['fields'][$k]['id'] = $existing_field['id'];
+                    }
+
 					if ( isset( $field['pod_id'] ) ) {
 						unset( $pod['fields'][ $k ]['pod_id'] );
 					}


### PR DESCRIPTION
otherwise it will result in a failed attempt to duplicate fields with the same name, IF the ids of the fields differ from the current DB values.

This resulted in a SQL error ( ALTER TABLE tries to add a column for an already existing column )
