### PR TITLE
Hotfix #1924

### DIFF
--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -72,10 +72,10 @@ class PodsComponents {
             $this->settings[ 'components' ] = array();
 
         // Get components (give it access to theme)
-        add_action( 'setup_theme', array( $this, 'get_components' ), 11 );
+        add_action( 'after_setup_theme', array( $this, 'get_components' ), 11 );
 
         // Load in components
-        add_action( 'setup_theme', array( $this, 'load' ), 12 );
+        add_action( 'after_setup_theme', array( $this, 'load' ), 12 );
 
         // AJAX handling
         if ( is_admin() ) {

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -123,7 +123,7 @@ class PodsInit {
         if ( !empty( self::$version ) ) {
             add_action( 'plugins_loaded', array( $this, 'load_components' ), 11 );
 
-			add_action( 'setup_theme', array( $this, 'load_meta' ), 14 );
+			add_action( 'after_setup_theme', array( $this, 'load_meta' ), 14 );
 
             add_action( 'init', array( $this, 'core' ), 11 );
 


### PR DESCRIPTION
Hi Scott,
This pull request solves the notice with buddy press plugin. Also corrects the initialization issue with theme_setup action, I think its no longer supposed to be used, instead after_theme_setup action is supposed to replace it, http://codex.wordpress.org/Plugin_API/Action_Reference
