### PR TITLE
Add some jQuery year options

### DIFF
--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -79,6 +79,24 @@ class PodsField_Date extends PodsField {
                     'y' => date_i18n( 'Y' )
                 )
             ),
+c            self::$type . '_year_range' => array(
+                'label' => __( 'Year Range', 'pods' ),
+                'default' => 'c-10:c+10',
+                'type' => 'text',
+                'help' => __( 'The range of years displayed in the year drop-down: either relative to today\'s year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn").', 'pods' )
+            ),
+            self::$type . '_min_date' => array(
+                'label' => __( 'Min Date', 'pods' ),
+                'default' => '',
+                'type' => 'text',
+                'help' => __( 'The minimum selectable date. When empty, there is no minimum.', 'pods' )
+            ),
+            self::$type . '_max_date' => array(
+                'label' => __( 'Max Date', 'pods' ),
+                'default' => '',
+                'type' => 'text',
+                'help' => __( 'The maximum selectable date. When empty, there is no maximum.', 'pods' )
+            ), 
             self::$type . '_allow_empty' => array(
                 'label' => __( 'Allow empty value?', 'pods' ),
                 'default' => 1,

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -120,6 +120,25 @@ class PodsField_DateTime extends PodsField {
                     'hh_mm_ss' => date_i18n( 'H:i:s' )
                 )
             ),
+            self::$type . '_year_range' => array(
+                'label' => __( 'Year Range', 'pods' ),
+                'default' => 'c-10:c+10',
+                'type' => 'text',
+                'help' => __( 'The range of years displayed in the year drop-down: either relative to today\'s year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn").', 'pods' )
+            ),
+            self::$type . '_min_date' => array(
+                'label' => __( 'Min Date', 'pods' ),
+                'default' => '',
+                'type' => 'text',
+                'help' => __( 'The minimum selectable date. When empty, there is no minimum.', 'pods' )
+            ),
+            self::$type . '_max_date' => array(
+                'label' => __( 'Max Date', 'pods' ),
+                'default' => '',
+                'type' => 'text',
+                'help' => __( 'The maximum selectable date. When empty, there is no maximum.', 'pods' )
+            ), 
+
             self::$type . '_allow_empty' => array(
                 'label' => __( 'Allow empty value?', 'pods' ),
                 'default' => 1,

--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -38,7 +38,10 @@
     $args = array(
         'dateFormat' => $date_format[ pods_var( $form_field_type . '_format', $options, 'mdy', null, true ) ],
         'changeMonth' => true,
-        'changeYear' => true
+        'changeYear' => true,
+        'yearRange' => pods_var( $form_field_type . '_year_range', $options ),
+        'minDate' => pods_var( $form_field_type . '_min_date', $options ),
+        'maxDate' => pods_var( $form_field_type . '_max_date', $options ),
     );
 
     $html5_format = 'Y-m-d';

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -64,7 +64,10 @@
         'timeFormat' => $time_format[ pods_var( $form_field_type . '_time_format', $options, 'h_mma', null, true ) ],
         'dateFormat' => $date_format[ $format_value ],
         'changeMonth' => true,
-        'changeYear' => true
+        'changeYear' => true,
+        'yearRange' => pods_var( $form_field_type . '_year_range', $options ),
+        'minDate' => pods_var( $form_field_type . '_min_date', $options ),
+        'maxDate' => pods_var( $form_field_type . '_max_date', $options ),
     );
 
     if ( false !== stripos( $args[ 'timeFormat' ], 'tt' ) )


### PR DESCRIPTION
## Let's try this one again since I had the wrong branch checked out on the previous attempt.

Wasn't sure if I should submit this for 2.x or 3.0-unstable, so here it is for 2.x and it's easy enough to go to 3.0-unstable.

Adds the yearRange, minDate, and maxDate jQuery options to the Date and DateTime fields.
