### PR TITLE
Allow field to be used in shortcode in other cases

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -893,22 +893,6 @@ function pods_shortcode ( $tags, $content = null ) {
 		$pod->find( $params );
 
 		$found = $pod->total();
-	} elseif ( ! empty( $tags['field'] ) ) {
-		if ( empty( $tags['helper'] ) ) {
-			$return .= $pod->display( $tags['field'] );
-		} else {
-			$return .= $pod->helper( $tags['helper'], $pod->field( $tags['field'] ), $tags['field'] );
-		}
-
-		if ( ! empty( $tags['after'] ) ) {
-			$return .= pods_evaluate_tags( $tags['after'] );
-		}
-
-		if ( $tags['shortcodes'] ) {
-			$return = do_shortcode( $return );
-		}
-
-		return $return;
 	} elseif ( ! empty( $tags['pods_page'] ) && class_exists( 'Pods_Pages' ) ) {
 		$pods_page = Pods_Pages::exists( $tags['pods_page'] );
 
@@ -928,6 +912,24 @@ function pods_shortcode ( $tags, $content = null ) {
 
 		return $return;
 	}
+
+	if ( ! empty( $tags['field'] ) ) {
+		if ( empty( $tags['helper'] ) ) {
+			$return .= $pod->display( $tags['field'] );
+		} else {
+			$return .= $pod->helper( $tags['helper'], $pod->field( $tags['field'] ), $tags['field'] );
+		}
+
+		if ( ! empty( $tags['after'] ) ) {
+			$return .= pods_evaluate_tags( $tags['after'] );
+		}
+
+		if ( $tags['shortcodes'] ) {
+			$return = do_shortcode( $return );
+		}
+
+		return $return;
+	} 
 
 	if ( empty( $id ) && false !== $tags['filters'] && 'before' == $tags['filters_location'] ) {
 		$return .= $pod->filters( $tags['filters'], $tags['filters_label'] );


### PR DESCRIPTION
If someone tries to use:
[pods name="podname" where="t.somthing = 'else'" field="test"]
it won't work, although this does work
[pods name="podname" where="t.somthing = 'else'"]{@test}[/pods]

I understand why they work differently but I don't see a reason not to allow this usage.

This really is an ugly diff, it looks like a lot was changed but all that happened was to move the last elseif block up and change the former elseif on field to an if.
