### PR TITLE
Update Pods.php

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1002,7 +1002,7 @@ class Pods implements Iterator {
 
 						$single_multi = pods_var( $this->fields[$params->name]['type'] . '_format_type', $this->fields[$params->name]['options'], 'single' );
 
-						if ( $simple && ! is_array( $value ) && 'single' != $single_multi ) {
+						if ( $simple && ! is_array( $value ) && 'multi' == $single_multi ) {
 							$value = get_post_meta( $id, $params->name );
 						}
 					} elseif ( in_array( $this->pod_data['type'], array( 'user', 'comment' ) ) ) {
@@ -1010,7 +1010,7 @@ class Pods implements Iterator {
 
 						$single_multi = pods_var( $this->fields[$params->name]['type'] . '_format_type', $this->fields[$params->name]['options'], 'single' );
 
-						if ( $simple && ! is_array( $value ) && 'single' != $single_multi ) {
+						if ( $simple && ! is_array( $value ) && 'multi' == $single_multi ) {
 							$value = get_metadata( $this->pod_data['type'], $this->id(), $params->name );
 						}
 					} elseif ( 'settings' == $this->pod_data['type'] ) {


### PR DESCRIPTION
$single_multi does not always return "single" or "multi" as might possibly be expected, but rather a value such as "number" or "checkbox".   then the (somewhat new) logic checks for 'single' != $single_multi .    but what if $single_multi == "number" ?  
proposing to invert the logic to 'multi' == $single_multi to address pods issue #2166, this change solves that bug.
