### PR TITLE
Don't always return array on previously looked up fields

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -785,13 +785,11 @@ class Pods implements Iterator {
 			if ( empty( $field_data ) || in_array( $field_data[ 'type' ], array( 'boolean', 'number', 'currency' ) ) )
 				$params->raw = true;
 			
-			if ( !isset( $this->fields[ $params->name ] ) || !in_array( $this->fields[ $params->name ][ 'type' ], $tableless_field_types ) ) {
-				if ( null === $params->single ) {
-					if ( isset( $this->fields[ $params->name ] ) && !in_array( $this->fields[ $params->name ][ 'type' ], $tableless_field_types ) )
-						$params->single = true;
-					else
-						$params->single = false;
-				}
+			if ( null === $params->single ) {
+				if ( isset( $this->fields[ $params->name ] ) && !in_array( $this->fields[ $params->name ][ 'type' ], $tableless_field_types ) )
+					$params->single = true;
+				else
+					$params->single = false;
 			}
 
 			$value = $this->row[ $params->name ];


### PR DESCRIPTION
The problem was that on a second call to field() $this->row[ $params->name ] is populated,
so $value is set from that and the whole big next block that sets $single isn't called.

Fixes #2347
Fixed #2166
