### PR TITLE
Allow fields to be sorted by orderby …

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1347,6 +1347,7 @@ class Pods implements Iterator {
 										if ( in_array( $id, $ids ) )
 											$data[ $id ] = $v;
 									}
+								}
 							}
 
 							if ( in_array( $last_type, $tableless_field_types ) || in_array( $last_type, array( 'boolean', 'number', 'currency' ) ) )


### PR DESCRIPTION
Two separate but connected issues.  First if orderby is passed then the $data array is
never populated.  Then looping through $ids will always give it results sorted by priority
in the relationships field (data returned by lookup_related_items)

Fixes #2277
