### PR TITLE
Don't force a default value in a format function

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -6464,7 +6464,7 @@ class PodsAPI {
 
         // Verify required fields
         if ( 1 == pods_var( 'required', $options[ 'options' ], 0 ) && 'slug' != $type ) {
-            if ( '' == $value || null === $value || array() === $value || 0 === $value || '0' === $value || 0.00 === $value || '0.00' === $value )
+            if ( '' == $value || null === $value || array() === $value )
                 return pods_error( sprintf( __( '%s is empty', 'pods' ), $label ), $this );
 
             if ( 'multi' == pods_var( 'pick_format_type', $options[ 'options' ] ) && 'autocomplete' != pods_var( 'pick_format_multi', $options[ 'options' ] ) ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -6488,7 +6488,7 @@ class PodsAPI {
 
         // @todo move this to after pre-save preparations
         // Verify unique fields
-        if ( 1 == pods_var( 'unique', $options[ 'options' ], 0 ) && '' !== $value && null !== $value && array() !== $value && 0 !== $value && '0' !== $value && 0.00 !== $value && '0.00' !== $value ) {
+        if ( 1 == pods_var( 'unique', $options[ 'options' ], 0 ) && '' !== $value && null !== $value && array() !== $value ) {
             if ( empty( $pod ) )
                 return false;
 

--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -626,6 +626,11 @@ class PodsField_Currency extends PodsField {
 
 		global $wp_locale;
 
+		if ( null === $value ) {
+			// Don't enforce a default value here
+			return null;
+		}
+
 		if ( '9.999,99' == pods_v( self::$type . '_format', $options ) ) {
 			$thousands = '.';
 			$dot = ',';

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -450,6 +450,11 @@ class PodsField_Number extends PodsField {
     public function format ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
         global $wp_locale;
 
+	if ( null === $value ) {
+		// Don't enforce a default value here
+		return null;
+	}
+
         if ( '9.999,99' == pods_var( self::$type . '_format', $options ) ) {
             $thousands = '.';
             $dot = ',';


### PR DESCRIPTION
This seems like a more sane fix to so many of the bugs related to default values. If
someone really wants to make 0, 0.00, etc. the default let them force it via the "Default
Value" attribute