### PR TITLE
Change the default of display_errors to true

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -47,7 +47,7 @@ class Pods implements Iterator {
 	/**
 	 * @var bool
 	 */
-	public $display_errors = false;
+	public $display_errors = true;
 
 	/**
 	 * @var array|bool|mixed|null|void


### PR DESCRIPTION
A previous changed corrected the reversed logic that was used in display_error.  This should keep the previously expected behavior the same
