### PR TITLE
When using HTML5 allow empty dates to be properly displayed

### DIFF
--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -48,7 +48,7 @@
 
     $formatted_date = $value;
 
-    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
+    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '', '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
         $formatted_date = $value = '';
     elseif ( 'text' != $type ) {
         $formatted_date = $value;

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -96,7 +96,7 @@
 
     $formatted_date = $value;
 
-    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
+    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '', '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
         $formatted_date = $value = '';
     elseif ( 'text' != $type ) {
         $formatted_date = $value;

--- a/ui/fields/time.php
+++ b/ui/fields/time.php
@@ -58,7 +58,7 @@
 
     $formatted_date = $value;
 
-    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
+    if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array( $value, array( '', '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ) ) )
         $formatted_date = $value = '';
     elseif ( 'text' != $type ) {
         $formatted_date = $value;


### PR DESCRIPTION
The dates were actually being saved correctly, it was on display that it would default to todays date.

Fixes #2333
