### PR TITLE
Trim off whitespace when saving custom fields

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3191,6 +3191,8 @@ class PodsAPI {
                                         if ( !isset( $custom_label[ 1 ] ) )
                                             $custom_label[ 1 ] = $custom_label[ 0 ];
 
+                                        $custom_label[ 0 ] = trim( (string) $custom_label[ 0 ] );
+                                        $custom_label[ 1 ] = trim( (string) $custom_label[ 1 ] );
                                         $custom_values[ $custom_label[ 0 ] ] = $custom_label[ 1 ];
                                     }
                                 }


### PR DESCRIPTION
The code in classes/fields/pick.php already does this trim when the choices are displayed

Fixes #2343
