### PR TITLE
Fixed default avatars on the Discussion settings page replaced by user's custom avatar

### DIFF
--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -298,6 +298,14 @@ class PodsField_Avatar extends PodsField {
      * @return string <img> tag for the user's avatar
      */
     public function get_avatar ( $avatar, $id_or_email, $size, $default = '', $alt ='' ) {
+        // Don't replace for the Avatars section of the Discussion settings page
+        if ( is_admin() ) {
+            $current_screen = get_current_screen();
+            if ( 'options-discussion' == $current_screen->id && 32 == $size ) {
+                return $avatar;
+            }
+        }
+
         $_user_ID = 0;
 
         if ( is_numeric( $id_or_email ) && 0 < $id_or_email )


### PR DESCRIPTION
If user objects have been extended with a custom avatar field, and a user with a custom avatar opens the Discussion settings page, the custom avatar image is shown in the Default Avatar section, instead of the default avatars (Mystery Man, Gravatar Logo, etc.). This fixes the default avatars. (I'm using Pods 2.4.3.)

Would be great if there was a better way to determine when to let the default avatar through; this works but it feels a bit brittle.
