### PR TITLE
Fixed default avatars on the Discussion settings page replaced by user's custom avatar (3.0-unstable)

### DIFF
--- a/classes/Pods/Field/Avatar.php
+++ b/classes/Pods/Field/Avatar.php
@@ -214,6 +214,14 @@ class Pods_Field_Avatar extends
 	 * @return string <img> tag for the user's avatar
 	 */
 	public function get_avatar( $avatar, $id_or_email, $size, $default = '', $alt = '' ) {
+		// Don't replace for the Avatars section of the Discussion settings page
+		if ( is_admin() ) {
+			$current_screen = get_current_screen();
+			if ( 'options-discussion' == $current_screen->id && 32 == $size ) {
+				return $avatar;
+			}
+		}
+
 		$_user_ID = 0;
 
 		if ( is_numeric( $id_or_email ) && 0 < $id_or_email ) {


### PR DESCRIPTION
This is the same patch as #2389, applied to the 3.0-unstable branch. (I'm pretty sure this works, though I'm not using 3.0 so I haven't tested it personally.)
