### PR TITLE
Don't assume value 1 is boolean, use the pods-boolean class

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -103,7 +103,7 @@
                             var val = $el.val();
 
                             if ( $el.is( 'input[type=checkbox]' ) && !$el.is( ':checked' ) ) {
-                                if ( 1 == val )
+                                if ( $el.is( '.pods-boolean' ) )
                                     val = 0;
                                 else
                                     return true; // This input isn't a boolean, continue the loop


### PR DESCRIPTION
I think if more people were using ACT this issue would have been seen more off on any select with checkboxes.

Fixes #1862 
