### PR TITLE
Setup JS scripts so the colorpicker works when not in admin int

### DIFF
--- a/ui/fields/color.php
+++ b/ui/fields/color.php
@@ -13,10 +13,7 @@ if ( !is_admin() ) {
 	wp_localize_script( 'wp-color-picker', 'wpColorPickerL10n', $colorpicker_l10n );
 } else {
 	wp_enqueue_script( 'wp-color-picker' );
-
 }
-
-
 
 $attributes = array();
 $attributes[ 'type' ] = 'text';


### PR DESCRIPTION
For some reason wp-includes/script-loader.php only loads this stuff if (is_admin())

Fixes #2108
