### PR TITLE
Build the cache key properly if there are multiple types

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5307,8 +5307,8 @@ class PodsAPI {
                 'compare' => 'IN'
             );
 
-            if ( 1 == count( $params->type ) )
-                $cache_key .= '_type_' . trim( implode( '', $params->type ) );
+            if ( 0 < count( $params->type ) )
+                $cache_key .= '_type_' . trim( implode( '_', $params->type ) );
         }
 
         if ( isset( $params->object ) && !empty( $params->object ) ) {


### PR DESCRIPTION
I would always notice sometimes that load_pods would return a short list of available pods.  Today it was 8 out of 26 total pods.  I realized the 8 were all CPT type pods.  I tracked this down to frontier auto-template calling load_pods with 2 entries in type and then pods would cache the 'taxonomy' and 'post_type' pods as the name
'pods_names_get_all' when it is definitely not 'all"
