### PR TITLE
Switch deprecated function like_escape to esc_like

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -112,7 +112,7 @@ function pods_sanitize_like( $input ) {
 	else {
 		global $wpdb;
 
-		if ( pods_version_check( 'wp', '4.0' ) ) {
+		if ( pods_version_check( 'wp', '4.0', '<' ) ) {
 			// like_escape is deprecated in WordPress 4.0
 			$output = like_escape( pods_sanitize( $input ) );
 		else {


### PR DESCRIPTION
I haven't tested this yet on WordPress 4.0, when I get a chance I will unless someone gets to it first
