### PR TITLE
Properly load Pods_Templates

### DIFF
--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -15,10 +15,6 @@
  * @subpackage Templates
  */
 
-if ( class_exists( 'Pods_Templates' ) ) {
-	return;
-}
-
 // Pull in the functions
 require_once( plugin_dir_path( __FILE__ ) . '/includes/functions-view_template.php' );
 require_once( plugin_dir_path( __FILE__ ) . '/includes/functions-pod_reference.php' );


### PR DESCRIPTION
Did this ever work?  Maybe I'm missing something here

When I enabled xcache on my server pods-frontier was causing an error because the 'frontier_get_regex' function wasn't available
