### PR TITLE
Small Alignment fix for the OK button in the slug change UI

### DIFF
--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -150,7 +150,7 @@ $tab_options = $pod->admin_options();
 	                    ),
 	                    'class'      => 'pods-validate pods-validate-required'
                     ) ); ?>
-	                <input type="button" class="save-button button" value="<?php esc_attr_e( 'OK', 'pods' ); ?>" /> <a class="cancel" href="#cancel-edit"><?php _e( 'Cancel', 'pods' ); ?></a>
+	                <input type="button" style="vertical-align: middle" class="save-button button" value="<?php esc_attr_e( 'OK', 'pods' ); ?>" /> <a class="cancel" href="#cancel-edit"><?php _e( 'Cancel', 'pods' ); ?></a>
                 </span>
             </span>
 		<?php


### PR DESCRIPTION
It was a bit unaligned before with "vertical-align: top;" Being the default setting from the default WordPress buttons, and that did not align it with the text field to change the slug. Should be fixed now!
