### PR TITLE
Pass $params to 'select' hook

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -657,7 +657,7 @@ class PodsData {
                 pods_view_set( $cache_key, $results, pods_var( 'expires', $params, 0, null, true ), pods_var( 'cache_mode', $params, 'cache', null, true ), 'pods_data_select' );
         }
 
-        $results = $this->do_hook( 'select', $results );
+        $results = $this->do_hook( 'select', $results, $params );
 
         $this->data = $results;
 


### PR DESCRIPTION
Most of the other hooks pass $params as well, this allows the filter to be a bit more useful and won't break anything
