### PR TITLE
Fix for Currency field decimal places.

### DIFF
--- a/classes/Pods/Field/Currency.php
+++ b/classes/Pods/Field/Currency.php
@@ -525,7 +525,7 @@ class Pods_Field_Currency extends
 			$length = 64;
 		}
 
-		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2, false );
+		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2 );
 
 		if ( $decimals < 1 ) {
 			$decimals = 0;


### PR DESCRIPTION
Issue #2193
Currency field with 0 decimal places was showing 2 d.p.
This was because strict formatting does not allow empty values - but in this case zero is a valid empty value.
