### PR TITLE
Don't hide text in title-prompt-text

### DIFF
--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -355,7 +355,7 @@ if ( 0 < $pod->id() ) {
 										do_action( 'pods_act_editor_before_title', $pod );
 									?>
                                     <div id="titlewrap">
-                                        <label class="hide-if-no-js" style="visibility:hidden" id="title-prompt-text" for="title"><?php echo apply_filters( 'pods_enter_name_here', __( 'Enter name here', 'pods' ), $pod, $fields ); ?></label>
+                                        <label class="hide-if-no-js" id="title-prompt-text" for="title"><?php echo apply_filters( 'pods_enter_name_here', __( 'Enter name here', 'pods' ), $pod, $fields ); ?></label>
                                         <input type="text" name="pods_field_<?php echo $pod->pod_data[ 'field_index' ]; ?>" data-name-clean="pods-field-<?php echo $pod->pod_data[ 'field_index' ]; ?>" id="title" size="30" tabindex="1" value="<?php echo esc_attr( htmlspecialchars( $pod->index() ) ); ?>" class="pods-form-ui-field-name-pods-field-<?php echo $pod->pod_data[ 'field_index' ]; ?>" autocomplete="off"<?php echo $extra; ?> />
 										<?php
 										/**


### PR DESCRIPTION
I always wondered why there was never anything prompting what to enter.  I get why the no-js thing is there, if you disable JS and type over then it looks ugly

Related to #2507
