### PR TITLE
Make sure title is hidden if there is text

### DIFF
--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -355,7 +355,7 @@ if ( 0 < $pod->id() ) {
 										do_action( 'pods_act_editor_before_title', $pod );
 									?>
                                     <div id="titlewrap">
-                                        <label class="screen-reader-text" style="visibility:hidden" id="title-prompt-text" for="title"><?php echo apply_filters( 'pods_enter_name_here', __( 'Enter name here', 'pods' ), $pod, $fields ); ?></label>
+                                        <label class="screen-reader-text" id="title-prompt-text" for="title"><?php echo apply_filters( 'pods_enter_name_here', __( 'Enter name here', 'pods' ), $pod, $fields ); ?></label>
                                         <input type="text" name="pods_field_<?php echo $pod->pod_data[ 'field_index' ]; ?>" data-name-clean="pods-field-<?php echo $pod->pod_data[ 'field_index' ]; ?>" id="title" size="30" tabindex="1" value="<?php echo esc_attr( htmlspecialchars( $pod->index() ) ); ?>" class="pods-form-ui-field-name-pods-field-<?php echo $pod->pod_data[ 'field_index' ]; ?>" autocomplete="off"<?php echo $extra; ?> />
 										<?php
 										/**


### PR DESCRIPTION
The patch in #2509 made the "Enter name here" text appear, but I didn't notice until just recently that if you are loading a form that already has data in it that it is displayed as well as the text

This changes the form so it is handled exactly the way that WordPress's form is
