### PR TITLE
Let jquery use .pods-form-ui-field-type-boolean also

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -181,7 +181,7 @@
                             var val = $el.val();
 
                             if ( $el.is( 'input[type=checkbox]' ) && !$el.is( ':checked' ) ) {
-                                if ( $el.is( '.pods-boolean' ) )
+                                if ( $el.is( '.pods-boolean' ) || $el.is( '.pods-form-ui-field-type-boolean') )
                                     val = 0;
                                 else
                                     return true; // This input isn't a boolean, continue the loop


### PR DESCRIPTION
Anything unchecked that was boolean in the admin interface would not get sent over in ajax query

Fixes #2610