### PR TITLE
Pods forum feed not retrieved in latest version of Pods

### DIFF
--- a/ui/admin/help.php
+++ b/ui/admin/help.php
@@ -21,7 +21,7 @@
     <?php
         include_once( ABSPATH . WPINC . '/feed.php' );
 
-        $feed = fetch_feed( 'http://pods.io/forums/forum/general-discussion/pods-2-x/feed/' );
+        $feed = fetch_feed( 'http://pods.io/forums/forum/pods-2-x/feed/' );
 
         if ( !is_wp_error( $feed ) ) {
             $max_items = $feed->get_item_quantity( 6 );


### PR DESCRIPTION
$feed returns something, hooray! This did not return the forum list, so I just made sure to change the URL, now all is good!