### PR TITLE
Make sure autoloader doesn't load the same class more than once

### DIFF
--- a/classes/Pods/ClassLoader.php
+++ b/classes/Pods/ClassLoader.php
@@ -133,7 +133,7 @@ class Pods_ClassLoader {
 		}
 
 		if ( $file = $this->findFile( $className ) ) {
-			require $file;
+			require_once $file;
 
 			return true;
 		}
@@ -145,13 +145,13 @@ class Pods_ClassLoader {
 			if ( $file = $this->findFile( $two_dot_oh ) ) {
 				$this->forwardClass( $two_dot_oh, $className );
 
-				require $file;
+				require_once $file;
 
 				return true;
 			} elseif ( $file = $this->findFile( $one_dot_oh ) ) {
 				$this->forwardClass( $one_dot_oh, $className );
 
-				require $file;
+				require_once $file;
 
 				return true;
 			}
@@ -208,20 +208,20 @@ class Pods_ClassLoader {
 	 * @return void
 	 */
 	public function forwardClass( $fromClass, $toClass ) {
+		if ( ! class_exists( $fromClass ) ) {
+			eval( "
+				class {$fromClass} extends {$toClass} {
 
-		eval( "
-			class {$fromClass} extends {$toClass} {
+					public static \$classLoader_forward_class = '{$fromClass}';
 
-				public static \$classLoader_forward_class = '{$fromClass}';
-
-				public function __construct() {
+					public function __construct() {
 
 					parent::__construct();
 
-				}
+					}
 
 			}
-		" );
-
+			" );
+		}
 	}
 }


### PR DESCRIPTION
Two distinct but related issues here.  First the code would try to alias classes more than once which caused php to complain that the class already existed.  Second the autoloader would try to 'require' files more than once which caused php to complain.

Fixes #2721