### PR TITLE
Properly build related object table

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -353,6 +353,7 @@ class PodsField_Pick extends PodsField {
         }
 
         if ( empty( self::$related_objects ) ) {
+                // Do a complete build of related_objects
             $new_data_loaded = true;
 
             // Custom

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -339,15 +339,22 @@ class PodsField_Pick extends PodsField {
      * @since 2.3
      */
     public function setup_related_objects ( $force = false ) {
-	    if ( !$force && ! empty( self::$related_objects ) ) {
-		    // Check if we've already been setup
-		    return false;
-	    }
-        $related_objects = pods_transient_get( 'pods_related_objects' );
+        $new_data_loaded = false;
 
-        if ( !$force && !empty( $related_objects ) )
-            self::$related_objects = $related_objects;
-        else {
+        if ( ! $force && empty( self::$related_objects ) ) {
+            // Only load transient if we aren't forcing a refresh
+            self::$related_objects = pods_transient_get( 'pods_related_objects' );
+            if ( false !== self::$related_objects ) {
+                $new_data_loaded = true;
+            }
+        } elseif ( $force ) {
+	        // If we are rebuilding, make sure we start with a clean slate
+	        self::$related_objects = array();
+        }
+
+        if ( empty( self::$related_objects ) ) {
+            $new_data_loaded = true;
+
             // Custom
             self::$related_objects[ 'custom-simple' ] = array(
                 'label' => __( 'Simple (custom defined list)', 'pods' ),
@@ -541,9 +548,12 @@ class PodsField_Pick extends PodsField {
         }
 
         foreach ( self::$custom_related_objects as $object => $related_object ) {
-            self::$related_objects[ $object ] = $related_object;
+            if ( ! isset( self::$related_objects[ $object ] ) ) {
+                $new_data_loaded = true;
+                self::$related_objects[ $object ] = $related_object;
+            }
         }
-	    return true;
+	    return $new_data_loaded;
     }
 
     /**


### PR DESCRIPTION
If pods_register_related_object() is called late in the game then the objects aren't actually added to the array
because the optimizations added for 2.5 keep the tables from constantly being rebuilded.  This patch lets the items to be added without doing a full rebuild.  Also, a force rebuild before would have loaded the transient and thrown the data away.

Fixes #2737