### PR TITLE
travis-ci: only build php nightly with latest stable wordpress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
     - 5.5
     - 5.6
     - hhvm
-    - nightly
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
@@ -23,6 +22,12 @@ env:
 matrix:
   allow_failures:
     - php: nightly
+    
+  include:
+    - php: nightly
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: nightly
+      env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
     - travis_retry composer self-update


### PR DESCRIPTION
this removed 8 builds / run
which saves nearly 2 hours per UT session

#2782