### PR TITLE
PR to merge WordPress Coding Standards by Scrutinizer into all

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,5 @@
+# .scrutinizer.yml
+tools:
+    php_code_sniffer:
+        config:
+            standard: "WordPress" # Other Values: PSR2, PEAR, Zend, WordPress


### PR DESCRIPTION
This adds a feature to check PHP for WordPress Coding Standards

Results: https://scrutinizer-ci.com/g/Ramoonus/pods/inspections/ed5140fd-45ce-4a52-8d2a-d103f5f634c8 
Versus https://scrutinizer-ci.com/g/pods-framework/pods/inspections/8f0d3433-2245-409f-a2c3-70f5e33715e8/issues/

generated approx 200 code styling errors