### PR TITLE
Removing double-slash trimming

### DIFF
--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -573,7 +573,6 @@ class PodsView {
 
 		// Keep it safe
 		$_view = trim( str_replace( array( '../', '\\' ), array( '', '/' ), (string) $_view ) );
-		$_view = preg_replace( '/\/+/', '/', $_view );
 
 		if ( empty( $_view ) ) {
 			return false;


### PR DESCRIPTION
This fixes issue #2658 
The removed trimming was causing issues on windows network-mounted filesystems. the function realpath() already does this for us.