### PR TITLE
Removing double-slash trimming

### DIFF
--- a/classes/Pods/View.php
+++ b/classes/Pods/View.php
@@ -584,7 +584,6 @@ class Pods_View {
 
 		// Keep it safe, stay thirsty my friends
 		$_view = trim( str_replace( array( '../', '\\' ), array( '', '/' ), (string) $_view ) );
-		$_view = preg_replace( '/\/+/', '/', $_view );
 
 		if ( empty( $_view ) ) {
 			return false;


### PR DESCRIPTION
This fixes issue #2658 

The removed trimming was causing issues on windows network-mounted filesystems. the function realpath() already does this for us.