### PR TITLE
Fixed #1786, Pods 2.x, fixed the merging data in fetch function.

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1942,7 +1942,7 @@ class PodsData {
                     $row = get_object_vars( (object) @current( $current_row ) );
 
                     if ( is_array( $this->row ) && !empty( $this->row ) )
-                        $this->row = array_merge( $row, $this->row );
+                        $this->row = array_merge( $this->row, $row );
                     else
                         $this->row = $row;
                 }


### PR DESCRIPTION
The incorrect order in array_merge causes old data being cached instead
of new one from DB.