### PR TITLE
Add $ui[‘sql’][‘select’] support for find() on SQL-based PodsUI instances for #2880 in 2.x

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -2155,6 +2155,10 @@ class PodsUI {
                 'fields' => $this->fields[ 'search' ],
                 'sql' => $sql
             );
+
+		if ( ! empty( $this->sql['select'] ) ) {
+			$find_params['select'] = $this->sql['select'];
+		}
         }
 
         if ( empty( $find_params[ 'where' ] ) && $this->restricted( $this->action ) )


### PR DESCRIPTION
Fixes #2880 for Pods 2.x