### PR TITLE
Add $ui[‘sql’][‘select’] support for find() on SQL-based PodsUI instances for #2880 in 3.0

### DIFF
--- a/classes/Pods/UI.php
+++ b/classes/Pods/UI.php
@@ -2518,6 +2518,10 @@ class Pods_UI {
 			    'search_query' => $this->search,
 			    'fields'       => $this->fields[ 'search' ]
 		    );
+
+			if ( ! empty( $this->sql['select'] ) ) {
+				$find_params['select'] = $this->sql['select'];
+			}
 	    }
 
 	    if ( empty( $find_params[ 'where' ] ) && $this->restricted( $this->action ) ) {


### PR DESCRIPTION
Fixes #2880 for 3.0