### PR TITLE
each branch designation must match the branch

### DIFF
--- a/init.php
+++ b/init.php
@@ -9,7 +9,7 @@ Author URI: http://pods.io/about/
 Text Domain: pods
 Domain Path: /languages/
 GitHub Plugin URI: https://github.com/pods-framework/pods
-GitHub Branch: 2.x
+GitHub Branch: master
 
 Copyright 2009-2015  Pods Foundation, Inc  (email : contact@podsfoundation.org)
 


### PR DESCRIPTION
The `GitHub Branch: master` must be the branch listed in version on wp.org.