### PR TITLE
Don't over escape icon URL in file fields previewer

### DIFF
--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -498,7 +498,7 @@ class PodsField_File extends PodsField {
             <?php } ?>
 
             <li class="pods-file-col pods-file-icon">
-                <img class="pinkynail" src="<?php echo esc_url( $icon ); ?>" alt="Icon" />
+                <img class="pinkynail" src="<?php echo $icon; ?>" alt="Icon" />
             </li>
 
             <li class="pods-file-col pods-file-name">

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -477,8 +477,12 @@ class PodsField_File extends PodsField {
         if ( empty( $id ) )
             $id = '{{id}}';
 
-        if ( empty( $icon ) )
-            $icon = '{{icon}}';
+        if ( empty( $icon ) ) {
+	        $icon = '{{icon}}';
+        }else{
+	        $icon = esc_url( $icon );
+        }
+
 
         if ( empty( $name ) )
             $name = '{{name}}';


### PR DESCRIPTION
#2995

We were using `esc_url` after handlebars escaped it, so it was always coming out as `http://icon`

Not sure if there are other instances where this could be a problem, but it fixed the issue for me in the CPT editor.

Assigning to @sc0ttkclark to consider the ramifications of this change and worry about any possible side-effects.