### PR TITLE
Fix current user can in 3.0

### DIFF
--- a/init.php
+++ b/init.php
@@ -84,14 +84,16 @@ else {
         if ( file_exists( $cmb2_init_path ) ) {
             require_once( $cmb2_init_path );
         } else {
-            if ( is_admin() && current_user_can( 'edit_options' ) ) {
-                add_action( 'admin_notices', function () { ?>
-                    <div class="updated">
-                        <p><?php _e( 'Pods was not installed correctly. Please download a demo build or reinstall from WordPress.org, or run composer update.', 'pods' ); ?></p>
-                    </div>
-                <?php
+            if ( is_admin() ) {
+                add_action( 'admin_notices', function () {
+	                if ( current_user_can( 'edit_options' ) ) {
+		                ?>
+		                <div class="updated">
+			                <p><?php _e( 'Pods was not installed correctly. Please download a demo build or reinstall from WordPress.org, or run composer update.', 'pods' ); ?></p>
+		                </div>
+	                <?php
+	                }
                 });
-
             }
         }
 

--- a/init.php
+++ b/init.php
@@ -91,7 +91,7 @@ else {
 		                <div class="updated">
 			                <p><?php _e( 'Pods was not installed correctly. Please download a demo build or reinstall from WordPress.org, or run composer update.', 'pods' ); ?></p>
 		                </div>
-	                <?php
+	                    <?php
 	                }
                 });
             }


### PR DESCRIPTION
current_user_can not yet defined and causes a PHP fatal for me locally. Moving the check inside the `admin_notices` hook fixes this.