### PR TITLE
Fix for pagination handling in shortcodes

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -594,6 +594,20 @@ function pods_shortcode ( $tags, $content = null ) {
 		return '';
 	}
 
+	// For enforcing pagination parameters when not displaying pagination
+	$page = 1;
+	$offset = 0;
+
+	if ( isset( $tags['page'] ) ) {
+		$page = (int) $tags['page'];
+		$page = max( $page, 1 );
+	}
+
+	if ( isset( $tags['offset'] ) ) {
+		$offset = (int) $tags['offset'];
+		$offset = max( $offset, 0 );
+	}
+
     $defaults = array(
         'name' => null,
         'id' => null,
@@ -760,14 +774,24 @@ function pods_shortcode ( $tags, $content = null ) {
 
 			$params[ 'search' ] = $tags[ 'search' ];
 
-			if ( 0 < absint( $tags[ 'page' ] ) ) {
-				$params[ 'page' ] = absint( $tags[ 'page' ] );
-			}
-
 			$params[ 'pagination' ] = $tags[ 'pagination' ];
 
-			if ( 0 < (int) $tags[ 'offset' ] ) {
-				$params[ 'offset' ] = (int) $tags[ 'offset' ];
+			// If we aren't displaying pagination, we need to enforce page/offset
+			if ( ! $params['pagination'] ) {
+				$params['page']   = $page;
+				$params['offset'] = $offset;
+			} else {
+				// If we are displaying pagination, allow page/offset override only if *set*
+
+				if ( isset( $tags['page'] ) ) {
+					$params['page'] = (int) $tags['page'];
+					$params['page'] = max( $params['page'], 1 );
+				}
+
+				if ( isset( $tags['offset'] ) ) {
+					$params['offset'] = (int) $tags['offset'];
+					$params['offset'] = max( $params['offset'], 0 );
+				}
 			}
 
 			if ( !empty( $tags[ 'cache_mode' ] ) && 'none' != $tags[ 'cache_mode' ] ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -780,6 +780,9 @@ function pods_shortcode ( $tags, $content = null ) {
 			if ( ! $params['pagination'] ) {
 				$params['page']   = $page;
 				$params['offset'] = $offset;
+
+				// Force pagination on, we need it and we're enforcing page/offset
+				$params['pagination'] = true;
 			} else {
 				// If we are displaying pagination, allow page/offset override only if *set*
 

--- a/tests/includes/tests-shortcodes.php
+++ b/tests/includes/tests-shortcodes.php
@@ -8,10 +8,10 @@ use Pods_Unit_Tests\Pods_UnitTestCase;
  */
 class Test_Shortcodes extends Pods_UnitTestCase {
 
-	/** @var int|null  */
+	/** @var int|null */
 	private $pod_id = null;
 
-	/** @var \Pods|false|null  */
+	/** @var \Pods|false|null */
 	private $pod = null;
 
 	public function setUp() {
@@ -79,12 +79,11 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 		$this->assertEquals( '~~', do_shortcode( '[pods name="planet" pagination=xyzzy limit="2"]~[/pods]' ) );
 
 		// Not enough records to trigger pagination even if on
-		$this->assertNotContains( '<a', do_shortcode(  '[pods name="planet" pagination="1" limit="100"]~[/pods]' ) );
-
+		$this->assertNotContains( '<a', do_shortcode( '[pods name="planet" pagination="1" limit="100"]~[/pods]' ) );
 
 		/** @link https://github.com/pods-framework/pods/pull/2807 */
-		$this->assertEquals( '57', do_shortcode('[pods name="planet" page="1" limit="2"]{@number_of_moons}[/pods]') );
-		$this->assertEquals( '5', do_shortcode('[pods name="planet" page="2" limit="2"]{@number_of_moons}[/pods]') );
+		$this->assertEquals( '57', do_shortcode( '[pods name="planet" page="1" limit="2"]{@number_of_moons}[/pods]' ) );
+		$this->assertEquals( '5', do_shortcode( '[pods name="planet" page="2" limit="2"]{@number_of_moons}[/pods]' ) );
 
 	}
 

--- a/tests/includes/tests-shortcodes.php
+++ b/tests/includes/tests-shortcodes.php
@@ -28,11 +28,13 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 			'type'   => 'number'
 		);
 		pods_api()->save_field( $params );
+
 	}
 
 	public function tearDown() {
 
 		pods_api()->delete_pod( array( 'id' => $this->pod_id ) );
+
 	}
 
 	/**
@@ -44,19 +46,19 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 		$this->pod->add( array( 'name' => 'Tatooine', 'number_of_moons' => 5 ) );
 
 		//test shortcode
-		$this->assertEquals( '5', do_shortcode( '[pods name ="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
+		$this->assertEquals( '5', do_shortcode( '[pods name="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
 
 		//add another item
 		$this->pod->add( array( 'name' => 'Alderaan', 'number_of_moons' => 7 ) );
 
 		//test shortcode
-		$this->assertEquals( '5', do_shortcode( '[pods name ="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
+		$this->assertEquals( '5', do_shortcode( '[pods name="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
 
 		//add third item
 		$this->pod->add( array( 'name' => 'Hoth', 'number_of_moons' => 5 ) );
 
 		//test shortcode
-		$this->assertEquals( '55', do_shortcode( '[pods name ="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
+		$this->assertEquals( '55', do_shortcode( '[pods name="planet" where="t.number_of_moons=5"]{@number_of_moons}[/pods]' ) );
 
 		// Test the pagination parameter
 		/** @see http://php.net/manual/en/filter.filters.validate.php FILTER_VALIDATE_BOOLEAN */
@@ -79,6 +81,11 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 		// Not enough records to trigger pagination even if on
 		$this->assertNotContains( '<a', do_shortcode(  '[pods name="planet" pagination="1" limit="100"]~[/pods]' ) );
 
+
+		/** @link https://github.com/pods-framework/pods/pull/2807 */
+		$this->assertEquals( '57', do_shortcode('[pods name="planet" page="1" limit="2"]{@number_of_moons}[/pods]') );
+		$this->assertEquals( '5', do_shortcode('[pods name="planet" page="2" limit="2"]{@number_of_moons}[/pods]') );
+
 	}
 
 	/**
@@ -93,7 +100,8 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 		$this->pod->add( array( 'name' => 'Dagobah', 'number_of_moons' => 5 ) );
 
 		//test shortcode
-		$this->assertEquals( '5', do_shortcode( '[pods name ="planet" where="t.number_of_moons=5" field="number_of_moons"]' ) );
+		$this->assertEquals( '5', do_shortcode( '[pods name="planet" where="t.number_of_moons=5" field="number_of_moons"]' ) );
+
 	}
 
 }


### PR DESCRIPTION
Shortcodes currently use 'pagination' for two contexts (display and data) but if `page` or `offset` is supplied, it's only *meant* for one context (display).