### PR TITLE
Avoid PHP Notice: Undefined index 'pick_object'

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -788,7 +788,7 @@ class Pods implements Iterator {
 		}
 
 		// Simple fields have no other output options
-		if ( 'pick' == $field_data[ 'type' ] && in_array( $field_data[ 'pick_object' ], $simple_tableless_objects ) ) {
+		if ( 'pick' == $field_data[ 'type' ] && isset($field_data[ 'pick_object' ]) && in_array( $field_data[ 'pick_object' ], $simple_tableless_objects ) ) {
 			$params->output = 'arrays';
 		}
 


### PR DESCRIPTION
Hello,

i am using your plugin with pods-json-api plugin

i have created one custom taxonomy in pods,

when i try to retrieve json data with pods-json-api i get one PHP Notice of a missing index 'pick_object' 

on file pods/classes/Pods.php on line 791

applied one quick patch to solve it, and i share it here.

Thanks,

good work!