### PR TITLE
Issue #2779: `permalink` field traversal has only been working for post types (3.0)

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1599,7 +1599,7 @@ class Pods implements Iterator {
 											$value[] = pods_image( $item_id, $size );
 
 											$params->raw_display = true;
-										} elseif ( in_array( $field, array( '_link', 'detail_url' ) ) || ( in_array( $field, array( 'permalink', 'the_permalink' ) ) && 'post' == $object_type ) ) {
+										} elseif ( in_array( $field, array( '_link', 'detail_url' ) ) || in_array( $field, array( 'permalink', 'the_permalink' ) ) ) {
 											if ( 'pod' == $object_type ) {
 												if ( is_object( $related_obj ) ) {
 													$related_obj->fetch( $item_id );


### PR DESCRIPTION
#2779