### PR TITLE
Update PodsAPI.php

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -7205,8 +7205,8 @@ class PodsAPI {
             $current_language = pods_sanitize( pll_current_language( 'slug' ) );
 
             if ( !empty( $current_language ) ) {
-                $current_language_t_id = (int) $polylang->get_language( $current_language )->term_id;
-                $current_language_tt_id = (int) $polylang->get_language( $current_language )->term_taxonomy_id;
+                $current_language_t_id = (int) $polylang->model->get_language( $current_language )->term_id;
+                $current_language_tt_id = (int) $polylang->model->get_language( $current_language )->term_taxonomy_id;
             }
         }
 


### PR DESCRIPTION
Got a warning from Polylang:

Notice: get_language was called incorrectly in **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php on line 7208: the call to $polylang->get_language() has been deprecated in Polylang 1.2, use $polylang->model->get_language() instead.
Error handler in **SITE_DIR**/wp-content/plugins/polylang/include/base.php on line 112

Call Stack:
    0.0004     243112   1. {main}() **SITE_DIR**/index.php:0
    0.0007     243864   2. require('**SITE_DIR**/wp-blog-header.php') **SITE_DIR**/index.php:17
    0.0011     245040   3. require_once('**SITE_DIR**/wp-load.php') **SITE_DIR**/wp-blog-header.php:12
    0.0014     246320   4. require_once('**SITE_DIR**/wp-config.php') **SITE_DIR**/wp-load.php:37
    0.0025     250000   5. require_once('**SITE_DIR**/wp-settings.php') **SITE_DIR**/wp-config.php:91
    0.9383   10615240   6. include('**SITE_DIR**/wp-content/themes/reflektis/functions.php') **SITE_DIR**/wp-settings.php:327
    1.0036   11433800   7. pods_field() **SITE_DIR**/wp-content/themes/reflektis/functions.php:14
    1.0036   11433856   8. pods() **SITE_DIR**/wp-content/plugins/pods/includes/general.php:1280
    1.0157   11469128   9. Pods->__construct() **SITE_DIR**/wp-content/plugins/pods/includes/classes.php:21
    1.0157   11469128  10. pods_api() **SITE_DIR**/wp-content/plugins/pods/classes/Pods.php:214
    1.0158   11469200  11. PodsAPI::init() **SITE_DIR**/wp-content/plugins/pods/includes/classes.php:68
    1.0158   11469432  12. PodsAPI->__construct() **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php:88
    1.0159   11471056  13. PodsAPI->load_pod() **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php:121
    1.0198   11473416  14. PodsAPI->get_table_info() **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php:5343
    1.0199   11478576  15. PLL_Frontend->get_language() **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php:7208
    1.0199   11479032  16. PLL_Base->__call() **SITE_DIR**/wp-content/plugins/pods/classes/PodsAPI.php:7208
    1.0200   11508128  17. trigger_error() **SITE_DIR**/wp-content/plugins/polylang/include/base.php:112