### PR TITLE
travis-ci: MySQL 5.7 instead of 5.7-dmr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         mariadb: 10.1
     # MySQL 5.7
     - php: 5.6
-      env: DB=mysql-5.7-dmr WP_VERSION=latest WP_MULTISITE=0
+      env: DB=mysql-5.7 WP_VERSION=latest WP_MULTISITE=0
 
 ## Cache composer bits
 cache:


### PR DESCRIPTION
Let travis do the confirmation, before inclusion