### PR TITLE
Fixes to REST API tab

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -2523,8 +2523,8 @@ class PodsAdmin {
 	    if ( ! function_exists( 'register_api_field' ) ) {
 		    $options[ 'rest-api' ] = array(
 			    'no_dependencies' => array(
-				    'label'      => __( 'Pods REST API support requires WordPress 4.3.1 or later and The WordPress REST API 2.0-beta7 or later.', 'pods' ),
-				    'help'       => __( sprintf( 'See %s for more information.', '<a href="http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/"</a>'), 'pods' ),
+				    'label'      => __( 'Pods REST API support requires WordPress 4.3.1 or later and the <a href="https://wordpress.org/plugins/rest-api/" target="_blank">WordPress REST API 2.0-beta7</a> or later.', 'pods' ),
+				    'help'       => __( sprintf( 'See %s for more information.', '<a href="http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/</a>'), 'pods' ),
 				    'type'       => 'html',
 			    ),
 		    );

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -2523,7 +2523,7 @@ class PodsAdmin {
 	    if ( ! function_exists( 'register_api_field' ) ) {
 		    $options[ 'rest-api' ] = array(
 			    'no_dependencies' => array(
-				    'label'      => __( 'Pods REST API support requires WordPress 4.3.1 or later and the <a href="https://wordpress.org/plugins/rest-api/" target="_blank">WordPress REST API 2.0-beta7</a> or later.', 'pods' ),
+				    'label'      => __( sprintf( 'Pods REST API support requires WordPress 4.3.1 or later and the %s or later.', '<a href="http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">WordPress REST API 2.0-beta7</a>' ), 'pods' ),
 				    'help'       => __( sprintf( 'See %s for more information.', '<a href="http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">http://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/</a>'), 'pods' ),
 				    'type'       => 'html',
 			    ),

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -461,3 +461,12 @@ div.row-actions.row-actions-toggle {
 .pods-field-option select:focus, .pods-field input[type=checkbox]:focus + label{
     background: #ffffcc;
 }
+
+/*
+ * REST API Tab
+ */
+
+#pods-rest-api label[for="pods-form-ui-no-dependencies"] {
+    width: 100%;
+    max-width: initial;
+}


### PR DESCRIPTION
Made some minor grammar changes, linked to rest api plugin on wordpress.org, and added a css class to target the rest api alert when no dependencies are available.