### PR TITLE
Fixing deprecated Polylang method for versions 1.2 and above

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -7205,8 +7205,8 @@ class PodsAPI {
             $current_language = pods_sanitize( pll_current_language( 'slug' ) );
 
             if ( !empty( $current_language ) ) {
-                $current_language_t_id = (int) $polylang->get_language( $current_language )->term_id;
-                $current_language_tt_id = (int) $polylang->get_language( $current_language )->term_taxonomy_id;
+                $current_language_t_id = (int) $polylang->model->get_language( $current_language )->term_id;
+                $current_language_tt_id = (int) $polylang->model->get_language( $current_language )->term_taxonomy_id;
             }
         }
 


### PR DESCRIPTION
When using Polylang > 1.2 
__Notice:__ get_language was called incorrectly in /var/www/html/wp-content/plugins/pods/classes/PodsAPI.php on line 7208: the call to $polylang->get_language() has been deprecated in Polylang 1.2, use $polylang->model->get_language() instead.