### PR TITLE
Change markup to support css in wp 4.4

### DIFF
--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -814,8 +814,8 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
     <div id="side-info-field" class="inner-sidebar">
         <div id="side-sortables">
             <div id="submitdiv" class="postbox pods-no-toggle">
-                <h2><span>Manage <small>(<a href="<?php echo esc_url( pods_query_arg( array( 'action' . $obj->num => 'manage', 'id' . $obj->num => '' ) ) ); ?>">&laquo; <?php _e( 'Back to Manage', 'pods' ); ?></a>)
-                </small></span></h2>
+                <h3><span>Manage <small>(<a href="<?php echo esc_url( pods_query_arg( array( 'action' . $obj->num => 'manage', 'id' . $obj->num => '' ) ) ); ?>">&laquo; <?php _e( 'Back to Manage', 'pods' ); ?></a>)
+                </small></span></h3>
                 <div class="inside">
                     <div class="submitbox" id="submitpost">
                         <div id="major-publishing-actions">

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -814,8 +814,8 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
     <div id="side-info-field" class="inner-sidebar">
         <div id="side-sortables">
             <div id="submitdiv" class="postbox pods-no-toggle">
-                <h3><span>Manage <small>(<a href="<?php echo esc_url( pods_query_arg( array( 'action' . $obj->num => 'manage', 'id' . $obj->num => '' ) ) ); ?>">&laquo; <?php _e( 'Back to Manage', 'pods' ); ?></a>)
-                </small></span></h3>
+                <h2><span>Manage <small>(<a href="<?php echo esc_url( pods_query_arg( array( 'action' . $obj->num => 'manage', 'id' . $obj->num => '' ) ) ); ?>">&laquo; <?php _e( 'Back to Manage', 'pods' ); ?></a>)
+                </small></span></h2>
                 <div class="inside">
                     <div class="submitbox" id="submitpost">
                         <div id="major-publishing-actions">

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -79,6 +79,13 @@
     margin-bottom: 0px !important;
 }
 
+#poststuff h3 {
+    font-size: 14px;
+    padding: 8px 12px;
+    margin: 0;
+    line-height: 1.4;
+}
+
 /*
  * Pods Tabbed
  */

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -79,7 +79,7 @@
     margin-bottom: 0px !important;
 }
 
-.pods-admin #poststuff h3 {
+#poststuff h3 {
     font-size: 14px;
     padding: 8px 12px;
     margin: 0;

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -79,7 +79,7 @@
     margin-bottom: 0px !important;
 }
 
-#poststuff h3 {
+.pods-admin #poststuff h3 {
     font-size: 14px;
     padding: 8px 12px;
     margin: 0;


### PR DESCRIPTION
WP 4.4 removed h3 as a pre-styled tag. Changing tag to an h2 resolves the issue. #3270 