### PR TITLE
`Pods::find()`: Ditch the reference inside the foreach loop that builds the `orderby` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [Pods Framework](http://pods.io) #
 [![Travis](https://secure.travis-ci.org/pods-framework/pods.png?branch=2.x)](http://travis-ci.org/pods-framework/pods)
+[![Dockunit Status](https://dockunit.io/svg/pods-framework/pods?2.x)](https://dockunit.io/projects/pods-framework/pods#2.x)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/pods-framework/pods/badges/quality-score.png?b=2.x)](https://scrutinizer-ci.com/g/pods-framework/pods/?branch=2.x)
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://github.com/pods-framework/pods/blob/2.x/license.txt)
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -2277,14 +2277,14 @@ class Pods implements Iterator {
 			if ( !is_array( $params->orderby ) )
 				$params->orderby = array( $params->orderby );
 
-			foreach ( $params->orderby as &$prefix_orderby ) {
-				if ( false === strpos( $prefix_orderby, ',' ) && false === strpos( $prefix_orderby, '(' ) && false === stripos( $prefix_orderby, ' AS ' ) && false === strpos( $prefix_orderby, '`' ) && false === strpos( $prefix_orderby, '.' ) ) {
-					if ( false !== stripos( $prefix_orderby, ' DESC' ) ) {
-						$k = trim( str_ireplace( array( '`', ' DESC' ), '', $prefix_orderby ) );
+			foreach ( $params->orderby as $orderby_key => $orderby_value ) {
+				if ( false === strpos( $orderby_value, ',' ) && false === strpos( $orderby_value, '(' ) && false === stripos( $orderby_value, ' AS ' ) && false === strpos( $orderby_value, '`' ) && false === strpos( $orderby_value, '.' ) ) {
+					if ( false !== stripos( $orderby_value, ' DESC' ) ) {
+						$k = trim( str_ireplace( array( '`', ' DESC' ), '', $orderby_value ) );
 						$dir = 'DESC';
 					}
 					else {
-						$k = trim( str_ireplace( array( '`', ' ASC' ), '', $prefix_orderby ) );
+						$k = trim( str_ireplace( array( '`', ' ASC' ), '', $orderby_value ) );
 						$dir = 'ASC';
 					}
 
@@ -2313,7 +2313,7 @@ class Pods implements Iterator {
 							$key = "`{$k}`.`meta_value`";
 					}
 
-					$prefix_orderby = "{$key} {$dir}";
+					$params->orderby[ $orderby_key ] = "{$key} {$dir}";
 				}
 			}
 		}


### PR DESCRIPTION
#3294 