### PR TITLE
Fix bug for issue number 3319 (Required files client side validation)

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -74,6 +74,17 @@
 
                     /* e.preventDefault(); */
 
+                    /**
+                     *   validate required files to be selected in client side
+                     */
+                    $('.postbox .pods-form-ui-field-type-file.pods-validate-required').each(function(){
+                        if($(this).find('.pods-files-list > li').length === 0){
+                            e.preventDefault();
+                            alert('You have same empty required files!');
+                            return false;
+                        }
+                    });
+
                     var postdata = {};
                     var field_data = {};
 


### PR DESCRIPTION
when adding a new post with a required field type 'File'; if i let the file empty the form is submitted and generate an error 'empty file' but the problem that the post has been added to the list without a file.

bug fix : iterate over pods required 'file' field type test if at least one file is selected, if not prevent submit and alert message showing 'You have same empty required files!'