### PR TITLE
Added clear cache command to wp-cli pods-api

### DIFF
--- a/classes/cli/PodsAPI_CLI_Command.php
+++ b/classes/cli/PodsAPI_CLI_Command.php
@@ -158,6 +158,18 @@ class PodsAPI_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Clear pods cache
+	 *
+	 * @subcommand clear-cache
+	 */
+	function clear_cache() {
+
+		pods_api()->cache_flush_pods();
+
+		WP_CLI::success( __( 'Pod cache cleared', 'pods' ) );
+	}
+
+	/**
 	 *
 	 *
 	 * @synopsis   --pod=<pod> --file=<file>


### PR DESCRIPTION
It would be nice to be able to clear the pods cache from wp-cli. 

Added a command to the pods api wp-cli command.