### PR TITLE
Create new 'post_id' method for pods_v

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -778,6 +778,22 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 					}
 				}
 				break;
+			case 'post_id':
+				if ( is_array( $var ) ) {
+					if ( isset( $var[ 'post_id' ] ) ) {
+						$post_id = $var[ 'post_id' ];
+					}
+					if ( isset( $var[ 'post_type' ] ) ) {
+						$post_type = $var[ 'post_type' ];
+					} else {
+						$post_type = 'post';
+					}
+				} else {
+					$post_id   = $var;
+					$post_type = 'post';
+				}
+				$output = apply_filters( 'wpml_object_id', $post_id, $post_type, true );
+				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );
 		}

--- a/includes/general.php
+++ b/includes/general.php
@@ -1264,7 +1264,7 @@ function pods_by_title ( $title, $output = OBJECT, $type = 'page', $status = nul
     $page = $wpdb->get_var( $wpdb->prepare( "SELECT `ID` FROM `{$wpdb->posts}` WHERE `post_title` = %s AND `post_type` = %s" . $status_sql . $orderby_sql, $prepared ) );
 
     if ( $page )
-        return get_post( $page, $output );
+        return get_post( pods_v( array( 'post_id' => $page, 'post_type' => $type ), 'post_id' ), $output );
 
     return null;
 }


### PR DESCRIPTION
Related to #3242

This provides a method to allow i18n plugins to return a different post id.  There might need to be other places this filter is called or additional methods might need to be called depending on which
translation plugin is used.