### PR TITLE
*#3527 Use html_entity_decode to convert separator

### DIFF
--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -291,7 +291,7 @@ class PodsField_Number extends PodsField {
             $dot = ',';
         }
         else {
-            $thousands = $wp_locale->number_format[ 'thousands_sep' ];
+            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
             $dot = $wp_locale->number_format[ 'decimal_point' ];
         }
 
@@ -336,7 +336,7 @@ class PodsField_Number extends PodsField {
             $dot = ',';
         }
         else {
-            $thousands = $wp_locale->number_format[ 'thousands_sep' ];
+            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
             $dot = $wp_locale->number_format[ 'decimal_point' ];
         }
 
@@ -390,7 +390,7 @@ class PodsField_Number extends PodsField {
             $dot = ',';
         }
         else {
-            $thousands = $wp_locale->number_format[ 'thousands_sep' ];
+            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
             $dot = $wp_locale->number_format[ 'decimal_point' ];
         }
 


### PR DESCRIPTION
Fixes #3527

Use html_entity_decode to convert separator as it is a html entity