### PR TITLE
feature/3520 - filter the pods metas to display

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -985,6 +985,8 @@ class PodsMeta {
 			self::$current_pod->fetch( $id );
 
         $pod = self::$current_pod;
+	// filter the pods metas to display
+	$metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_' . __FUNCTION__ . '_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id );
 
         foreach ( $metabox[ 'args' ][ 'group' ][ 'fields' ] as $field ) {
             if ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $metabox[ 'args' ][ 'group' ][ 'fields' ], $pod, $id ) ) {


### PR DESCRIPTION
Add $metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta' . FUNCTION . 'fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id ); 
to classes/PodsMeta.php abvoe foreach ( $metabox[ 'args' ][ 'group' ][ 'fields' ] as $field )  line:991 so I can filter fields to display for each page.