### PR TITLE
Create new 'post_id' method for pods_v

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -778,6 +778,39 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 					}
 				}
 				break;
+			case 'post_id':
+				if ( is_array( $var ) ) {
+					if ( isset( $var[ 'post_id' ] ) ) {
+						$post_id = $var[ 'post_id' ];
+					}
+					if ( isset( $var[ 'post_type' ] ) ) {
+						$post_type = $var[ 'post_type' ];
+					} else {
+						$post_type = 'post';
+					}
+				} else {
+					$post_id   = $var;
+					$post_type = 'post';
+				}
+				if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+					/* Only call filter if WPML is installed */
+					$post_id = apply_filters( 'wpml_object_id', $post_id, $post_type, true );
+				}
+				// Add other translation plugin specific code here
+
+				/**
+				 * Filter to override post_id
+				 *
+				 * Generally used with language translation plugins in order to return the post id of a
+				 * translated post
+				 *
+				 * @param  int $post_id The post ID of current post
+				 * @param  string $post_type Post type of current post
+				 *
+				 * @since 2.6.6
+				 */
+				$output = apply_filters( 'pods_var_post_id', $post_id, $post_type );
+				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );
 		}

--- a/includes/data.php
+++ b/includes/data.php
@@ -798,14 +798,13 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				 * translated post
 				 *
 				 * @param  int $post_id The post ID of current post
-				 * @param  mixed $default The default value to set if variable doesn't exist
 				 * @param  mixed $var The variable name, can also be a modifier for specific types
 				 * @param  bool $strict Only allow values (must not be empty)
 				 * @param  array $params Set 'casting'=>true to cast value from $default, 'allowed'=>$allowed to restrict a value to what's allowed
 				 *
 				 * @since 2.6.6
 				 */
-				$output = apply_filters( 'pods_var_post_id', $post_id, $default, $var, $strict, $params );
+				$output = apply_filters( 'pods_var_post_id', $post_id, $var, $strict, $params );
 				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );

--- a/includes/data.php
+++ b/includes/data.php
@@ -803,13 +803,14 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				 * translated post
 				 *
 				 * @param  int $post_id The post ID of current post
+				 * @param  mixed $default The default value to set if variable doesn't exist
 				 * @param  mixed $var The variable name, can also be a modifier for specific types
 				 * @param  bool $strict Only allow values (must not be empty)
 				 * @param  array $params Set 'casting'=>true to cast value from $default, 'allowed'=>$allowed to restrict a value to what's allowed
 				 *
 				 * @since 2.6.6
 				 */
-				$output = apply_filters( 'pods_var_post_id', $post_id, $var, $strict, $params );
+				$output = apply_filters( 'pods_var_post_id', $post_id, $default, $var, $strict, $params );
 				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );

--- a/includes/data.php
+++ b/includes/data.php
@@ -780,7 +780,12 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				break;
 			case 'post_id':
 				if ( empty( $var ) ) {
-					$post_id = get_the_ID();
+					if ( ! empty( $default ) ) {
+						$post_id = $default;
+					} else {
+						// If no $var and no $default then use current post ID
+						$post_id = get_the_ID();
+					}
 				} else {
 					$post_id = $var;
 				}

--- a/includes/data.php
+++ b/includes/data.php
@@ -780,14 +780,17 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				break;
 			case 'post_id':
 				if ( is_array( $var ) ) {
-					if ( isset( $var[ 'post_id' ] ) ) {
-						$post_id = $var[ 'post_id' ];
+					if ( isset( $var['post_id'] ) ) {
+						$post_id = $var['post_id'];
 					}
-					if ( isset( $var[ 'post_type' ] ) ) {
-						$post_type = $var[ 'post_type' ];
+					if ( isset( $var['post_type'] ) ) {
+						$post_type = $var['post_type'];
 					} else {
 						$post_type = 'post';
 					}
+				} elseif ( null === $var ) {
+					$post_id = get_the_ID();
+					$post_type = get_post_type( $post_id );
 				} else {
 					$post_id   = $var;
 					$post_type = 'post';
@@ -806,10 +809,13 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				 *
 				 * @param  int $post_id The post ID of current post
 				 * @param  string $post_type Post type of current post
+				 * @param  mixed $default The default value to set if variable doesn't exist
+				 * @param  bool $strict Only allow values (must not be empty)
+				 * @param  array $params Set 'casting'=>true to cast value from $default, 'allowed'=>$allowed to restrict a value to what's allowed
 				 *
 				 * @since 2.6.6
 				 */
-				$output = apply_filters( 'pods_var_post_id', $post_id, $post_type );
+				$output = apply_filters( 'pods_var_post_id', $post_id, $post_type, $default, $var, $strict, $params );
 				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );

--- a/includes/data.php
+++ b/includes/data.php
@@ -779,24 +779,14 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				}
 				break;
 			case 'post_id':
-				if ( is_array( $var ) ) {
-					if ( isset( $var['post_id'] ) ) {
-						$post_id = $var['post_id'];
-					}
-					if ( isset( $var['post_type'] ) ) {
-						$post_type = $var['post_type'];
-					} else {
-						$post_type = 'post';
-					}
-				} elseif ( null === $var ) {
+				if ( empty( $var ) ) {
 					$post_id = get_the_ID();
-					$post_type = get_post_type( $post_id );
 				} else {
-					$post_id   = $var;
-					$post_type = 'post';
+					$post_id = $var;
 				}
 				if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
 					/* Only call filter if WPML is installed */
+					$post_type = get_post_type( $post_id );
 					$post_id = apply_filters( 'wpml_object_id', $post_id, $post_type, true );
 				}
 				// Add other translation plugin specific code here
@@ -808,14 +798,14 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				 * translated post
 				 *
 				 * @param  int $post_id The post ID of current post
-				 * @param  string $post_type Post type of current post
 				 * @param  mixed $default The default value to set if variable doesn't exist
+				 * @param  mixed $var The variable name, can also be a modifier for specific types
 				 * @param  bool $strict Only allow values (must not be empty)
 				 * @param  array $params Set 'casting'=>true to cast value from $default, 'allowed'=>$allowed to restrict a value to what's allowed
 				 *
 				 * @since 2.6.6
 				 */
-				$output = apply_filters( 'pods_var_post_id', $post_id, $post_type, $default, $var, $strict, $params );
+				$output = apply_filters( 'pods_var_post_id', $post_id, $default, $var, $strict, $params );
 				break;
 			default:
 				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );

--- a/includes/general.php
+++ b/includes/general.php
@@ -1264,7 +1264,7 @@ function pods_by_title ( $title, $output = OBJECT, $type = 'page', $status = nul
     $page = $wpdb->get_var( $wpdb->prepare( "SELECT `ID` FROM `{$wpdb->posts}` WHERE `post_title` = %s AND `post_type` = %s" . $status_sql . $orderby_sql, $prepared ) );
 
     if ( $page )
-        return get_post( $page, $output );
+        return get_post( pods_v( array( 'post_id' => $page, 'post_type' => $type ), 'post_id' ), $output );
 
     return null;
 }

--- a/includes/general.php
+++ b/includes/general.php
@@ -1264,7 +1264,7 @@ function pods_by_title ( $title, $output = OBJECT, $type = 'page', $status = nul
     $page = $wpdb->get_var( $wpdb->prepare( "SELECT `ID` FROM `{$wpdb->posts}` WHERE `post_title` = %s AND `post_type` = %s" . $status_sql . $orderby_sql, $prepared ) );
 
     if ( $page )
-        return get_post( pods_v( array( 'post_id' => $page, 'post_type' => $type ), 'post_id' ), $output );
+        return get_post( pods_v( $page, 'post_id' ), $output );
 
     return null;
 }


### PR DESCRIPTION
Related to #3242 and #3526

This provides a method to allow i18n plugins to return a different post id. There might need to be other places this filter is called or additional methods might need to be called depending on which
translation plugin is used.