### PR TITLE
feature/3520 - filter the pods metas to display

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -986,6 +986,19 @@ class PodsMeta {
 
         $pod = self::$current_pod;
 
+	/**
+	 * Filter the pods metas to display
+	 *
+	 * @since 2.6.6
+	 *
+	 * @param array    $metabox[ 'args' ][ 'group' ][ 'fields' ] fields from the current Pod
+	 * @param int      $id post id.
+	 * @param object   $post the post
+	 * @param array	   $metabox the metabox from the current Pod
+	 * @param object   $pod the current Pod
+	 */
+        // 
+ +	$metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_post_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id,  $post, $metabox, $pod  );
         foreach ( $metabox[ 'args' ][ 'group' ][ 'fields' ] as $field ) {
             if ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $metabox[ 'args' ][ 'group' ][ 'fields' ], $pod, $id ) ) {
                 if ( pods_var( 'hidden', $field[ 'options' ], false ) )

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -969,38 +969,47 @@ class PodsMeta {
         do_action( 'pods_meta_' . __FUNCTION__, $post );
 
         $hidden_fields = array();
-?>
-    <table class="form-table pods-metabox pods-admin pods-dependency">
-		<?php echo PodsForm::field( 'pods_meta', wp_create_nonce( 'pods_meta_' . $pod_type ), 'hidden' ); ?>
-
-        <?php
+        
         $id = null;
 
         if ( is_object( $post ) && false === strpos( $_SERVER[ 'REQUEST_URI' ], '/post-new.php' ) )
             $id = $post->ID;
 
-        if ( empty( self::$current_pod_data ) || !is_object( self::$current_pod ) || self::$current_pod->pod != $metabox[ 'args' ][ 'group' ][ 'pod' ][ 'name' ] )
-            self::$current_pod = pods( $metabox[ 'args' ][ 'group' ][ 'pod' ][ 'name' ], $id, true );
-		elseif ( self::$current_pod->id() != $id )
-			self::$current_pod->fetch( $id );
+	if ( empty( self::$current_pod_data ) || !is_object( self::$current_pod ) || self::$current_pod->pod != $metabox[ 'args' ][ 'group' ][ 'pod' ][ 'name' ] ) {
+		self::$current_pod = pods( $metabox[ 'args' ][ 'group' ][ 'pod' ][ 'name' ], $id, true );
+	} elseif ( self::$current_pod->id() != $id ) {
+		self::$current_pod->fetch( $id );
+	}
 
         $pod = self::$current_pod;
 
+	$fields = $metabox['args']['group']['fields'];
+
 	/**
-	 * Filter the pods metas to display
+	 * Filter the fields used for the Pods metabox group
 	 *
 	 * @since 2.6.6
 	 *
-	 * @param array    $metabox[ 'args' ][ 'group' ][ 'fields' ] fields from the current Pod
-	 * @param int      $id post id.
-	 * @param object   $post the post
-	 * @param array	   $metabox the metabox from the current Pod
-	 * @param object   $pod the current Pod
+	 * @param array   $fields  Fields from the current Pod metabox group
+	 * @param int     $id      Post ID
+	 * @param WP_Post $post    Post object
+	 * @param array	  $metabox Metabox args from the current Pod metabox group
+	 * @param Pods    $pod     Pod object
 	 */
-       
- 	$metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_post_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id,  $post, $metabox, $pod  );
-        foreach ( $metabox[ 'args' ][ 'group' ][ 'fields' ] as $field ) {
-            if ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $metabox[ 'args' ][ 'group' ][ 'fields' ], $pod, $id ) ) {
+ 	$fields = apply_filters( 'pods_meta_post_fields', $fields, $id,  $post, $metabox, $pod  );
+ 	
+ 	if ( empty( $fields ) ) {
+ 		_e( 'There are no fields to display', 'pods' );
+ 		
+ 		return;
+ 	}
+?>
+    <table class="form-table pods-metabox pods-admin pods-dependency">
+	<?php
+	echo PodsForm::field( 'pods_meta', wp_create_nonce( 'pods_meta_' . $pod_type ), 'hidden' );
+	
+        foreach ( $fields as $field ) {
+            if ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $fields, $pod, $id ) ) {
                 if ( pods_var( 'hidden', $field[ 'options' ], false ) )
                     $field[ 'type' ] = 'hidden';
                 else

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -997,8 +997,8 @@ class PodsMeta {
 	 * @param array	   $metabox the metabox from the current Pod
 	 * @param object   $pod the current Pod
 	 */
-        // 
- +	$metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_post_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id,  $post, $metabox, $pod  );
+       
+ 	$metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_post_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id,  $post, $metabox, $pod  );
         foreach ( $metabox[ 'args' ][ 'group' ][ 'fields' ] as $field ) {
             if ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $metabox[ 'args' ][ 'group' ][ 'fields' ], $pod, $id ) ) {
                 if ( pods_var( 'hidden', $field[ 'options' ], false ) )


### PR DESCRIPTION
Add $metabox[ 'args' ][ 'group' ][ 'fields' ] = apply_filters( 'pods_meta_post_fields', $metabox[ 'args' ][ 'group' ][ 'fields' ], $id,  $post, $metabox, $pod  );
to classes/PodsMeta.php below $pod = self::$current_pod; line:987 so I can filter fields to display for each page.