### PR TITLE
Don't add space to currency names that use HTML encoding

### DIFF
--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -312,7 +312,7 @@ class PodsField_Currency extends PodsField {
 		// Multiple sign currencies: 100 Fr, Kr 100
 		$currency_gap = '';
 
-		if ( strlen( $currency_sign ) > 1 ) {
+		if ( strlen( $currency_sign ) > 1 && 0 !== strpos( $currency_sign, '&' ) ) {
 			$currency_gap = ' ';
 		}
 

--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -312,7 +312,7 @@ class PodsField_Currency extends PodsField {
 		// Multiple sign currencies: 100 Fr, Kr 100
 		$currency_gap = '';
 
-		if ( strlen( $currency_sign ) > 1 && 0 !== strpos( $currency_sign, '&' ) ) {
+		if ( strlen( $currency_sign ) > 1 && false === strpos( $currency_sign, '&' ) ) {
 			$currency_gap = ' ';
 		}
 


### PR DESCRIPTION
Resolves #3498