### PR TITLE
Make javascript strings translatable + fix deprecated var functions from ui/admin/*.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ npm-debug.log
 
 # PHPunit config
 phpunit.xml
+*.bak

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -7438,7 +7438,7 @@ class PodsAPI {
 		    $info[ 'orderby' ] = '`t`.`menu_order`, `t`.`' . $info[ 'field_index' ] . '`, `t`.`post_date`';
 
 		    // WPML support
-		    if ( is_object( $sitepress ) && $sitepress->is_translated_post_type( $post_type ) && !$icl_adjust_id_url_filter_off ) {
+		    if ( is_object( $sitepress ) && !empty( $current_language ) && $sitepress->is_translated_post_type( $post_type ) && !$icl_adjust_id_url_filter_off ) {
 			    $info[ 'join' ][ 'wpml_translations' ] = "
                         LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
                             ON `wpml_translations`.`element_id` = `t`.`ID`
@@ -7516,7 +7516,7 @@ class PodsAPI {
 		    );
 
 		    // WPML Support
-		    if ( is_object( $sitepress ) && $sitepress->is_translated_taxonomy( $taxonomy ) && !$icl_adjust_id_url_filter_off ) {
+		    if ( is_object( $sitepress ) && !empty( $current_language ) && $sitepress->is_translated_taxonomy( $taxonomy ) && !$icl_adjust_id_url_filter_off ) {
 			    $info[ 'join' ][ 'wpml_translations' ] = "
                         LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
                             ON `wpml_translations`.`element_id` = `tt`.`term_taxonomy_id`

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -300,6 +300,12 @@ class PodsInit {
 	public function localize_assets() {
 		wp_localize_script('pods', 'pods_localized_strings', array(
 			'__is_required' => __( '%s is required.', 'pods' ),
+			'__add' => __( 'Add', 'pods' ),
+			'__added' => __( 'Added!', 'pods' ),
+			'__added_choose_another_or_close_this_box' => __( 'Added! Choose another or <a href="#">close this box</a>', 'pods' ),
+			'__copy' => __( 'Copy', 'pods' ),
+			'__navigating_away_from_this_page_will_discard_any_changes_you_have_made' => __( 'Navigating away from this page will discard any changes you have made.', 'pods' ),
+			'__unable_to_process_request_please_try_again' => __( 'Unable to process request, please try again.', 'pods' ),
 		));
 	}
 

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -290,6 +290,17 @@ class PodsInit {
 		wp_register_script( 'pods-select2', PODS_URL . 'ui/js/select2/select2.min.js', array( 'jquery' ), '3.3.1' );
 
 		wp_register_script( 'pods-handlebars', PODS_URL . 'ui/js/handlebars.js', array(), '1.0.0.beta.6' );
+
+		$this->localize_assets();
+	}
+
+	/**
+	 * Localize assets
+	 */
+	public function localize_assets() {
+		wp_localize_script('pods', 'pods_localized_strings', array(
+			'__is_required' => __( '%s is required.', 'pods' ),
+		));
 	}
 
 	/**

--- a/ui/admin/components-admin.php
+++ b/ui/admin/components-admin.php
@@ -38,7 +38,7 @@
                         }
 
                         if ( !is_array( $field_option[ 'group' ] ) ) {
-                            $value = pods_var_raw( $field_name, $settings, $field_option[ 'default' ] );
+                            $value = pods_v( $field_name, $settings, $field_option[ 'default' ] );
                 ?>
                     <tr valign="top" class="pods-field-option" id="pods-setting-<?php echo esc_attr( $field_name ); ?>">
                         <th>
@@ -69,7 +69,7 @@
 
                                         $depends_option = PodsForm::dependencies( $field_group_option );
 
-                                        $value = pods_var_raw( $field_group_name, $settings, $field_group_option[ 'default' ] );
+                                        $value = pods_v( $field_group_name, $settings, $field_group_option[ 'default' ] );
                                 ?>
                                     <li class="<?php echo esc_attr( $depends_option ); ?>">
                                         <?php echo PodsForm::field( 'pods_setting_' . $field_group_name, $value, $field_group_option[ 'type' ], $field_group_option ); ?>

--- a/ui/admin/field-option.php
+++ b/ui/admin/field-option.php
@@ -35,7 +35,7 @@ foreach ( $field_options as $field_name => $field_option ) {
         if ( isset( $field_option[ 'value' ] ) && 0 < strlen( $field_option[ 'value' ] ) )
             $value = $field_option[ 'value' ];
         else
-            $value = pods_var_raw( $field_name, $field, $value );
+            $value = pods_v( $field_name, $field, $value );
 
         if ( in_array( $field_option[ 'type' ], PodsForm::file_field_types() ) ) {
             if ( is_array( $value ) && !isset( $value[ 'id' ] ) ) {
@@ -81,7 +81,7 @@ foreach ( $field_options as $field_name => $field_option ) {
                         if ( isset( $field_group_option[ 'value' ] ) && 0 < strlen( $field_group_option[ 'value' ] ) )
                             $value = $field_group_option[ 'value' ];
                         else
-                            $value = pods_var_raw( $field_group_name, $field, $value );
+                            $value = pods_v( $field_group_name, $field, $value );
 
                         ?>
                         <li class="<?php echo esc_attr( $depends_option ); ?>">

--- a/ui/admin/form-settings.php
+++ b/ui/admin/form-settings.php
@@ -15,19 +15,19 @@ foreach ( $fields as $k => $field ) {
     if ( in_array( $field[ 'name' ], array( 'created', 'modified' ) ) )
         unset( $fields[ $k ] );
     elseif ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $fields, $pod, $pod->id() ) ) {
-        if ( pods_var( 'hidden', $field[ 'options' ], false ) )
+        if ( pods_v_sanitized( 'hidden', $field[ 'options' ], false ) )
             $fields[ $k ][ 'type' ] = 'hidden';
         else
             unset( $fields[ $k ] );
     }
-    elseif ( !pods_has_permissions( $field[ 'options' ] ) && pods_var( 'hidden', $field[ 'options' ], false ) )
+    elseif ( !pods_has_permissions( $field[ 'options' ] ) && pods_v_sanitized( 'hidden', $field[ 'options' ], false ) )
         $fields[ $k ][ 'type' ] = 'hidden';
 }
 
 $submittable_fields = $fields;
 
 foreach ( $submittable_fields as $k => $field ) {
-    if ( pods_var( 'readonly', $field, false ) )
+    if ( pods_v_sanitized( 'readonly', $field, false ) )
         unset( $submittable_fields[ $k ] );
 }
 

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -24,10 +24,10 @@ foreach ( $groups as $g => $group ) {
             continue;
         }
         elseif ( false === PodsForm::permission( $field[ 'type' ], $field[ 'name' ], $field[ 'options' ], $group[ 'fields' ], $pod, $pod->id() ) ) {
-            if ( pods_var( 'hidden', $field[ 'options' ], false ) ) {
+            if ( pods_v_sanitized( 'hidden', $field[ 'options' ], false ) ) {
                 $group[ 'fields' ][ $k ][ 'type' ] = 'hidden';
             }
-            elseif ( pods_var( 'read_only', $field[ 'options' ], false ) ) {
+            elseif ( pods_v_sanitized( 'read_only', $field[ 'options' ], false ) ) {
                 $group[ 'fields' ][ $k ][ 'readonly' ] = true;
             }
             else {
@@ -37,15 +37,15 @@ foreach ( $groups as $g => $group ) {
             }
 	    }
 	    elseif ( !pods_has_permissions( $field[ 'options' ] ) ) {
-            if ( pods_var( 'hidden', $field[ 'options' ], false ) ) {
+            if ( pods_v_sanitized( 'hidden', $field[ 'options' ], false ) ) {
                 $group[ 'fields' ][ $k ][ 'type' ] = 'hidden';
             }
-            elseif ( pods_var( 'read_only', $field[ 'options' ], false ) ) {
+            elseif ( pods_v_sanitized( 'read_only', $field[ 'options' ], false ) ) {
                 $group[ 'fields' ][ $k ][ 'readonly' ] = true;
             }
 	    }
 
-        if ( !pods_var( 'readonly', $field, false ) ) {
+        if ( !pods_v_sanitized( 'readonly', $field, false ) ) {
             $submittable_fields[ $field[ 'name' ]] = $group[ 'fields' ][ $k ];
         }
 
@@ -70,9 +70,9 @@ $nonce = wp_create_nonce( 'pods_form_' . $pod->pod . '_' . $uid . '_' . ( $dupli
 if ( isset( $_POST[ '_pods_nonce' ] ) ) {
     $action = __( 'saved', 'pods' );
 
-    if ( 'create' == pods_var_raw( 'do', 'post', 'save' ) )
+    if ( 'create' == pods_v( 'do', 'post', 'save' ) )
         $action = __( 'created', 'pods' );
-    elseif ( 'duplicate' == pods_var_raw( 'do', 'get', 'save' ) )
+    elseif ( 'duplicate' == pods_v( 'do', 'get', 'save' ) )
         $action = __( 'duplicated', 'pods' );
 
     try {
@@ -81,7 +81,7 @@ if ( isset( $_POST[ '_pods_nonce' ] ) ) {
 
         $message = sprintf( __( '<strong>Success!</strong> %s %s successfully.', 'pods' ), $obj->item, $action );
 
-        if ( 0 < strlen( pods_var( 'detail_url', $pod->pod_data[ 'options' ] ) ) )
+        if ( 0 < strlen( pods_v_sanitized( 'detail_url', $pod->pod_data[ 'options' ] ) ) )
             $message .= ' <a target="_blank" href="' . $pod->field( 'detail_url' ) . '">' . sprintf( __( 'View %s', 'pods' ), $obj->item ) . '</a>';
 
         $error = sprintf( __( '<strong>Error:</strong> %s %s successfully.', 'pods' ), $obj->item, $action );
@@ -98,14 +98,14 @@ if ( isset( $_POST[ '_pods_nonce' ] ) ) {
 elseif ( isset( $_GET[ 'do' ] ) ) {
     $action = __( 'saved', 'pods' );
 
-    if ( 'create' == pods_var_raw( 'do', 'get', 'save' ) )
+    if ( 'create' == pods_v( 'do', 'get', 'save' ) )
         $action = __( 'created', 'pods' );
-    elseif ( 'duplicate' == pods_var_raw( 'do', 'get', 'save' ) )
+    elseif ( 'duplicate' == pods_v( 'do', 'get', 'save' ) )
         $action = __( 'duplicated', 'pods' );
 
     $message = sprintf( __( '<strong>Success!</strong> %s %s successfully.', 'pods' ), $obj->item, $action );
 
-    if ( 0 < strlen( pods_var( 'detail_url', $pod->pod_data[ 'options' ] ) ) )
+    if ( 0 < strlen( pods_v_sanitized( 'detail_url', $pod->pod_data[ 'options' ] ) ) )
         $message .= ' <a target="_blank" href="' . $pod->field( 'detail_url' ) . '">' . sprintf( __( 'View %s', 'pods' ), $obj->item ) . '</a>';
 
     $error = sprintf( __( '<strong>Error:</strong> %s not %s.', 'pods' ), $obj->item, $action );
@@ -185,11 +185,11 @@ if ( 0 < $pod->id() ) {
                         <div class="inside">
                             <div class="submitbox" id="submitpost">
                                 <?php
-                                    if ( 0 < $pod->id() && ( isset( $pod->pod_data[ 'fields' ][ 'created' ] ) || isset( $pod->pod_data[ 'fields' ][ 'modified' ] ) || 0 < strlen( pods_var( 'detail_url', $pod->pod_data[ 'options' ] ) ) ) ) {
+                                    if ( 0 < $pod->id() && ( isset( $pod->pod_data[ 'fields' ][ 'created' ] ) || isset( $pod->pod_data[ 'fields' ][ 'modified' ] ) || 0 < strlen( pods_v_sanitized( 'detail_url', $pod->pod_data[ 'options' ] ) ) ) ) {
                                 ?>
                                     <div id="minor-publishing">
                                         <?php
-                                            if ( 0 < strlen( pods_var( 'detail_url', $pod->pod_data[ 'options' ] ) ) ) {
+                                            if ( 0 < strlen( pods_v_sanitized( 'detail_url', $pod->pod_data[ 'options' ] ) ) ) {
                                         ?>
                                             <div id="minor-publishing-actions">
                                                 <div id="preview-action">
@@ -305,12 +305,12 @@ if ( 0 < $pod->id() ) {
                     </div>
                     <!-- /#submitdiv --><!-- END PUBLISH DIV --><!-- TODO: minor column fields -->
                     <?php
-                        if ( pods_var_raw( 'action' ) == 'edit' && !$duplicate && !in_array( 'navigate', (array) $obj->actions_disabled ) && !in_array( 'navigate', (array) $obj->actions_hidden ) ) {
+                        if ( pods_v( 'action' ) == 'edit' && !$duplicate && !in_array( 'navigate', (array) $obj->actions_disabled ) && !in_array( 'navigate', (array) $obj->actions_hidden ) ) {
                             if ( !isset( $singular_label ) )
                                 $singular_label = ucwords( str_replace( '_', ' ', $pod->pod_data[ 'name' ] ) );
 
-                            $singular_label = pods_var_raw( 'label', $pod->pod_data[ 'options' ], $singular_label, null, true );
-                            $singular_label = pods_var_raw( 'label_singular', $pod->pod_data[ 'options' ], $singular_label, null, true );
+                            $singular_label = pods_v( 'label', $pod->pod_data[ 'options' ], $singular_label, null, true );
+                            $singular_label = pods_v( 'label_singular', $pod->pod_data[ 'options' ], $singular_label, null, true );
 
                             $pod->params = $obj->get_params( null, 'manage' );
 
@@ -424,7 +424,7 @@ if ( 0 < $pod->id() ) {
                                 $more = true;
                                 $extra = '';
 
-                                $max_length = (int) pods_var( 'maxlength', $field[ 'options' ], pods_var( $field[ 'type' ] . '_max_length', $field[ 'options' ], 0 ), null, true );
+                                $max_length = (int) pods_v_sanitized( 'maxlength', $field[ 'options' ], pods_v_sanitized( $field[ 'type' ] . '_max_length', $field[ 'options' ], 0 ), null, true );
 
                                 if ( 0 < $max_length )
                                     $extra .= ' maxlength="' . esc_attr( $max_length ) . '"';

--- a/ui/admin/settings-reset.php
+++ b/ui/admin/settings-reset.php
@@ -27,7 +27,7 @@
 	// Monday Mode
 	$monday_mode = pods_v( 'pods_monday_mode', 'get', 0, true );
 
-	if ( pods_var( 'pods_reset_weekend', 'post', pods_var( 'pods_reset_weekend', 'get', 0, null, true ), null, true ) ) {
+	if ( pods_v_sanitized( 'pods_reset_weekend', 'post', pods_v_sanitized( 'pods_reset_weekend', 'get', 0, null, true ), null, true ) ) {
         if ( $monday_mode ) {
             $html = '<br /><br /><iframe width="480" height="360" src="http://www.youtube-nocookie.com/embed/QH2-TGUlwu4?autoplay=1" frameborder="0" allowfullscreen></iframe>';
             pods_message( 'The weekend has been reset and you have been sent back to Friday night. Unfortunately due to a tear in the fabric of time, you slipped back to Monday. We took video of the whole process and you can see it below..' . $html );

--- a/ui/admin/settings-tools.php
+++ b/ui/admin/settings-tools.php
@@ -12,7 +12,7 @@
             pods_redirect( pods_query_arg( array( 'pods_clearcache' => 1 ), array( 'page', 'tab' ) ) );
         }
     }
-    elseif ( 1 == pods_var( 'pods_clearcache' ) )
+    elseif ( 1 == pods_v_sanitized( 'pods_clearcache' ) )
         pods_message( 'Pods transients and cache have been cleared.' );
 ?>
 

--- a/ui/admin/settings.php
+++ b/ui/admin/settings.php
@@ -18,7 +18,7 @@
                 foreach ( $tabs as $tab => $label ) {
                     $class = '';
 
-                    if ( $tab == pods_var( 'tab', 'get', $default ) ) {
+                    if ( $tab == pods_v_sanitized( 'tab', 'get', $default ) ) {
                         $class = ' nav-tab-active';
 
                         $label = 'Pods ' . $label;
@@ -38,7 +38,7 @@
         <?php
             wp_nonce_field( 'pods-settings' );
 
-            $tab = pods_var( 'tab', 'get', $default );
+            $tab = pods_v_sanitized( 'tab', 'get', $default );
             $tab = sanitize_title( $tab );
 
             echo pods_view( PODS_DIR . 'ui/admin/settings-' . $tab . '.php' );

--- a/ui/admin/setup-add.php
+++ b/ui/admin/setup-add.php
@@ -95,7 +95,7 @@
                                             if ( empty( $data[ 'pod' ] ) )
                                                 unset( $data[ 'pod' ] );
 
-                                            echo PodsForm::field( 'create_pod_type', pods_var_raw( 'create_pod_type', 'post' ), 'pick', array( 'data' => $data, 'class' => 'pods-dependent-toggle' ) );
+                                            echo PodsForm::field( 'create_pod_type', pods_v( 'create_pod_type', 'post' ), 'pick', array( 'data' => $data, 'class' => 'pods-dependent-toggle' ) );
                                         ?>
                                     </div>
 
@@ -122,7 +122,7 @@
                                                     $default = 'meta';
                                                 }
 
-                                                echo PodsForm::field( 'create_storage_taxonomy', pods_var_raw( 'create_storage_taxonomy', 'post', $default, null, true ), 'pick', array( 'data' => $data ) );
+                                                echo PodsForm::field( 'create_storage_taxonomy', pods_v( 'create_storage_taxonomy', 'post', $default, null, true ), 'pick', array( 'data' => $data ) );
                                             ?>
                                         </div>
                                     <?php
@@ -133,13 +133,13 @@
                                         <div class="pods-field-option">
                                             <?php
                                                 echo PodsForm::label( 'create_label_singular', __( 'Singular Label', 'pods' ), __( '<h6>Singular Label</h6> This is the label for 1 item (Singular) that will appear throughout the WordPress admin area for managing the content.', 'pods' ) );
-                                                echo PodsForm::field( 'create_label_singular', pods_var_raw( 'create_label_singular', 'post' ), 'text', array( 'class' => 'pods-validate pods-validate-required', 'text_max_length' => 30 ) );
+                                                echo PodsForm::field( 'create_label_singular', pods_v( 'create_label_singular', 'post' ), 'text', array( 'class' => 'pods-validate pods-validate-required', 'text_max_length' => 30 ) );
                                             ?>
                                         </div>
                                         <div class="pods-field-option">
                                             <?php
                                                 echo PodsForm::label( 'create_label_plural', __( 'Plural Label', 'pods' ), __( '<h6>Plural Label</h6> This is the label for more than 1 item (Plural) that will appear throughout the WordPress admin area for managing the content.', 'pods' ) );
-                                                echo PodsForm::field( 'create_label_plural', pods_var_raw( 'create_label_plural', 'post' ), 'text', array( 'text_max_length' => 30 ) );
+                                                echo PodsForm::field( 'create_label_plural', pods_v( 'create_label_plural', 'post' ), 'text', array( 'text_max_length' => 30 ) );
                                             ?>
                                         </div>
                                     </div>
@@ -147,13 +147,13 @@
                                         <div class="pods-field-option">
                                             <?php
                                                 echo PodsForm::label( 'create_label_title', __( 'Page Title', 'pods' ), __( '<h6>Page Title</h6> This is the text that will appear at the top of your settings page.', 'pods' ) );
-                                                echo PodsForm::field( 'create_label_title', pods_var_raw( 'create_label_title', 'post' ), 'text', array( 'class' => 'pods-validate pods-validate-required', 'text_max_length' => 30 ) );
+                                                echo PodsForm::field( 'create_label_title', pods_v( 'create_label_title', 'post' ), 'text', array( 'class' => 'pods-validate pods-validate-required', 'text_max_length' => 30 ) );
                                             ?>
                                         </div>
                                         <div class="pods-field-option">
                                             <?php
                                                 echo PodsForm::label( 'create_label_menu', __( 'Menu Label', 'pods' ), __( '<h6>Menu Label</h6> This is the label that will appear throughout the WordPress admin area for your settings.', 'pods' ) );
-                                                echo PodsForm::field( 'create_label_menu', pods_var_raw( 'create_label_menu', 'post' ), 'text', array( 'text_max_length' => 30 ) );
+                                                echo PodsForm::field( 'create_label_menu', pods_v( 'create_label_menu', 'post' ), 'text', array( 'text_max_length' => 30 ) );
                                             ?>
                                         </div>
                                         <div class="pods-field-option">
@@ -166,7 +166,7 @@
                                                     'top' => 'Make a new menu item below Settings'
                                                 );
 
-                                                echo PodsForm::field( 'create_menu_location', pods_var_raw( 'create_menu_location', 'post' ), 'pick', array( 'data' => $data ) );
+                                                echo PodsForm::field( 'create_menu_location', pods_v( 'create_menu_location', 'post' ), 'pick', array( 'data' => $data ) );
                                             ?>
                                         </div>
                                     </div>
@@ -184,7 +184,7 @@
                                                 $max_length_name -= strlen( $wpdb->prefix . 'pods_' );
 
                                                 echo PodsForm::label( 'create_name', __( 'Pod Name', 'pods' ), __( '<h6>Pod Indentifier</h6> This is different than the labels users will see in the WordPress admin areas, it is the name you will use to programatically reference this object throughout your theme, WordPress, and other PHP.', 'pods' ) );
-                                                echo PodsForm::field( 'create_name', pods_var_raw( 'create_name', 'post' ), 'db', array( 'attributes' => array( 'maxlength' => $max_length_name, 'size' => 25 ) ) );
+                                                echo PodsForm::field( 'create_name', pods_v( 'create_name', 'post' ), 'db', array( 'attributes' => array( 'maxlength' => $max_length_name, 'size' => 25 ) ) );
                                             ?>
                                         </div>
                                         <div class="pods-field-option pods-depends-on pods-depends-on-create-pod-type pods-depends-on-create-pod-type-settings">
@@ -195,7 +195,7 @@
                                                 $max_length_name -= strlen( $wpdb->prefix . 'pods_' );
 
                                                 echo PodsForm::label( 'create_setting_name', __( 'Pod Name', 'pods' ), __( '<h6>Pod Indentifier</h6> This is different than the labels users will see in the WordPress admin areas, it is the name you will use to programatically reference this object throughout your theme, WordPress, and other PHP.', 'pods' ) );
-                                                echo PodsForm::field( 'create_setting_name', pods_var_raw( 'create_setting_name', 'post' ), 'db', array( 'attributes' => array( 'maxlength' => $max_length_name, 'size' => 25 ) ) );
+                                                echo PodsForm::field( 'create_setting_name', pods_v( 'create_setting_name', 'post' ), 'db', array( 'attributes' => array( 'maxlength' => $max_length_name, 'size' => 25 ) ) );
                                             ?>
                                         </div>
 
@@ -211,7 +211,7 @@
                                                         'table' => __( 'Table Based', 'pods' )
                                                     );
 
-                                                    echo PodsForm::field( 'create_storage', pods_var_raw( 'create_storage', 'post' ), 'pick', array( 'data' => $data ) );
+                                                    echo PodsForm::field( 'create_storage', pods_v( 'create_storage', 'post' ), 'pick', array( 'data' => $data ) );
                                                 ?>
                                             </div>
                                         <?php
@@ -260,7 +260,7 @@
                                             if ( empty( $data[ 'taxonomy' ] ) )
                                                 unset( $data[ 'taxonomy' ] );
 
-                                            echo PodsForm::field( 'extend_pod_type', pods_var_raw( 'extend_pod_type', 'post' ), 'pick', array( 'data' => $data, 'class' => 'pods-dependent-toggle' ) );
+                                            echo PodsForm::field( 'extend_pod_type', pods_v( 'extend_pod_type', 'post' ), 'pick', array( 'data' => $data, 'class' => 'pods-dependent-toggle' ) );
                                         ?>
                                     </div>
                                     <div class="pods-field-option pods-depends-on pods-depends-on-extend-pod-type pods-depends-on-extend-pod-type-post-type">
@@ -283,7 +283,7 @@
                                             }
 
                                             echo PodsForm::label( 'extend_post_type', __( 'Post Type', 'pods' ), array( __( '<h6>Post Types</h6> WordPress can hold and display many different types of content. Internally, these are all stored in the same place, in the wp_posts table. These are differentiated by a column called post_type.', 'pods' ), 'http://codex.wordpress.org/Post_Types' ) );
-                                            echo PodsForm::field( 'extend_post_type', pods_var_raw( 'extend_post_type', 'post', 'table', null, true ), 'pick', array( 'data' => $post_types ) );
+                                            echo PodsForm::field( 'extend_post_type', pods_v( 'extend_post_type', 'post', 'table', null, true ), 'pick', array( 'data' => $post_types ) );
                                         ?>
                                     </div>
                                     <div class="pods-field-option pods-depends-on pods-depends-on-extend-pod-type pods-depends-on-extend-pod-type-taxonomy">
@@ -312,7 +312,7 @@
                                             }
 
                                             echo PodsForm::label( 'extend_taxonomy', __( 'Taxonomy', 'pods' ), array( __( '<h6>Taxonomies</h6> A taxonomy is a way to group Post Types.', 'pods' ), 'http://codex.wordpress.org/Taxonomies' ) );
-                                            echo PodsForm::field( 'extend_taxonomy', pods_var_raw( 'extend_taxonomy', 'post' ), 'pick', array( 'data' => $taxonomies ) );
+                                            echo PodsForm::field( 'extend_taxonomy', pods_v( 'extend_taxonomy', 'post' ), 'pick', array( 'data' => $taxonomies ) );
                                         ?>
                                     </div>
 
@@ -339,7 +339,7 @@
                                                     $default = 'meta';
                                                 }
 
-                                                echo PodsForm::field( 'extend_storage_taxonomy', pods_var_raw( 'extend_storage_taxonomy', 'post', $default, null, true ), 'pick', array( 'data' => $data ) );
+                                                echo PodsForm::field( 'extend_storage_taxonomy', pods_v( 'extend_storage_taxonomy', 'post', $default, null, true ), 'pick', array( 'data' => $data ) );
                                             ?>
                                         </div>
                                     <?php
@@ -362,7 +362,7 @@
                                                             'table' => __( 'Table Based', 'pods' )
                                                         );
 
-                                                        echo PodsForm::field( 'extend_storage', pods_var_raw( 'extend_storage', 'post' ), 'pick', array( 'data' => $data ) );
+                                                        echo PodsForm::field( 'extend_storage', pods_v( 'extend_storage', 'post' ), 'pick', array( 'data' => $data ) );
                                                     ?>
                                                 </div>
                                             </div>

--- a/ui/admin/setup-edit-field-fluid.php
+++ b/ui/admin/setup-edit-field-fluid.php
@@ -1,9 +1,9 @@
 <?php
 $field = array_merge( $field_settings[ 'field_defaults' ], $field );
 
-$pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_val', $field ), '-' );
+$pick_object = trim( pods_v_sanitized( 'pick_object', $field ) . '-' . pods_v_sanitized( 'pick_val', $field ), '-' );
 ?>
-<tr id="row-<?php echo esc_attr( $pods_i ); ?>" class="pods-manage-row pods-field-new pods-field-<?php echo esc_attr( pods_var( 'name', $field ) ) . ( '--1' === $pods_i ? ' flexible-row' : ' pods-submittable-fields' ); ?>" valign="top" data-row="<?php echo esc_attr( $pods_i ); ?>">
+<tr id="row-<?php echo esc_attr( $pods_i ); ?>" class="pods-manage-row pods-field-new pods-field-<?php echo esc_attr( pods_v_sanitized( 'name', $field ) ) . ( '--1' === $pods_i ? ' flexible-row' : ' pods-submittable-fields' ); ?>" valign="top" data-row="<?php echo esc_attr( $pods_i ); ?>">
     <th scope="row" class="check-field pods-manage-sort">
         <img src="<?php echo esc_url( PODS_URL ); ?>ui/images/handle.gif" alt="<?php esc_attr_e( 'Move', 'pods' ); ?>" />
     </th>
@@ -60,38 +60,38 @@ $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_v
                         <div id="pods-basic-options-<?php echo esc_attr( $pods_i ); ?>" class="pods-tab pods-basic-options">
                             <div class="pods-field-option">
                                 <?php echo PodsForm::label( 'field_data[' . $pods_i . '][label]', __( 'Label', 'pods' ), __( 'help', 'pods' ) ); ?>
-                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][label]', pods_var_raw( 'label', $field, '' ), 'text', array( 'class' => 'pods-validate pods-validate-required' ) ); ?>
+                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][label]', pods_v( 'label', $field, '' ), 'text', array( 'class' => 'pods-validate pods-validate-required' ) ); ?>
                             </div>
                             <div class="pods-field-option">
                                 <?php echo PodsForm::label( 'field_data[' . $pods_i . '][name]', __( 'Name', 'pods' ), __( 'You will use this name to programatically reference this field throughout WordPress', 'pods' ) ); ?>
-                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][name]', pods_var_raw( 'name', $field, '' ), 'db', array( 'attributes' => array( 'maxlength' => 50, 'data-sluggable' => 'field_data[' . $pods_i . '][label]' ), 'class' => 'pods-validate pods-validate-required pods-slugged-lower' ) ); ?>
+                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][name]', pods_v( 'name', $field, '' ), 'db', array( 'attributes' => array( 'maxlength' => 50, 'data-sluggable' => 'field_data[' . $pods_i . '][label]' ), 'class' => 'pods-validate pods-validate-required pods-slugged-lower' ) ); ?>
                             </div>
                             <div class="pods-field-option">
                                 <?php echo PodsForm::label( 'field_data[' . $pods_i . '][description]', __( 'Description', 'pods' ), __( 'help', 'pods' ) ); ?>
-                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][description]', pods_var_raw( 'description', $field, '' ), 'text' ); ?>
+                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][description]', pods_v( 'description', $field, '' ), 'text' ); ?>
                             </div>
                             <div class="pods-field-option">
                                 <?php echo PodsForm::label( 'field_data[' . $pods_i . '][type]', __( 'Field Type', 'pods' ), __( 'help', 'pods' ) ); ?>
-                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][type]', pods_var_raw( 'type', $field, '' ), 'pick', array( 'data' => pods_var_raw( 'field_types_select', $field_settings ), 'class' => 'pods-dependent-toggle' ) ); ?>
+                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][type]', pods_v( 'type', $field, '' ), 'pick', array( 'data' => pods_v( 'field_types_select', $field_settings ), 'class' => 'pods-dependent-toggle' ) ); ?>
                             </div>
                             <div class="pods-field-option-container pods-depends-on pods-depends-on-field-data-type pods-depends-on-field-data-type-pick">
                                 <div class="pods-field-option">
                                     <?php echo PodsForm::label( 'field_data[' . $pods_i . '][pick_object]', __( 'Related To', 'pods' ), __( 'help', 'pods' ) ); ?>
-                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_object]', $pick_object, 'pick', array( 'required' => true, 'data' => pods_var_raw( 'pick_object', $field_settings ), 'class' => 'pods-dependent-toggle' ) ); ?>
+                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_object]', $pick_object, 'pick', array( 'required' => true, 'data' => pods_v( 'pick_object', $field_settings ), 'class' => 'pods-dependent-toggle' ) ); ?>
                                 </div>
                                 <div class="pods-field-option pods-depends-on pods-depends-on-field-data-pick-object pods-depends-on-field-data-pick-object-custom-simple">
                                     <?php echo PodsForm::label( 'field_data[' . $pods_i . '][pick_custom]', __( 'Custom Defined Options', 'pods' ), __( 'One option per line, use <em>value|Label</em> for separate values and labels', 'pods' ) ); ?>
-                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_custom]', pods_var_raw( 'pick_custom', $field, '' ), 'paragraph' ); ?>
+                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_custom]', pods_v( 'pick_custom', $field, '' ), 'paragraph' ); ?>
                                 </div>
                                 <div class="pods-field-option pods-depends-on pods-depends-on-field-data-pick-object pods-depends-on-field-data-pick-object-table">
                                     <?php echo PodsForm::label( 'field_data[' . $pods_i . '][pick_table]', __( 'Related Table', 'pods' ), __( 'help', 'pods' ) ); ?>
-                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_table]', pods_var_raw( 'pick_table', $field, '' ), 'pick', array( 'required' => true, 'data' => pods_var_raw( 'pick_table', $field_settings ) ) ); ?>
+                                    <?php echo PodsForm::field( 'field_data[' . $pods_i . '][pick_table]', pods_v( 'pick_table', $field, '' ), 'pick', array( 'required' => true, 'data' => pods_v( 'pick_table', $field_settings ) ) ); ?>
                                 </div>
                                 <div class="pods-field-option pods-depends-on pods-depends-on-field-data-pick-object pods-depends-on-field-data-pick-object-<?php echo esc_attr( str_replace( '_', '-', implode( ' pods-depends-on-field-data-pick-object-', $bidirectional_objects ) ) ); ?>" data-dependency-trigger="pods_sister_field">
                                     <?php echo PodsForm::label( 'field_data[' . $pods_i . '][sister_id]', __( 'Bi-directional Field', 'pods' ), __( 'Bi-directional fields will update their related field for any item you select. This feature is only available for two relationships between two Pods.<br /><br />For example, when you update a Parent pod item to relate to a Child item, when you go to edit that Child item you will see the Parent pod item selected.', 'pods' ) ); ?>
 
                                     <div class="pods-sister-field">
-                                        <?php echo PodsForm::field( 'field_data[' . $pods_i . '][sister_id]', pods_var_raw( 'sister_id', $field, '' ), 'text' ); ?>
+                                        <?php echo PodsForm::field( 'field_data[' . $pods_i . '][sister_id]', pods_v( 'sister_id', $field, '' ), 'text' ); ?>
                                     </div>
                                 </div>
                             </div>
@@ -103,13 +103,13 @@ $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_v
                                 <div class="pods-pick-values pods-pick-checkbox">
                                     <ul>
                                         <li>
-                                            <?php echo PodsForm::field( 'field_data[' . $pods_i . '][required]', pods_var_raw( 'required', $field, 0 ), 'boolean', array( 'class' => 'pods-dependent-toggle', 'boolean_yes_label' => __( 'Required', 'pods' ), 'help' => __( 'help', 'pods' ) ) ); ?>
+                                            <?php echo PodsForm::field( 'field_data[' . $pods_i . '][required]', pods_v( 'required', $field, 0 ), 'boolean', array( 'class' => 'pods-dependent-toggle', 'boolean_yes_label' => __( 'Required', 'pods' ), 'help' => __( 'help', 'pods' ) ) ); ?>
                                         </li>
                                         <?php
                                             if ( 'table' == $pod[ 'storage' ] ) {
                                         ?>
                                             <li class="pods-excludes-on pods-excludes-on-field-data-type pods-excludes-on-field-data-type-pick pods-excludes-on-field-data-type-file pods-excludes-on-field-data-type-boolean pods-excludes-on-field-data-type-date pods-excludes-on-field-data-type-datetime pods-excludes-on-field-data-type-time">
-                                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][unique]', pods_var_raw( 'unique', $field, 0 ), 'boolean', array( 'class' => 'pods-dependent-toggle', 'boolean_yes_label' => __( 'Unique', 'pods' ), 'help' => __( 'help', 'pods' ) ) ); ?>
+                                                <?php echo PodsForm::field( 'field_data[' . $pods_i . '][unique]', pods_v( 'unique', $field, 0 ), 'boolean', array( 'class' => 'pods-dependent-toggle', 'boolean_yes_label' => __( 'Unique', 'pods' ), 'help' => __( 'help', 'pods' ) ) ); ?>
                                             </li>
                                         <?php
                                             }
@@ -195,18 +195,18 @@ $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_v
         </div>
     </td>
     <td class="pods-manage-row-name">
-        <a title="Edit this field" class="pods-manage-row-edit row-name" href="#edit-field"><?php echo esc_html( pods_var_raw( 'name', $field ) ); ?></a>
+        <a title="Edit this field" class="pods-manage-row-edit row-name" href="#edit-field"><?php echo esc_html( pods_v( 'name', $field ) ); ?></a>
     </td>
     <td class="pods-manage-row-type">
         <?php
         $type = 'Unknown';
 
-        if ( isset( $field_types[ pods_var( 'type', $field ) ] ) )
-            $type = $field_types[ pods_var( 'type', $field ) ][ 'label' ];
+        if ( isset( $field_types[ pods_v_sanitized( 'type', $field ) ] ) )
+            $type = $field_types[ pods_v_sanitized( 'type', $field ) ][ 'label' ];
 
-        echo esc_html( $type ) . ' <span class="pods-manage-row-more">[type: ' . pods_var( 'type', $field ) . ']</span>';
+        echo esc_html( $type ) . ' <span class="pods-manage-row-more">[type: ' . pods_v_sanitized( 'type', $field ) . ']</span>';
 
-        if ( 'pick' == pods_var( 'type', $field ) && '' != pods_var( 'pick_object', $field, '' ) ) {
+        if ( 'pick' == pods_v_sanitized( 'type', $field ) && '' != pods_v_sanitized( 'pick_object', $field, '' ) ) {
             $pick_object_name = null;
 
             foreach ( $field_settings[ 'pick_object' ] as $object => $object_label ) {
@@ -230,7 +230,7 @@ $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_v
                         }
                     }
                 }
-                elseif ( pods_var( 'pick_object', $field ) == $object ) {
+                elseif ( pods_v_sanitized( 'pick_object', $field ) == $object ) {
                     $pick_object_name = $object_label;
 
                     break;
@@ -238,10 +238,10 @@ $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_v
             }
 
             if ( null === $pick_object_name ) {
-                $pick_object_name = ucwords( str_replace( array( '-', '_' ), ' ', pods_var_raw( 'pick_object', $field ) ) );
+                $pick_object_name = ucwords( str_replace( array( '-', '_' ), ' ', pods_v( 'pick_object', $field ) ) );
 
-                if ( 0 < strlen( pods_var_raw( 'pick_val', $field ) ) )
-                    $pick_object_name = pods_var_raw( 'pick_val', $field ) . ' (' . $pick_object_name . ')';
+                if ( 0 < strlen( pods_v( 'pick_val', $field ) ) )
+                    $pick_object_name = pods_v( 'pick_val', $field ) . ' (' . $pick_object_name . ')';
             }
             ?>
             <br /><span class="pods-manage-field-type-desc">&rsaquo; <?php echo $pick_object_name; ?></span>

--- a/ui/admin/setup-edit-field.php
+++ b/ui/admin/setup-edit-field.php
@@ -2,7 +2,7 @@
     $field = array_merge( $field_settings[ 'field_defaults' ], $field );
 
     // Migrate pick object when saving
-    if ( 'pod' == pods_var( 'pick_object', $field ) ) {
+    if ( 'pod' == pods_v_sanitized( 'pick_object', $field ) ) {
         if ( isset( PodsMeta::$post_types[ $field[ 'pick_val' ] ] ) )
             $field[ 'pick_object' ] = 'post_type';
         elseif ( isset( PodsMeta::$taxonomies[ $field[ 'pick_val' ] ] ) )
@@ -23,9 +23,9 @@
 
     $ignored_pick_objects = apply_filters( '', array( 'table' ) );
 
-    if ( !in_array( pods_var( 'pick_object', $field ), $ignored_pick_objects ) ) {
+    if ( !in_array( pods_v_sanitized( 'pick_object', $field ), $ignored_pick_objects ) ) {
         // Set pick object
-        $field[ 'pick_object' ] = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_val', $field ), '-' );
+        $field[ 'pick_object' ] = trim( pods_v_sanitized( 'pick_object', $field ) . '-' . pods_v_sanitized( 'pick_val', $field ), '-' );
     }
 
     // Unset pick_val for the field to be used above
@@ -43,20 +43,20 @@
         'row' => $pods_i
     );
 ?>
-<tr id="row-<?php echo esc_attr( $pods_i ); ?>" class="pods-manage-row pods-field-init pods-field-<?php echo esc_attr( pods_var( 'name', $field ) ) . ( '--1' === $pods_i ? ' flexible-row' : ' pods-submittable-fields' ); ?>" valign="top"<?php PodsForm::data( $data ); ?>>
+<tr id="row-<?php echo esc_attr( $pods_i ); ?>" class="pods-manage-row pods-field-init pods-field-<?php echo esc_attr( pods_v_sanitized( 'name', $field ) ) . ( '--1' === $pods_i ? ' flexible-row' : ' pods-submittable-fields' ); ?>" valign="top"<?php PodsForm::data( $data ); ?>>
     <th scope="row" class="check-field pods-manage-sort">
         <img src="<?php echo esc_url( PODS_URL ); ?>ui/images/handle.gif" alt="<?php esc_attr_e( 'Move', 'pods' ); ?>" />
     </th>
     <td class="pods-manage-row-label">
         <strong> <a class="pods-manage-row-edit row-label" title="<?php esc_attr_e( 'Edit this field', 'pods' ); ?>" href="#edit-field">
-            <?php echo esc_html( pods_var_raw( 'label', $field ) ); ?>
-        </a> <abbr title="required" class="required<?php echo esc_attr( 1 == pods_var_raw( 'required', $field ) ? '' : ' hidden' ); ?>">*</abbr> </strong>
+            <?php echo esc_html( pods_v( 'label', $field ) ); ?>
+        </a> <abbr title="required" class="required<?php echo esc_attr( 1 == pods_v( 'required', $field ) ? '' : ' hidden' ); ?>">*</abbr> </strong>
 
         <?php
-        if ( '__1' != pods_var( 'id', $field ) ) {
+        if ( '__1' != pods_v_sanitized( 'id', $field ) ) {
             ?>
             <span class="pods-manage-row-more">
-                        [id: <?php echo esc_html( pods_var( 'id', $field ) ); ?>]
+                        [id: <?php echo esc_html( pods_v_sanitized( 'id', $field ) ); ?>]
                     </span>
             <?php
         }
@@ -77,25 +77,25 @@
             <input type="hidden" name="field_data_json[<?php echo esc_attr( $pods_i ); ?>]" value="<?php echo esc_attr( ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ? json_encode( $field, JSON_UNESCAPED_UNICODE ) : json_encode( $field ) ) ); ?>" class="field_data" />
 
             <div class="pods-manage-field pods-dependency">
-                <input type="hidden" name="field_data[<?php echo esc_attr( $pods_i ); ?>][id]" value="<?php echo esc_attr( pods_var_raw( 'id', $field ) ); ?>" />
+                <input type="hidden" name="field_data[<?php echo esc_attr( $pods_i ); ?>][id]" value="<?php echo esc_attr( pods_v( 'id', $field ) ); ?>" />
             <div>
         </div>
     </td>
     <td class="pods-manage-row-name">
-        <a title="Edit this field" class="pods-manage-row-edit row-name" href="#edit-field"><?php echo esc_html( pods_var_raw( 'name', $field ) ); ?></a>
+        <a title="Edit this field" class="pods-manage-row-edit row-name" href="#edit-field"><?php echo esc_html( pods_v( 'name', $field ) ); ?></a>
     </td>
     <td class="pods-manage-row-type">
         <?php
             $type = 'Unknown';
 
-            if ( isset( $field_types[ pods_var( 'type', $field ) ] ) )
-                $type = $field_types[ pods_var( 'type', $field ) ][ 'label' ];
+            if ( isset( $field_types[ pods_v_sanitized( 'type', $field ) ] ) )
+                $type = $field_types[ pods_v_sanitized( 'type', $field ) ][ 'label' ];
 
-            echo esc_html( $type ) . ' <span class="pods-manage-row-more">[type: ' . pods_var( 'type', $field ) . ']</span>';
+            echo esc_html( $type ) . ' <span class="pods-manage-row-more">[type: ' . pods_v_sanitized( 'type', $field ) . ']</span>';
 
-            $pick_object = trim( pods_var( 'pick_object', $field ) . '-' . pods_var( 'pick_val', $field ), '-' );
+            $pick_object = trim( pods_v_sanitized( 'pick_object', $field ) . '-' . pods_v_sanitized( 'pick_val', $field ), '-' );
 
-            if ( 'pick' == pods_var( 'type', $field ) && '' != pods_var( 'pick_object', $field, '' ) ) {
+            if ( 'pick' == pods_v_sanitized( 'type', $field ) && '' != pods_v_sanitized( 'pick_object', $field, '' ) ) {
                 $pick_object_name = null;
 
                 foreach ( $field_settings[ 'pick_object' ] as $object => $object_label ) {
@@ -121,7 +121,7 @@
                             }
                         }
                     }
-                    elseif ( pods_var( 'pick_object', $field ) == $object ) {
+                    elseif ( pods_v_sanitized( 'pick_object', $field ) == $object ) {
                         $pick_object_name = $object_label;
 
                         break;
@@ -129,10 +129,10 @@
                 }
 
                 if ( null === $pick_object_name ) {
-                    $pick_object_name = ucwords( str_replace( array( '-', '_' ), ' ', pods_var_raw( 'pick_object', $field ) ) );
+                    $pick_object_name = ucwords( str_replace( array( '-', '_' ), ' ', pods_v( 'pick_object', $field ) ) );
 
-                    if ( 0 < strlen( pods_var_raw( 'pick_val', $field ) ) )
-                        $pick_object_name = pods_var_raw( 'pick_val', $field ) . ' (' . $pick_object_name . ')';
+                    if ( 0 < strlen( pods_v( 'pick_val', $field ) ) )
+                        $pick_object_name = pods_v( 'pick_val', $field ) . ' (' . $pick_object_name . ')';
                 }
         ?>
             <br /><span class="pods-manage-field-type-desc">&rsaquo; <?php echo $pick_object_name; ?></span>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -5,7 +5,7 @@ $api = pods_api();
 
 $pod = $api->load_pod( array( 'id' => $obj->id ) );
 
-if ( 'taxonomy' == $pod[ 'type' ] && 'none' == $pod[ 'storage' ] && 1 == pods_var( 'enable_extra_fields', 'get' ) ) {
+if ( 'taxonomy' == $pod[ 'type' ] && 'none' == $pod[ 'storage' ] && 1 == pods_v_sanitized( 'enable_extra_fields', 'get' ) ) {
     $api->save_pod( array( 'id' => $obj->id, 'storage' => 'table' ) );
 
     $pod = $api->load_pod( array( 'id' => $obj->id ) );
@@ -34,9 +34,9 @@ foreach ( $field_types as $type => $field_type_data ) {
     if ( true !== $field_type_vars[ 'pod_types' ] ) {
         if ( empty( $field_type_vars[ 'pod_types' ] ) )
             continue;
-        elseif ( is_array( $field_type_vars[ 'pod_types' ] ) && !in_array( pods_var( 'type', $pod ), $field_type_vars[ 'pod_types' ] ) )
+        elseif ( is_array( $field_type_vars[ 'pod_types' ] ) && !in_array( pods_v_sanitized( 'type', $pod ), $field_type_vars[ 'pod_types' ] ) )
             continue;
-        elseif ( !is_array( $field_type_vars[ 'pod_types' ] ) && pods_var( 'type', $pod ) != $field_type_vars[ 'pod_types' ] )
+        elseif ( !is_array( $field_type_vars[ 'pod_types' ] ) && pods_v_sanitized( 'type', $pod ) != $field_type_vars[ 'pod_types' ] )
             continue;
     }
 
@@ -161,7 +161,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
                     <input type="button" class="edit-slug-button button" value="Edit" />
                 </span>
                 <span class="pods-slug-edit">
-                    <?php echo PodsForm::field( 'name', pods_var_raw( 'name', $pod ), 'db', array(
+                    <?php echo PodsForm::field( 'name', pods_v( 'name', $pod ), 'db', array(
                     'attributes' => array(
                         'maxlength' => $max_length_name,
                         'size' => 25
@@ -182,7 +182,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
 
         <h2 class="nav-tab-wrapper pods-nav-tabs">
             <?php
-                $default = sanitize_title( pods_var( 'tab', 'get', 'manage-fields', null, true ) );
+                $default = sanitize_title( pods_v_sanitized( 'tab', 'get', 'manage-fields', null, true ) );
 
                 if ( !isset( $tabs[ $default ] ) ) {
                     $tab_keys = array_keys( $tabs );
@@ -217,9 +217,9 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
 if ( isset( $_GET[ 'do' ] ) ) {
     $action = __( 'saved', 'pods' );
 
-    if ( 'create' == pods_var( 'do', 'get', 'save' ) )
+    if ( 'create' == pods_v_sanitized( 'do', 'get', 'save' ) )
         $action = __( 'created', 'pods' );
-    elseif ( 'duplicate' == pods_var( 'do', 'get', 'save' ) )
+    elseif ( 'duplicate' == pods_v_sanitized( 'do', 'get', 'save' ) )
         $action = __( 'duplicated', 'pods' );
 
     $message = sprintf( __( '<strong>Success!</strong> %s %s successfully.', 'pods' ), $obj->item, $action );
@@ -324,106 +324,106 @@ if ( isset( $_GET[ 'do' ] ) ) {
 ?>
 <div id="pods-labels" class="pods-nav-tab pods-manage-field pods-dependency pods-submittable-fields">
 <?php
-if ( strlen( pods_var( 'object', $pod ) ) < 1 && 'settings' != pods_var( 'type', $pod ) ) {
+if ( strlen( pods_v_sanitized( 'object', $pod ) ) < 1 && 'settings' != pods_v_sanitized( 'type', $pod ) ) {
     ?>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label', __( 'Label', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label', pods_var_raw( 'label', $pod ), 'text', array( 'text_max_length' => 30 ) ); ?>
+        <?php echo PodsForm::field( 'label', pods_v( 'label', $pod ), 'text', array( 'text_max_length' => 30 ) ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_singular', __( 'Singular Label', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_singular', pods_var_raw( 'label_singular', $pod, pods_var_raw( 'label', $pod, ucwords( str_replace( '_', ' ', pods_var_raw( 'name', $pod ) ) ) ) ), 'text', array( 'text_max_length' => 30 ) ); ?>
+        <?php echo PodsForm::field( 'label_singular', pods_v( 'label_singular', $pod, pods_v( 'label', $pod, ucwords( str_replace( '_', ' ', pods_v( 'name', $pod ) ) ) ) ), 'text', array( 'text_max_length' => 30 ) ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_add_new', __( 'Add New', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_add_new', pods_var_raw( 'label_add_new', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_add_new', pods_v( 'label_add_new', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_add_new_item', __( 'Add New <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_add_new_item', pods_var_raw( 'label_add_new_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_add_new_item', pods_v( 'label_add_new_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_new_item', __( 'New <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_new_item', pods_var_raw( 'label_new_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_new_item', pods_v( 'label_new_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_edit', __( 'Edit', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_edit', pods_var_raw( 'label_edit', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_edit', pods_v( 'label_edit', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_edit_item', __( 'Edit <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_edit_item', pods_var_raw( 'label_edit_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_edit_item', pods_v( 'label_edit_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_update_item', __( 'Update <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_update_item', pods_var_raw( 'label_update_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_update_item', pods_v( 'label_update_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_view', __( 'View', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_view', pods_var_raw( 'label_view', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_view', pods_v( 'label_view', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_view_item', __( 'View <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_view_item', pods_var_raw( 'label_view_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_view_item', pods_v( 'label_view_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_all_items', __( 'All <span class="pods-slugged" data-sluggable="label">Items</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_all_items', pods_var_raw( 'label_all_items', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_all_items', pods_v( 'label_all_items', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_search_items', __( 'Search <span class="pods-slugged" data-sluggable="label">Items</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_search_items', pods_var_raw( 'label_search_items', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_search_items', pods_v( 'label_search_items', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_not_found', __( 'Not Found', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_not_found', pods_var_raw( 'label_not_found', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_not_found', pods_v( 'label_not_found', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_feature_image', __( 'Featured Image', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_feature_image', pods_var_raw( 'label_feature_image', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_feature_image', pods_v( 'label_feature_image', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_set_featured_image', __( 'Set featured image', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_set_featured_image', pods_var_raw( 'label_set_featured_image', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_set_featured_image', pods_v( 'label_set_featured_image', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_remove_featured_image', __( 'Remove featured image', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_remove_featured_image', pods_var_raw( 'label_remove_featured_image', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_remove_featured_image', pods_v( 'label_remove_featured_image', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_use_featured_image', __( 'Use as featured image', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_use_featured_image', pods_var_raw( 'label_use_featured_image', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_use_featured_image', pods_v( 'label_use_featured_image', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_archives', __( '<span class="pods-slugged" data-sluggable="label_singular">Item</span> Archives', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_archives', pods_var_raw( 'label_archives', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_archives', pods_v( 'label_archives', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_insert_into_item', __( 'Insert into <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_insert_into_item', pods_var_raw( 'label_insert_into_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_insert_into_item', pods_v( 'label_insert_into_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_uploaded_to_this_item', __( 'Uploaded to this <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_uploaded_to_this_item', pods_var_raw( 'label_uploaded_to_this_item', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_uploaded_to_this_item', pods_v( 'label_uploaded_to_this_item', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_filter_items_list', __( 'Filter <span class="pods-slugged" data-sluggable="label">Items</span> lists', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_filter_items_list', pods_var_raw( 'label_filter_items_list', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_filter_items_list', pods_v( 'label_filter_items_list', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_items_list_navigation', __( '<span class="pods-slugged" data-sluggable="label">Items</span> list navigation', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_items_list_navigation', pods_var_raw( 'label_items_list_navigation', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_items_list_navigation', pods_v( 'label_items_list_navigation', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_items_list', __( '<span class="pods-slugged" data-sluggable="label">Items</span> list', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_items_list', pods_var_raw( 'label_items_list', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_items_list', pods_v( 'label_items_list', $pod ), 'text' ); ?>
     </div>
     <?php
-    if ( in_array( pods_var( 'type', $pod ), array( 'post_type', 'pod' ) ) ) {
+    if ( in_array( pods_v_sanitized( 'type', $pod ), array( 'post_type', 'pod' ) ) ) {
         ?>
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'label_not_found_in_trash', __( 'Not Found in Trash', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'label_not_found_in_trash', pods_var_raw( 'label_not_found_in_trash', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'label_not_found_in_trash', pods_v( 'label_not_found_in_trash', $pod ), 'text' ); ?>
         </div>
         <?php
     }
@@ -431,31 +431,31 @@ if ( strlen( pods_var( 'object', $pod ) ) < 1 && 'settings' != pods_var( 'type',
 
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_popular_items', __( 'Popular <span class="pods-slugged" data-sluggable="label">Items</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_popular_items', pods_var_raw( 'label_popular_items', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_popular_items', pods_v( 'label_popular_items', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_separate_items_with_commas', __( 'Separate <span class="pods-slugged-lower" data-sluggable="label">items</span> with commas', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_separate_items_with_commas', pods_var_raw( 'label_separate_items_with_commas', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_separate_items_with_commas', pods_v( 'label_separate_items_with_commas', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_add_or_remove_items', __( 'Add or remove <span class="pods-slugged-lower" data-sluggable="label">items</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_add_or_remove_items', pods_var_raw( 'label_add_or_remove_items', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_add_or_remove_items', pods_v( 'label_add_or_remove_items', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label_choose_from_the_most_used', __( 'Choose from the most used', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label_choose_from_the_most_used', pods_var_raw( 'label_choose_from_the_most_used', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'label_choose_from_the_most_used', pods_v( 'label_choose_from_the_most_used', $pod ), 'text' ); ?>
     </div>
     <?php
 }
-elseif ( 'settings' == pods_var( 'type', $pod ) ) {
+elseif ( 'settings' == pods_v_sanitized( 'type', $pod ) ) {
     ?>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'label', __( 'Page Title', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'label', pods_var_raw( 'label', $pod ), 'text', array( 'text_max_length' => 30 ) ); ?>
+        <?php echo PodsForm::field( 'label', pods_v( 'label', $pod ), 'text', array( 'text_max_length' => 30 ) ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'menu_name', __( 'Menu Name', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'menu_name', pods_var_raw( 'menu_name', $pod, pods_var_raw( 'label', $pod, ucwords( str_replace( '_', ' ', pods_var_raw( 'name', $pod ) ) ) ) ), 'text', array( 'text_max_length' => 30 ) ); ?>
+        <?php echo PodsForm::field( 'menu_name', pods_v( 'menu_name', $pod, pods_v( 'label', $pod, ucwords( str_replace( '_', ' ', pods_v( 'name', $pod ) ) ) ) ), 'text', array( 'text_max_length' => 30 ) ); ?>
     </div>
     <?php
 }
@@ -468,7 +468,7 @@ if ( isset( $tabs[ 'advanced' ] ) ) {
 ?>
 <div id="pods-advanced" class="pods-nav-tab pods-manage-field pods-dependency pods-submittable-fields">
 <?php
-if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod ) ) < 1 ) {
+if ( 'post_type' == pods_v_sanitized( 'type', $pod ) && strlen( pods_v_sanitized( 'object', $pod ) ) < 1 ) {
     $fields = $tab_options[ 'advanced' ];
     $field_options = PodsForm::fields_setup( $fields );
     $field = $pod;
@@ -484,74 +484,74 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
             <ul>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_title', pods_var_raw( 'supports_title', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Title', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_title', pods_v( 'supports_title', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Title', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_editor', pods_var_raw( 'supports_editor', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Editor', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_editor', pods_v( 'supports_editor', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Editor', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_author', pods_var_raw( 'supports_author', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Author', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_author', pods_v( 'supports_author', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Author', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_thumbnail', pods_var_raw( 'supports_thumbnail', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Featured Image', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_thumbnail', pods_v( 'supports_thumbnail', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Featured Image', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_excerpt', pods_var_raw( 'supports_excerpt', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Excerpt', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_excerpt', pods_v( 'supports_excerpt', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Excerpt', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_trackbacks', pods_var_raw( 'supports_trackbacks', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Trackbacks', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_trackbacks', pods_v( 'supports_trackbacks', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Trackbacks', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_custom_fields', pods_var_raw( 'supports_custom_fields', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Custom Fields', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_custom_fields', pods_v( 'supports_custom_fields', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Custom Fields', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_comments', pods_var_raw( 'supports_comments', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Comments', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_comments', pods_v( 'supports_comments', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Comments', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_revisions', pods_var_raw( 'supports_revisions', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Revisions', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_revisions', pods_v( 'supports_revisions', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Revisions', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_page_attributes', pods_var_raw( 'supports_page_attributes', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Page Attributes', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_page_attributes', pods_v( 'supports_page_attributes', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Page Attributes', 'pods' ) ) ); ?>
                     </div>
                 </li>
                 <li>
                     <div class="pods-field pods-boolean">
-                        <?php echo PodsForm::field( 'supports_post_formats', pods_var_raw( 'supports_post_formats', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Post Formats', 'pods' ) ) ); ?>
+                        <?php echo PodsForm::field( 'supports_post_formats', pods_v( 'supports_post_formats', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Post Formats', 'pods' ) ) ); ?>
                     </div>
                 </li>
 
                 <?php if ( function_exists( 'genesis' ) ) { ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_genesis_seo', pods_var_raw( 'supports_genesis_seo', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: SEO', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_genesis_seo', pods_v( 'supports_genesis_seo', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: SEO', 'pods' ) ) ); ?>
                         </div>
                     </li>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_genesis_layouts', pods_var_raw( 'supports_genesis_layouts', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: Layouts', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_genesis_layouts', pods_v( 'supports_genesis_layouts', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: Layouts', 'pods' ) ) ); ?>
                         </div>
                     </li>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_genesis_simple_sidebars', pods_var_raw( 'supports_genesis_simple_sidebars', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: Simple Sidebars', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_genesis_simple_sidebars', pods_v( 'supports_genesis_simple_sidebars', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Genesis: Simple Sidebars', 'pods' ) ) ); ?>
                         </div>
                     </li>
                 <?php } ?>
@@ -559,7 +559,7 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
 				<?php if ( defined( 'YARPP_VERSION' ) ) { ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_yarpp_support', pods_var_raw( 'supports_yarpp_support', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'YARPP Support', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_yarpp_support', pods_v( 'supports_yarpp_support', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'YARPP Support', 'pods' ) ) ); ?>
                         </div>
                     </li>
 				<?php } ?>
@@ -567,12 +567,12 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
 				<?php if ( class_exists( 'Jetpack' ) ) { ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_jetpack_publicize', pods_var_raw( 'supports_jetpack_publicize', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Jetpack Publicize Support', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_jetpack_publicize', pods_v( 'supports_jetpack_publicize', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Jetpack Publicize Support', 'pods' ) ) ); ?>
                         </div>
                     </li>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'supports_jetpack_markdown', pods_var_raw( 'supports_jetpack_markdown', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Jetpack Markdown Support', 'pods' ) ) ); ?>
+                            <?php echo PodsForm::field( 'supports_jetpack_markdown', pods_v( 'supports_jetpack_markdown', $pod, false ), 'boolean', array( 'boolean_yes_label' => __( 'Jetpack Markdown Support', 'pods' ) ) ); ?>
                         </div>
                     </li>
 				<?php } ?>
@@ -581,7 +581,7 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'supports_custom', __( 'Advanced Supports', 'pods' ), __( 'Comma-separated list of custom "supports" values to pass to register_post_type.', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'supports_custom', pods_var_raw( 'supports_custom', $pod, '' ), 'text' ); ?>
+        <?php echo PodsForm::field( 'supports_custom', pods_v( 'supports_custom', $pod, '' ), 'text' ); ?>
     </div>
     <div class="pods-field-option-group">
         <p class="pods-field-option-group-label">
@@ -596,7 +596,7 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
                     ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'built_in_taxonomies_' . $taxonomy, pods_var_raw( 'built_in_taxonomies_' . $taxonomy, $pod, false ), 'boolean', array( 'boolean_yes_label' => $label . ' <small>(' . $taxonomy . ')</small>' ) ); ?>
+                            <?php echo PodsForm::field( 'built_in_taxonomies_' . $taxonomy, pods_v( 'built_in_taxonomies_' . $taxonomy, $pod, false ), 'boolean', array( 'boolean_yes_label' => $label . ' <small>(' . $taxonomy . ')</small>' ) ); ?>
                         </div>
                     </li>
                     <?php
@@ -607,66 +607,66 @@ if ( 'post_type' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod
     </div>
     <?php
 }
-elseif ( 'taxonomy' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $pod ) ) < 1 ) {
+elseif ( 'taxonomy' == pods_v_sanitized( 'type', $pod ) && strlen( pods_v_sanitized( 'object', $pod ) ) < 1 ) {
     ?>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'public', __( 'Public', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'public', pods_var_raw( 'public', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'public', pods_v( 'public', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'hierarchical', __( 'Hierarchical', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'hierarchical', pods_var_raw( 'hierarchical', $pod, false ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'hierarchical', pods_v( 'hierarchical', $pod, false ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
     </div>
     <div class="pods-field-option-container pods-depends-on pods-depends-on-hierarchical">
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'label_parent_item_colon', __( '<strong>Label: </strong> Parent <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'label_parent_item_colon', pods_var_raw( 'label_parent_item_colon', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'label_parent_item_colon', pods_v( 'label_parent_item_colon', $pod ), 'text' ); ?>
         </div>
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'label_parent', __( '<strong>Label: </strong> Parent', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'label_parent', pods_var_raw( 'label_parent', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'label_parent', pods_v( 'label_parent', $pod ), 'text' ); ?>
         </div>
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'label_no_terms', __( 'No <span class="pods-slugged" data-sluggable="label">Items</span>', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'label_no_terms', pods_var_raw( 'label_no_terms', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'label_no_terms', pods_v( 'label_no_terms', $pod ), 'text' ); ?>
         </div>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'rewrite', __( 'Rewrite', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'rewrite', pods_var_raw( 'rewrite', $pod, true ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'rewrite', pods_v( 'rewrite', $pod, true ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
     </div>
     <div class="pods-field-option-container pods-depends-on pods-depends-on-rewrite">
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'rewrite_custom_slug', __( 'Custom Rewrite Slug', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'rewrite_custom_slug', pods_var_raw( 'rewrite_custom_slug', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'rewrite_custom_slug', pods_v( 'rewrite_custom_slug', $pod ), 'text' ); ?>
         </div>
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'rewrite_with_front', __( 'Allow Front Prepend', 'pods' ), __( 'Allows permalinks to be prepended with front base (example: if your permalink structure is /blog/, then your links will be: Checked->/news/, Unchecked->/blog/news/)', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'rewrite_with_front', pods_var_raw( 'rewrite_with_front', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
+            <?php echo PodsForm::field( 'rewrite_with_front', pods_v( 'rewrite_with_front', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
         </div>
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'rewrite_hierarchical', __( 'Hierarchical Permalinks', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'rewrite_hierarchical', pods_var_raw( 'rewrite_hierarchical', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
+            <?php echo PodsForm::field( 'rewrite_hierarchical', pods_v( 'rewrite_hierarchical', $pod, true ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
         </div>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'query_var', __( 'Query Var', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'query_var', pods_var_raw( 'query_var', $pod ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'query_var', pods_v( 'query_var', $pod ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
     </div>
     <div class="pods-field-option-container pods-depends-on pods-depends-on-query-var">
         <div class="pods-field-option">
             <?php echo PodsForm::label( 'query_var_string', __( 'Custom Query Var Name', 'pods' ), __( 'help', 'pods' ) ); ?>
-            <?php echo PodsForm::field( 'query_var_string', pods_var_raw( 'query_var_string', $pod ), 'text' ); ?>
+            <?php echo PodsForm::field( 'query_var_string', pods_v( 'query_var_string', $pod ), 'text' ); ?>
         </div>
     </div>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'sort', __( 'Remember order saved on Post Types', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'sort', pods_var_raw( 'sort', $pod ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'sort', pods_v( 'sort', $pod ), 'boolean', array( 'boolean_yes_label' => '' ) ); ?>
     </div>
 
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'update_count_callback', __( 'Function to call when updating counts', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'update_count_callback', pods_var_raw( 'update_count_callback', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'update_count_callback', pods_v( 'update_count_callback', $pod ), 'text' ); ?>
     </div>
     <div class="pods-field-option-group">
         <p class="pods-field-option-group-label">
@@ -682,7 +682,7 @@ elseif ( 'taxonomy' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $
                 ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'built_in_post_types_' . $post_type, pods_var_raw( 'built_in_post_types_' . $post_type, $pod, false ), 'boolean', array( 'boolean_yes_label' => $label ) ); ?>
+                            <?php echo PodsForm::field( 'built_in_post_types_' . $post_type, pods_v( 'built_in_post_types_' . $post_type, $pod, false ), 'boolean', array( 'boolean_yes_label' => $label ) ); ?>
                         </div>
                     </li>
                 <?php
@@ -694,7 +694,7 @@ elseif ( 'taxonomy' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $
                 ?>
                     <li>
                         <div class="pods-field pods-boolean">
-                            <?php echo PodsForm::field( 'built_in_post_types_attachment', pods_var_raw( 'built_in_post_types_attachment', $pod, false ), 'boolean', array( 'boolean_yes_label' => 'Media <small>(attachment)</small>' ) ); ?>
+                            <?php echo PodsForm::field( 'built_in_post_types_attachment', pods_v( 'built_in_post_types_attachment', $pod, false ), 'boolean', array( 'boolean_yes_label' => 'Media <small>(attachment)</small>' ) ); ?>
                         </div>
                     </li>
                 <?php
@@ -705,11 +705,11 @@ elseif ( 'taxonomy' == pods_var( 'type', $pod ) && strlen( pods_var( 'object', $
     </div>
     <?php
 }
-elseif ( 'pod' == pods_var( 'type', $pod ) ) {
+elseif ( 'pod' == pods_v_sanitized( 'type', $pod ) ) {
 ?>
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'detail_url', __( 'Detail Page URL', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'detail_url', pods_var_raw( 'detail_url', $pod ), 'text' ); ?>
+        <?php echo PodsForm::field( 'detail_url', pods_v( 'detail_url', $pod ), 'text' ); ?>
     </div>
 
     <?php
@@ -723,19 +723,19 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
 
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'pod_index', __( 'Title Field', 'pods' ), __( 'If you delete the "name" field, we need to specify the field to use as your primary title field. This field will serve as an index of your content. Most commonly this field represents the name of a person, place, thing, or a summary field.', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'pod_index', pods_var_raw( 'pod_index', $pod, 'name' ), 'pick', array( 'data' => $index_fields ) ); ?>
+        <?php echo PodsForm::field( 'pod_index', pods_v( 'pod_index', $pod, 'name' ), 'pick', array( 'data' => $index_fields ) ); ?>
     </div>
 
     <div class="pods-field-option">
         <?php echo PodsForm::label( 'hierarchical', __( 'Hierarchical', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'hierarchical', (int) pods_var_raw( 'hierarchical', $pod, 0 ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
+        <?php echo PodsForm::field( 'hierarchical', (int) pods_v( 'hierarchical', $pod, 0 ), 'boolean', array( 'dependency' => true, 'boolean_yes_label' => '' ) ); ?>
     </div>
 
     <?php
         $hierarchical_fields = array();
 
         foreach ( $pod[ 'fields' ] as $field ) {
-            if ( 'pick' == $field[ 'type' ] && 'pod' == pods_var( 'pick_object', $field ) && $pod[ 'name' ] == pods_var( 'pick_val', $field ) && 'single' == pods_var( 'pick_format_type', $field[ 'options' ] ) )
+            if ( 'pick' == $field[ 'type' ] && 'pod' == pods_v_sanitized( 'pick_object', $field ) && $pod[ 'name' ] == pods_v_sanitized( 'pick_val', $field ) && 'single' == pods_v_sanitized( 'pick_format_type', $field[ 'options' ] ) )
                 $hierarchical_fields[ $field[ 'name' ] ] = $field[ 'label' ];
         }
 
@@ -745,7 +745,7 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
 
     <div class="pods-field-option pods-depends-on pods-depends-on-hierarchical">
         <?php echo PodsForm::label( 'pod_parent', __( 'Hierarchical Field', 'pods' ), __( 'help', 'pods' ) ); ?>
-        <?php echo PodsForm::field( 'pod_parent', pods_var_raw( 'pod_parent', $pod, 'name' ), 'pick', array( 'data' => $hierarchical_fields ) ); ?>
+        <?php echo PodsForm::field( 'pod_parent', pods_v( 'pod_parent', $pod, 'name' ), 'pick', array( 'data' => $hierarchical_fields ) ); ?>
     </div>
 
     <?php
@@ -763,7 +763,7 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
             }
 
             echo PodsForm::label( 'pre_save_helpers', __( 'Pre-Save Helper(s)', 'pods' ), __( 'help', 'pods' ) );
-            echo PodsForm::field( 'pre_save_helpers', pods_var_raw( 'pre_save_helpers', $pod ), 'pick', array( 'data' => $pre_save_helpers ) );
+            echo PodsForm::field( 'pre_save_helpers', pods_v( 'pre_save_helpers', $pod ), 'pick', array( 'data' => $pre_save_helpers ) );
         ?>
     </div>
     <div class="pods-field-option">
@@ -777,7 +777,7 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
             }
 
             echo PodsForm::label( 'post_save_helpers', __( 'Post-Save Helper(s)', 'pods' ), __( 'help', 'pods' ) );
-            echo PodsForm::field( 'post_save_helpers', pods_var_raw( 'post_save_helpers', $pod ), 'pick', array( 'data' => $post_save_helpers ) );
+            echo PodsForm::field( 'post_save_helpers', pods_v( 'post_save_helpers', $pod ), 'pick', array( 'data' => $post_save_helpers ) );
         ?>
     </div>
     <div class="pods-field-option">
@@ -791,7 +791,7 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
             }
 
             echo PodsForm::label( 'pre_delete_helpers', __( 'Pre-Delete Helper(s)', 'pods' ), __( 'help', 'pods' ) );
-            echo PodsForm::field( 'pre_delete_helpers', pods_var_raw( 'pre_delete_helpers', $pod ), 'pick', array( 'data' => $pre_delete_helpers ) );
+            echo PodsForm::field( 'pre_delete_helpers', pods_v( 'pre_delete_helpers', $pod ), 'pick', array( 'data' => $pre_delete_helpers ) );
         ?>
     </div>
     <div class="pods-field-option">
@@ -805,7 +805,7 @@ elseif ( 'pod' == pods_var( 'type', $pod ) ) {
             }
 
             echo PodsForm::label( 'post_delete_helpers', __( 'Post-Delete Helper(s)', 'pods' ), __( 'help', 'pods' ) );
-            echo PodsForm::field( 'post_delete_helpers', pods_var_raw( 'post_delete_helpers', $pod ), 'pick', array( 'data' => $post_delete_helpers ) );
+            echo PodsForm::field( 'post_delete_helpers', pods_v( 'post_delete_helpers', $pod ), 'pick', array( 'data' => $post_delete_helpers ) );
         ?>
     </div>
     <?php
@@ -839,7 +839,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
 <div id="pods-extra-fields" class="pods-nav-tab">
     <p><?php _e( 'Taxonomies do not support extra fields natively, but Pods can add this feature for you easily. Table based storage will operate in a way where each field you create for your content type becomes a field in a table.', 'pods' ); ?></p>
 
-    <p><?php echo sprintf( __( 'Enabling extra fields for this taxonomy will add a custom table into your database as <em>%s</em>.', 'pods' ), $wpdb->prefix . 'pods_' . pods_var( 'name', $pod ) ); ?></p>
+    <p><?php echo sprintf( __( 'Enabling extra fields for this taxonomy will add a custom table into your database as <em>%s</em>.', 'pods' ), $wpdb->prefix . 'pods_' . pods_v_sanitized( 'name', $pod ) ); ?></p>
 
     <p><a href="http://pods.io/docs/comparisons/compare-storage-types/" target="_blank"><?php _e( 'Find out more', 'pods' ); ?> &raquo;</a></p>
 
@@ -956,7 +956,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
 
         pods_sister_field_going[ id + '_' + $el.prop( 'id' ) ] = true;
 
-        var default_select = '<?php echo str_replace( array( "\n", "\r" ), ' ', PodsForm::field( 'field_data[--1][sister_id]', '', 'pick', array( 'data' => pods_var_raw( 'sister_id', $field_settings ) ) ) ); ?>';
+        var default_select = '<?php echo str_replace( array( "\n", "\r" ), ' ', PodsForm::field( 'field_data[--1][sister_id]', '', 'pick', array( 'data' => pods_v( 'sister_id', $field_settings ) ) ) ); ?>';
         default_select = default_select.replace( /\-\-1/g, id );
 
         var related_pod_name = jQuery( '#pods-form-ui-field-data-' + id + '-pick-object' ).val();

--- a/ui/js/jquery.pods.attach.js
+++ b/ui/js/jquery.pods.attach.js
@@ -14,7 +14,7 @@ function pods_attachments ( src, file_limit ) {
 
         if ( wp_media_show.data( 'pods-injected-quick-add') !== true ) {
             // Create 'Add' link
-            var pods_file_quick_add = jQuery( '<a href="#">Add</a>' ).addClass( 'pods-quick-add' );
+            var pods_file_quick_add = jQuery( '<a href="#">' + pods_localized_strings.__add + '</a>' ).addClass( 'pods-quick-add' );
 
             pods_file_quick_add.bind( 'click', function( e ) {
                 var item = jQuery( this );
@@ -23,7 +23,7 @@ function pods_attachments ( src, file_limit ) {
                 item.fadeOut( 'fast', function() {
 
                     // Not sure if the close link should be there for each link?
-                    item.before( '<span class="pods-attached pods-quick-add">Added!</span>' );
+                    item.before( '<span class="pods-attached pods-quick-add">' + pods_localized_strings.__added + '</span>' );
                     //item.before( '<span class="pods-attached pods-quick-add">Added! <a href="#">close this box</a>.</span>' );
 
                     item.remove(); }
@@ -92,7 +92,7 @@ function pods_attachments ( src, file_limit ) {
         }
 
         if ( 1 < file_limit || file_limit == 0 ) {
-            jQuery( this ).after( ' <span class="pods-attached">Added! Choose another or <a href="#">close this box</a>.</span>' );
+            jQuery( this ).after( ' <span class="pods-attached">' + pods_localized_strings.__added_choose_another_or_close_this_box + '</span>' );
             jQuery( this ).parent().find( 'span.pods-attached a' ).on( 'click', function ( e ) {
                 parent.eval( 'tb_remove()' );
 

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -48,7 +48,7 @@
                     if ( !valid_field ) {
                         if ( -1 == jQuery.inArray( $el.prop( 'name' ), pods_form_field_names ) ) {
                             $el.closest( '.pods-field-input' ).find( '.pods-validate-error-message' ).remove();
-                            $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + label.replace( /( <([^>]+ )> )/ig, '' ) + ' is required.</div>' );
+                            $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
                             $el.addClass( 'pods-validate-error' );
 
                             pods_form_field_names.push( $el.prop( 'name' ) );
@@ -1848,6 +1848,11 @@
                 } );
             }
         };
+
+    if ( typeof pods_localized_strings == 'undefined' ) {
+        pods_localized_strings = {
+        };
+    }
 
     $.fn.Pods = function ( method ) {
         if ( methods[ method ] ) {

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -1860,7 +1860,7 @@
             '__add': 'Add',
             '__added': 'Added!',
             '__added_choose_another_or_close_this_box': 'Added! Choose another or <a href="#">close this box</a>',
-            '__copy': '(Copy)',
+            '__copy': 'Copy',
             '__navigating_away_from_this_page_will_discard_any_changes_you_have_made': 'Navigating away from this page will discard any changes you have made.',
             '__unable_to_process_request_please_try_again': 'Unable to process request, please try again.',
         };

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -48,7 +48,7 @@
                     if ( !valid_field ) {
                         if ( -1 == jQuery.inArray( $el.prop( 'name' ), pods_form_field_names ) ) {
                             $el.closest( '.pods-field-input' ).find( '.pods-validate-error-message' ).remove();
-                            $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
+                            
                             $el.addClass( 'pods-validate-error' );
 
                             pods_form_field_names.push( $el.prop( 'name' ) );

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -48,7 +48,12 @@
                     if ( !valid_field ) {
                         if ( -1 == jQuery.inArray( $el.prop( 'name' ), pods_form_field_names ) ) {
                             $el.closest( '.pods-field-input' ).find( '.pods-validate-error-message' ).remove();
-                            $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
+                            
+                            if ( $el.closest( '.pods-field-input > td' ).length > 0 ) {
+                                $el.closest( '.pods-field-input > td' ).last().prepend( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
+                            } else {
+                                $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
+                            }
                             $el.addClass( 'pods-validate-error' );
 
                             pods_form_field_names.push( $el.prop( 'name' ) );

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -1851,6 +1851,7 @@
 
     if ( typeof pods_localized_strings == 'undefined' ) {
         pods_localized_strings = {
+            '__is_required': '%s is required.',
         };
     }
 

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -48,7 +48,7 @@
                     if ( !valid_field ) {
                         if ( -1 == jQuery.inArray( $el.prop( 'name' ), pods_form_field_names ) ) {
                             $el.closest( '.pods-field-input' ).find( '.pods-validate-error-message' ).remove();
-                            
+                            $el.closest( '.pods-field-input' ).append( '<div class="pods-validate-error-message">' + pods_localized_strings.__is_required.replace( '%s', label.replace( /( <([^>]+ )> )/ig, '' ) ) + '</div>' );
                             $el.addClass( 'pods-validate-error' );
 
                             pods_form_field_names.push( $el.prop( 'name' ) );

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -388,7 +388,7 @@
                             }
                         },
                         error : function () {
-                            var err_msg = 'Unable to process request, please try again.';
+                            var err_msg = pods_localized_strings.__unable_to_process_request_please_try_again;
 
                             if ( 'undefined' != typeof pods_admin_submit_error_callback )
                                 pods_admin_submit_error_callback( err_msg, $submittable );
@@ -1714,7 +1714,7 @@
                         var $new_row_content = $new_row_label.find( 'div.pods-manage-row-wrapper' );
 
                         field_data[ 'name' ] += '_copy';
-                        field_data[ 'label' ] += ' (Copy)';
+                        field_data[ 'label' ] += ' (' + pods_localized_strings.__copy + ')';
                         field_data[ 'id' ] = 0;
 
                         $new_row_label.find( 'a.pods-manage-row-edit.row-label' ).html( field_data[ 'label' ] );
@@ -1799,7 +1799,7 @@
 
                     window.onbeforeunload = function () {
                         if ( pods_changed )
-                            return 'Navigating away from this page will discard any changes you have made.';
+                            return pods_localized_strings.__navigating_away_from_this_page_will_discard_any_changes_you_have_made;
                     }
                 } );
 
@@ -1852,6 +1852,12 @@
     if ( typeof pods_localized_strings == 'undefined' ) {
         pods_localized_strings = {
             '__is_required': '%s is required.',
+            '__add': 'Add',
+            '__added': 'Added!',
+            '__added_choose_another_or_close_this_box': 'Added! Choose another or <a href="#">close this box</a>',
+            '__copy': '(Copy)',
+            '__navigating_away_from_this_page_will_discard_any_changes_you_have_made': 'Navigating away from this page will discard any changes you have made.',
+            '__unable_to_process_request_please_try_again': 'Unable to process request, please try again.',
         };
     }
 

--- a/ui/js/jquery.pods.migrate.js
+++ b/ui/js/jquery.pods.migrate.js
@@ -66,7 +66,7 @@
                     },
                     error : function () {
                         $row.removeClass( 'pods-wizard-table-active' ).addClass( 'pods-wizard-table-error' );
-                        $row.find( 'td span.pods-wizard-info' ).text( 'Unable to process request, please try again.' );
+                        $row.find( 'td span.pods-wizard-info' ).text( pods_localized_strings.__unable_to_process_request_please_try_again );
                     },
                     dataType : 'html'
                 } );
@@ -172,7 +172,7 @@
                     },
                     error : function () {
                         $row.removeClass( 'pods-wizard-table-active' ).addClass( 'pods-wizard-table-error' );
-                        $row.find( 'td span.pods-wizard-info' ).text( 'Unable to process request, please try again.' );
+                        $row.find( 'td span.pods-wizard-info' ).text( pods_localized_strings.__unable_to_process_request_please_try_again );
                     },
                     dataType : 'html'
                 } );

--- a/ui/js/jquery.pods.upgrade.js
+++ b/ui/js/jquery.pods.upgrade.js
@@ -56,7 +56,7 @@
                     },
                     error : function () {
                         $row.removeClass( 'pods-wizard-table-active' ).addClass( 'pods-wizard-table-error' );
-                        $row.find( 'td span.pods-wizard-info' ).text( 'Unable to process request, please try again.' );
+                        $row.find( 'td span.pods-wizard-info' ).text( pods_localized_strings.__unable_to_process_request_please_try_again );
                     },
                     dataType : 'html'
                 } );
@@ -150,7 +150,7 @@
                     },
                     error : function () {
                         $row.removeClass( 'pods-wizard-table-active' ).addClass( 'pods-wizard-table-error' );
-                        $row.find( 'td span.pods-wizard-info' ).text( 'Unable to process request, please try again.' );
+                        $row.find( 'td span.pods-wizard-info' ).text( pods_localized_strings.__unable_to_process_request_please_try_again );
                     },
                     dataType : 'html'
                 } );


### PR DESCRIPTION
Fixes https://github.com/pods-framework/pods/issues/2054 and more adds even more strings

Sorry for the .gitignore commit, I've reverted the changes but I can't figure out how to remove this file from the pull-request.