### PR TITLE
New Link field with WP link modal

### DIFF
--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -1310,6 +1310,7 @@ class PodsForm {
         $field_types = array(
             'text',
             'website',
+            'link',
             'phone',
             'email',
             'password',
@@ -1327,7 +1328,6 @@ class PodsForm {
             'boolean',
             'color',
             'slug',
-            'link',
         );
 
         $field_types = array_merge( $field_types, array_keys( self::$field_types ) );

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -1326,7 +1326,8 @@ class PodsForm {
             'pick',
             'boolean',
             'color',
-            'slug'
+            'slug',
+            'link',
         );
 
         $field_types = array_merge( $field_types, array_keys( self::$field_types ) );

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -305,7 +305,7 @@ class PodsField_Link extends PodsField_Website {
 
 		$options = (array) $options;
 
-		$value = array_merge( (array) $value, array( 'url' => '', 'text' => '', 'target' => '' ) );
+		$value = array_merge( array( 'url' => '', 'text' => '', 'target' => '' ), (array) $value );
 
 		// Start URL format
 		if ( ! empty( $value['url'] ) ) {

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -326,4 +326,21 @@ class PodsField_Link extends PodsField_Website {
 
 	}
 
+	/**
+	 * Init the editor needed for WP Link modal to work
+	 */
+	public function init_link_editor() {
+
+		static $init;
+
+		if ( empty( $init ) ) {
+			echo '<div style="display:none">';
+			wp_editor( '', '#pods-link-editor-hidden' );
+			echo '</div>';
+		}
+
+		$init = true;
+
+	}
+
 }

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -1,4 +1,6 @@
 <?php
+require_once( PODS_DIR . 'classes/fields/website.php' );
+
 /**
  * @package Pods\Fields
  */

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -334,9 +334,11 @@ class PodsField_Link extends PodsField_Website {
 		static $init;
 
 		if ( empty( $init ) ) {
-			echo '<div style="display:none">';
-			wp_editor( '', '#pods-link-editor-hidden' );
-			echo '</div>';
+			if ( ! did_action( 'wp_enqueue_editor' ) ) {
+				echo '<div style="display:none">';
+				wp_editor( '', '#pods-link-editor-hidden' );
+				echo '</div>';
+			}
 		}
 
 		$init = true;

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -4,139 +4,139 @@
  */
 class PodsField_Link extends PodsField_Website {
 
-    /**
-     * Field Type Group
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $group = 'Text';
+	/**
+	 * Field Type Group
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $group = 'Text';
 
-    /**
-     * Field Type Identifier
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $type = 'link';
+	/**
+	 * Field Type Identifier
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $type = 'link';
 
-    /**
-     * Field Type Label
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $label = 'Link';
+	/**
+	 * Field Type Label
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $label = 'Link';
 
-    /**
-     * Field Type Preparation
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $prepare = '%s';
+	/**
+	 * Field Type Preparation
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $prepare = '%s';
 
-    /**
-     * Do things like register/enqueue scripts and stylesheets
-     *
-     * @since 2.0
-     */
-    public function __construct () {
+	/**
+	 * Do things like register/enqueue scripts and stylesheets
+	 *
+	 * @since 2.0
+	 */
+	public function __construct () {
 
-    }
+	}
 
-    /**
-     * Add options and set defaults to
-     *
-     * @param array $options
-     *
-     * @since 2.0
-     */
-    public function options () {
-        $options = array(
-            self::$type . '_repeatable' => array(
-                'label' => __( 'Repeatable Field', 'pods' ),
-                'default' => 0,
-                'type' => 'boolean',
-                'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
-                'boolean_yes_label' => '',
-                'dependency' => true,
-                'developer_mode' => true
-            ),
-            self::$type . '_format' => array(
-                'label' => __( 'Format', 'pods' ),
-                'default' => 'normal',
-                'type' => 'pick',
-                'data' => array(
-                    'none' => __( 'No URL format restrictions', 'pods' ),
-                    'normal' => __( 'http://example.com/', 'pods' ),
-                    'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
-                    'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
-                    'no-http' => __( 'example.com', 'pods' ),
-                    'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
-                    'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
-                )
-            ),
-            'output_options' => array(
-                'label' => __( 'Output Options', 'pods' ),
-                'group' => array(
-                    self::$type . '_allow_shortcode' => array(
-                        'label' => __( 'Allow Shortcodes?', 'pods' ),
-                        'default' => 0,
-                        'type' => 'boolean',
-                        'dependency' => true
-                    ),
-                    self::$type . '_allow_html' => array(
-                        'label' => __( 'Allow HTML?', 'pods' ),
-                        'default' => 0,
-                        'type' => 'boolean',
-                        'dependency' => true
-                    )
-                )
-            ),
-            self::$type . '_allowed_html_tags' => array(
-                'label' => __( 'Allowed HTML Tags', 'pods' ),
-                'depends-on' => array( self::$type . '_allow_html' => true ),
-                'default' => 'strong em a ul ol li b i',
-                'type' => 'text'
-            ),
-            /*self::$type . '_max_length' => array(
-                'label' => __( 'Maximum Length', 'pods' ),
-                'default' => 255,
-                'type' => 'number',
-                'help' => __( 'Set to -1 for no limit', 'pods' )
-            ),*/
-            self::$type . '_html5' => array(
-                'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
-                'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
-                'type' => 'boolean'
-            )/*,
-            self::$type . '_size' => array(
-                'label' => __( 'Field Size', 'pods' ),
-                'default' => 'medium',
-                'type' => 'pick',
-                'data' => array(
-                    'small' => __( 'Small', 'pods' ),
-                    'medium' => __( 'Medium', 'pods' ),
-                    'large' => __( 'Large', 'pods' )
-                )
-            )*/
-        );
-        return $options;
-    }
+	/**
+	 * Add options and set defaults to
+	 *
+	 * @param array $options
+	 *
+	 * @since 2.0
+	 */
+	public function options () {
+		$options = array(
+			self::$type . '_repeatable' => array(
+				'label' => __( 'Repeatable Field', 'pods' ),
+				'default' => 0,
+				'type' => 'boolean',
+				'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
+				'boolean_yes_label' => '',
+				'dependency' => true,
+				'developer_mode' => true
+			),
+			self::$type . '_format' => array(
+				'label' => __( 'Format', 'pods' ),
+				'default' => 'normal',
+				'type' => 'pick',
+				'data' => array(
+					'none' => __( 'No URL format restrictions', 'pods' ),
+					'normal' => __( 'http://example.com/', 'pods' ),
+					'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
+					'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
+					'no-http' => __( 'example.com', 'pods' ),
+					'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
+					'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
+				)
+			),
+			'output_options' => array(
+				'label' => __( 'Output Options', 'pods' ),
+				'group' => array(
+					self::$type . '_allow_shortcode' => array(
+						'label' => __( 'Allow Shortcodes?', 'pods' ),
+						'default' => 0,
+						'type' => 'boolean',
+						'dependency' => true
+					),
+					self::$type . '_allow_html' => array(
+						'label' => __( 'Allow HTML?', 'pods' ),
+						'default' => 0,
+						'type' => 'boolean',
+						'dependency' => true
+					)
+				)
+			),
+			self::$type . '_allowed_html_tags' => array(
+				'label' => __( 'Allowed HTML Tags', 'pods' ),
+				'depends-on' => array( self::$type . '_allow_html' => true ),
+				'default' => 'strong em a ul ol li b i',
+				'type' => 'text'
+			),
+			/*self::$type . '_max_length' => array(
+				'label' => __( 'Maximum Length', 'pods' ),
+				'default' => 255,
+				'type' => 'number',
+				'help' => __( 'Set to -1 for no limit', 'pods' )
+			),*/
+			self::$type . '_html5' => array(
+				'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
+				'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
+				'type' => 'boolean'
+			)/*,
+			self::$type . '_size' => array(
+				'label' => __( 'Field Size', 'pods' ),
+				'default' => 'medium',
+				'type' => 'pick',
+				'data' => array(
+					'small' => __( 'Small', 'pods' ),
+					'medium' => __( 'Medium', 'pods' ),
+					'large' => __( 'Large', 'pods' )
+				)
+			)*/
+		);
+		return $options;
+	}
 
-    /**
-     * Define the current field's schema for DB table storage
-     *
-     * @param array $options
-     *
-     * @return array
-     * @since 2.0
-     */
-    public function schema ( $options = null ) {
-        $schema = 'LONGTEXT';
-        return $schema;
-    }
+	/**
+	 * Define the current field's schema for DB table storage
+	 *
+	 * @param array $options
+	 *
+	 * @return array
+	 * @since 2.0
+	 */
+	public function schema ( $options = null ) {
+		$schema = 'LONGTEXT';
+		return $schema;
+	}
 
 	/**
 	 * Change the value of the field
@@ -154,314 +154,314 @@ class PodsField_Link extends PodsField_Website {
 		return $value;
 	}
 
-    /**
-     * Change the way the value of the field is displayed with Pods::get
-     *
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $pod
-     * @param int $id
-     *
-     * @return mixed|null|string
-     * @since 2.0
-     */
-    public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+	/**
+	 * Change the way the value of the field is displayed with Pods::get
+	 *
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @return mixed|null|string
+	 * @since 2.0
+	 */
+	public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
-        // Validate for an array because display is also used for the get_post_meta filters along the function chain
-        if ( ! is_array( $value ) ) {
-            return $value;
-        }
+		// Validate for an array because display is also used for the get_post_meta filters along the function chain
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
 
-        // Ensure proper format
-        $value = $this->pre_save( $value, $id, $name, $options, null, $pod );
+		// Ensure proper format
+		$value = $this->pre_save( $value, $id, $name, $options, null, $pod );
 
-        if ( isset( $value['url'] ) ) {
+		if ( isset( $value['url'] ) ) {
 
-            $link = '<a href="%s"%s>%s</a>';
+			$link = '<a href="%s"%s>%s</a>';
 
-            // Build the URL
-            $url = $this->build_url( parse_url( $value['url'] ) );
+			// Build the URL
+			$url = $this->build_url( parse_url( $value['url'] ) );
 
-            // Display URL as text by default. If text provided, use the text input
-            $text = $url;
-            if ( isset( $value['text'] ) && ! empty( $value['text'] ) ) {
-                $text = $this->strip_html( $value['text'], $options );
-            }
+			// Display URL as text by default. If text provided, use the text input
+			$text = $url;
+			if ( isset( $value['text'] ) && ! empty( $value['text'] ) ) {
+				$text = $this->strip_html( $value['text'], $options );
+			}
 
-            $atts = '';
-            if ( ! empty( $value['target'] ) ) {
-                // Possible support for other targets in future
-                $atts .= ' target="' . esc_attr( $value['target'] ) . '"';
-            }
+			$atts = '';
+			if ( ! empty( $value['target'] ) ) {
+				// Possible support for other targets in future
+				$atts .= ' target="' . esc_attr( $value['target'] ) . '"';
+			}
 
-            // Do shortcodes if this is enabled
-            if ( 1 == pods_var( self::$type . '_allow_shortcode', $options ) ) {
-                $url = do_shortcode( $url );
-                $text = do_shortcode( $text );
-            }
+			// Do shortcodes if this is enabled
+			if ( 1 == pods_var( self::$type . '_allow_shortcode', $options ) ) {
+				$url = do_shortcode( $url );
+				$text = do_shortcode( $text );
+			}
 
-            // Return the value
-            $value = sprintf( $link, esc_url( $url ), $atts, $text );
+			// Return the value
+			$value = sprintf( $link, esc_url( $url ), $atts, $text );
 
-        } elseif ( isset( $value['text'] ) ) {
-            // No URL data found (probably database error), return text is this is available
-            $value = $this->strip_html( $value['text'], $options );
-        }
+		} elseif ( isset( $value['text'] ) ) {
+			// No URL data found (probably database error), return text is this is available
+			$value = $this->strip_html( $value['text'], $options );
+		}
 
-        // Return database value or display value if above conditions are met
-        return $value;
-    }
+		// Return database value or display value if above conditions are met
+		return $value;
+	}
 
-    /**
-     * Customize output of the form field
-     *
-     * @param string $name
-     * @param mixed $value
-     * @param array $options
-     * @param array $pod
-     * @param int $id
-     *
-     * @since 2.0
-     */
-    public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
-        $options = (array) $options;
-        $form_field_type = PodsForm::$field_type;
-        $field_type = 'link';
-        pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
-    }
+	/**
+	 * Customize output of the form field
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @since 2.0
+	 */
+	public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
+		$options = (array) $options;
+		$form_field_type = PodsForm::$field_type;
+		$field_type = 'link';
+		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
+	}
 
-    /**
-     * Validate a value before it's saved
-     *
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     * @param int $id
-     *
-     * @since 2.0
-     */
-    public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
-        $errors = array();
+	/**
+	 * Validate a value before it's saved
+	 *
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @since 2.0
+	 */
+	public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+		$errors = array();
 
-        $label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
+		$label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
 
-        $check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
+		$check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
 
-        if ( is_array( $check['url'] ) )
-            $errors = $check['url'];
-        else {
-            if ( 0 < strlen( $value['url'] ) && strlen( $check['url'] ) < 1 ) {
-                if ( 1 == pods_var( 'required', $options ) )
-                    $errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
-                else
-                    $errors[] = sprintf( __( 'Invalid link provided for the field %s.', 'pods' ), $label );
-            }
-        }
+		if ( is_array( $check['url'] ) )
+			$errors = $check['url'];
+		else {
+			if ( 0 < strlen( $value['url'] ) && strlen( $check['url'] ) < 1 ) {
+				if ( 1 == pods_var( 'required', $options ) )
+					$errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
+				else
+					$errors[] = sprintf( __( 'Invalid link provided for the field %s.', 'pods' ), $label );
+			}
+		}
 
-        if ( !empty( $errors ) )
-            return $errors;
+		if ( !empty( $errors ) )
+			return $errors;
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Change the value or perform actions after validation but before saving to the DB
-     *
-     * @param mixed $value
-     * @param int $id
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     * @param object $params
-     *
-     * @since 2.0
-     */
-    public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
-        $options = (array) $options;
+	/**
+	 * Change the value or perform actions after validation but before saving to the DB
+	 *
+	 * @param mixed $value
+	 * @param int $id
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 * @param object $params
+	 *
+	 * @since 2.0
+	 */
+	public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
+		$options = (array) $options;
 
 		// Start URL format
-        if ( isset ($value['url']) ) {
-	       $value['url'] = $this->validate_url( $value['url'], $options );
-        }
+		if ( isset ($value['url']) ) {
+		   $value['url'] = $this->validate_url( $value['url'], $options );
+		}
 
 		// Start Title format
-        if ( isset ($value['text']) ) {
-            $value['text'] = $this->strip_html( $value['text'], $options );
-        }
+		if ( isset ($value['text']) ) {
+			$value['text'] = $this->strip_html( $value['text'], $options );
+		}
 
 		// Start Target format
-        if ( isset ($value['target']) ) {
-           $value['target'] = $this->validate_target( $value['target'], $options );
-        }
+		if ( isset ($value['target']) ) {
+		   $value['target'] = $this->validate_target( $value['target'], $options );
+		}
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Customize the Pods UI manage table column output
-     *
-     * @param int $id
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     *
-     * @since 2.0
-     */
-    public function ui ( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
-        if ( 'link' == pods_var( self::$type . '_format_type', $options ) && 0 < strlen( pods_var( self::$type . '_format', $options ) ) )
-            $value = make_clickable( $value );
+	/**
+	 * Customize the Pods UI manage table column output
+	 *
+	 * @param int $id
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 *
+	 * @since 2.0
+	 */
+	public function ui ( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
+		if ( 'link' == pods_var( self::$type . '_format_type', $options ) && 0 < strlen( pods_var( self::$type . '_format', $options ) ) )
+			$value = make_clickable( $value );
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Validate an URL with the options
-     *
-     * @param string $value
-     * @param array $options
-     *
-     * @since 2.0
-     */
-    public function validate_url( $value, $options = null ) {
-        if ( empty( $value ) )
-            return $value;
+	/**
+	 * Validate an URL with the options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @since 2.0
+	 */
+	public function validate_url( $value, $options = null ) {
+		if ( empty( $value ) )
+			return $value;
 
-        if ( 'none' != pods_var( self::$type . '_format', $options ) ) {
+		if ( 'none' != pods_var( self::$type . '_format', $options ) ) {
 
-            if ( is_array( $value ) ) {
-                if ( isset( $value[ 'scheme' ] ) )
-                    $value = $this->build_url( $value );
-                else
-                    $value = implode( '', $value );
-            }
+			if ( is_array( $value ) ) {
+				if ( isset( $value[ 'scheme' ] ) )
+					$value = $this->build_url( $value );
+				else
+					$value = implode( '', $value );
+			}
 
-            if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
-                $value = 'http://' . $value;
+			if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
+				$value = 'http://' . $value;
 
-            $url = @parse_url( $value );
+			$url = @parse_url( $value );
 
-            if ( empty( $url ) || count( $url ) < 2 )
-                $value = '';
-            else {
-                $defaults = array(
-                    'scheme' => 'http',
-                    'host' => '',
-                    'path' => '/',
-                    'query' => '',
-                    'fragment' => ''
-                );
+			if ( empty( $url ) || count( $url ) < 2 )
+				$value = '';
+			else {
+				$defaults = array(
+					'scheme' => 'http',
+					'host' => '',
+					'path' => '/',
+					'query' => '',
+					'fragment' => ''
+				);
 
-                $url = array_merge( $defaults, $url );
+				$url = array_merge( $defaults, $url );
 
-                if ( 'normal' == pods_var( self::$type . '_format', $options ) )
-                    $value = $this->build_url( $url );
-                elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
-                    if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
-                        $url[ 'host' ] = substr( $url[ 'host' ], 4 );
+				if ( 'normal' == pods_var( self::$type . '_format', $options ) )
+					$value = $this->build_url( $url );
+				elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+						$url[ 'host' ] = substr( $url[ 'host' ], 4 );
 
-                    $value = $this->build_url( $url );
-                }
-                elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
-                    if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
-                        $url[ 'host' ] = 'www.' . $url[ 'host' ];
+					$value = $this->build_url( $url );
+				}
+				elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+						$url[ 'host' ] = 'www.' . $url[ 'host' ];
 
-                    $value = $this->build_url( $url );
-                }
-                elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
-                    $value = $this->build_url( $url );
-                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+					$value = $this->build_url( $url );
+				}
+				elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
 
-                    if ( '/' == $url[ 'path' ] )
-                        $value = trim( $value, '/' );
-                }
-                elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
-                    if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
-                        $url[ 'host' ] = substr( $url[ 'host' ], 4 );
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+				elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+						$url[ 'host' ] = substr( $url[ 'host' ], 4 );
 
-                    $value = $this->build_url( $url );
-                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
 
-                    if ( '/' == $url[ 'path' ] )
-                        $value = trim( $value, '/' );
-                }
-                elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
-                    if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
-                        $url[ 'host' ] = 'www.' . $url[ 'host' ];
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+				elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+						$url[ 'host' ] = 'www.' . $url[ 'host' ];
 
-                    $value = $this->build_url( $url );
-                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
 
-                    if ( '/' == $url[ 'path' ] )
-                        $value = trim( $value, '/' );
-                }
-            }
-        } else {
-            $value = $this->strip_html( $value, $options );
-        }
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+			}
+		} else {
+			$value = $this->strip_html( $value, $options );
+		}
 
-        $value = esc_url( $value );
+		$value = esc_url( $value );
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Validate an targit attribute with the options
-     *
-     * @param string $value
-     * @param array $options
-     *
-     * @since 2.0
-     */
-    public function validate_target( $value, $options = null ) {
-        if ( ! empty( $value ) && $value == '_blank' ) {
-            $value = '_blank';
-        } else {
-            $value = '';
-        }
-        return $value;
-    }
+	/**
+	 * Validate an targit attribute with the options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @since 2.0
+	 */
+	public function validate_target( $value, $options = null ) {
+		if ( ! empty( $value ) && $value == '_blank' ) {
+			$value = '_blank';
+		} else {
+			$value = '';
+		}
+		return $value;
+	}
 
 
-    /**
-     * Strip HTML based on options
-     *
-     * @param string $value
-     * @param array $options
-     *
-     * @return string
-     */
-    public function strip_html ( $value, $options = null ) {
-        if ( is_array( $value ) )
-            $value = @implode( ' ', $value );
+	/**
+	 * Strip HTML based on options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @return string
+	 */
+	public function strip_html ( $value, $options = null ) {
+		if ( is_array( $value ) )
+			$value = @implode( ' ', $value );
 
-        $value = trim( $value );
+		$value = trim( $value );
 
-        if ( empty( $value ) )
-            return $value;
+		if ( empty( $value ) )
+			return $value;
 
-        $options = (array) $options;
+		$options = (array) $options;
 
-        if ( 1 == pods_var( self::$type . '_allow_html', $options, 0, null, true ) ) {
-            $allowed_html_tags = '';
+		if ( 1 == pods_var( self::$type . '_allow_html', $options, 0, null, true ) ) {
+			$allowed_html_tags = '';
 
-            if ( 0 < strlen( pods_var( self::$type . '_allowed_html_tags', $options ) ) ) {
-                $allowed_html_tags = explode( ' ', trim( pods_var( self::$type . '_allowed_html_tags', $options ) ) );
-                $allowed_html_tags = '<' . implode( '><', $allowed_html_tags ) . '>';
-            }
+			if ( 0 < strlen( pods_var( self::$type . '_allowed_html_tags', $options ) ) ) {
+				$allowed_html_tags = explode( ' ', trim( pods_var( self::$type . '_allowed_html_tags', $options ) ) );
+				$allowed_html_tags = '<' . implode( '><', $allowed_html_tags ) . '>';
+			}
 
-            if ( !empty( $allowed_html_tags ) && '<>' != $allowed_html_tags )
-                $value = strip_tags( $value, $allowed_html_tags );
-        }
-        else
-            $value = strip_tags( $value );
+			if ( !empty( $allowed_html_tags ) && '<>' != $allowed_html_tags )
+				$value = strip_tags( $value, $allowed_html_tags );
+		}
+		else
+			$value = strip_tags( $value );
 
-        return $value;
-    }
+		return $value;
+	}
 
 }

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -1,0 +1,499 @@
+<?php
+/**
+ * @package Pods\Fields
+ */
+class PodsField_Link extends PodsField {
+
+    /**
+     * Field Type Group
+     *
+     * @var string
+     * @since 2.0
+     */
+    public static $group = 'Text';
+
+    /**
+     * Field Type Identifier
+     *
+     * @var string
+     * @since 2.0
+     */
+    public static $type = 'link';
+
+    /**
+     * Field Type Label
+     *
+     * @var string
+     * @since 2.0
+     */
+    public static $label = 'Link';
+
+    /**
+     * Field Type Preparation
+     *
+     * @var string
+     * @since 2.0
+     */
+    public static $prepare = '%s';
+
+    /**
+     * Do things like register/enqueue scripts and stylesheets
+     *
+     * @since 2.0
+     */
+    public function __construct () {
+		
+    }
+	
+    /**
+     * Add options and set defaults to
+     *
+     * @param array $options
+     *
+     * @since 2.0
+     */
+    public function options () {
+        $options = array(
+            self::$type . '_repeatable' => array(
+                'label' => __( 'Repeatable Field', 'pods' ),
+                'default' => 0,
+                'type' => 'boolean',
+                'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
+                'boolean_yes_label' => '',
+                'dependency' => true,
+                'developer_mode' => true
+            ),
+            self::$type . '_format' => array(
+                'label' => __( 'Format', 'pods' ),
+                'default' => 'normal',
+                'type' => 'pick',
+                'data' => array(
+                    'none' => __( 'No URL format restrictions', 'pods' ),
+                    'normal' => __( 'http://example.com/', 'pods' ),
+                    'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
+                    'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
+                    'no-http' => __( 'example.com', 'pods' ),
+                    'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
+                    'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
+                )
+            ),
+            'output_options' => array(
+                'label' => __( 'Output Options', 'pods' ),
+                'group' => array(
+                    self::$type . '_allow_shortcode' => array(
+                        'label' => __( 'Allow Shortcodes?', 'pods' ),
+                        'default' => 0,
+                        'type' => 'boolean',
+                        'dependency' => true
+                    ),
+                    self::$type . '_allow_html' => array(
+                        'label' => __( 'Allow HTML?', 'pods' ),
+                        'default' => 0,
+                        'type' => 'boolean',
+                        'dependency' => true
+                    )
+                )
+            ),
+            self::$type . '_allowed_html_tags' => array(
+                'label' => __( 'Allowed HTML Tags', 'pods' ),
+                'depends-on' => array( self::$type . '_allow_html' => true ),
+                'default' => 'strong em a ul ol li b i',
+                'type' => 'text'
+            ),
+            /*self::$type . '_max_length' => array(
+                'label' => __( 'Maximum Length', 'pods' ),
+                'default' => 255,
+                'type' => 'number',
+                'help' => __( 'Set to -1 for no limit', 'pods' )
+            ),*/
+            self::$type . '_html5' => array(
+                'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
+                'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
+                'type' => 'boolean'
+            )/*,
+            self::$type . '_size' => array(
+                'label' => __( 'Field Size', 'pods' ),
+                'default' => 'medium',
+                'type' => 'pick',
+                'data' => array(
+                    'small' => __( 'Small', 'pods' ),
+                    'medium' => __( 'Medium', 'pods' ),
+                    'large' => __( 'Large', 'pods' )
+                )
+            )*/
+        );
+        return $options;
+    }
+
+    /**
+     * Define the current field's schema for DB table storage
+     *
+     * @param array $options
+     *
+     * @return array
+     * @since 2.0
+     */
+    public function schema ( $options = null ) {
+        $schema = 'LONGTEXT';
+        return $schema;
+    }
+    
+	/**
+	 * Change the value of the field
+	 *
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @return mixed|null|string
+	 * @since 2.3
+	 */
+	public function value ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+		return $value;
+	}
+	
+    /**
+     * Change the way the value of the field is displayed with Pods::get
+     *
+     * @param mixed $value
+     * @param string $name
+     * @param array $options
+     * @param array $pod
+     * @param int $id
+     *
+     * @return mixed|null|string
+     * @since 2.0
+     */
+    public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+
+        // Validate for an array because display is also used for the get_post_meta filters along the function chain
+        if ( ! is_array( $value ) ) {
+            return $value;
+        }
+
+        // Ensure proper format
+        $value = $this->pre_save( $value, $id, $name, $options, null, $pod );
+        
+        if ( isset( $value['url'] ) ) {
+
+            $link = '<a href="%s"%s>%s</a>';
+
+            // Build the URL
+            $url = $this->build_url( parse_url( $value['url'] ) );
+
+            // Display URL as text by default. If text provided, use the text input
+            $text = $url;
+            if ( isset( $value['text'] ) && ! empty( $value['text'] ) ) {
+                $text = $this->strip_html( $value['text'], $options );
+            }
+
+            $atts = '';
+            if ( ! empty( $value['target'] ) ) {
+                // Possible support for other targets in future
+                $atts .= ' target="' . esc_attr( $value['target'] ) . '"';
+            }
+
+            // Do shortcodes if this is enabled
+            if ( 1 == pods_var( self::$type . '_allow_shortcode', $options ) ) {
+                $url = do_shortcode( $url );
+                $text = do_shortcode( $text );
+            }
+
+            // Return the value
+            $value = sprintf( $link, esc_url( $url ), $atts, $text );
+
+        } elseif ( isset( $value['text'] ) ) {
+            // No URL data found (probably database error), return text is this is available
+            $value = $this->strip_html( $value['text'], $options );
+        }
+
+        // Return database value or display value if above conditions are met
+        return $value;
+    }
+
+    /**
+     * Customize output of the form field
+     *
+     * @param string $name
+     * @param mixed $value
+     * @param array $options
+     * @param array $pod
+     * @param int $id
+     *
+     * @since 2.0
+     */
+    public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
+        $options = (array) $options;
+        $form_field_type = PodsForm::$field_type;
+        $field_type = 'link';
+        pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
+    }
+
+    /**
+     * Validate a value before it's saved
+     *
+     * @param mixed $value
+     * @param string $name
+     * @param array $options
+     * @param array $fields
+     * @param array $pod
+     * @param int $id
+     *
+     * @since 2.0
+     */
+    public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+        $errors = array();
+		
+        $label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
+
+        $check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
+		
+        if ( is_array( $check['url'] ) )
+            $errors = $check['url'];
+        else {
+            if ( 0 < strlen( $value['url'] ) && strlen( $check['url'] ) < 1 ) {
+                if ( 1 == pods_var( 'required', $options ) )
+                    $errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
+                else
+                    $errors[] = sprintf( __( 'Invalid link provided for the field %s.', 'pods' ), $label );
+            }
+        }
+
+        if ( !empty( $errors ) )
+            return $errors;
+		
+        return true;
+    }
+
+    /**
+     * Change the value or perform actions after validation but before saving to the DB
+     *
+     * @param mixed $value
+     * @param int $id
+     * @param string $name
+     * @param array $options
+     * @param array $fields
+     * @param array $pod
+     * @param object $params
+     *
+     * @since 2.0
+     */
+    public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
+        $options = (array) $options;
+		
+		// Start URL format
+        if ( isset ($value['url']) ) {
+	       $value['url'] = $this->validate_url( $value['url'], $options );
+        }
+		
+		// Start Title format
+        if ( isset ($value['text']) ) {
+            $value['text'] = $this->strip_html( $value['text'], $options );
+        }
+
+		// Start Target format
+        if ( isset ($value['target']) ) {
+           $value['target'] = $this->validate_target( $value['target'], $options );
+        }
+		
+        return $value;
+    }
+	
+    /**
+     * Customize the Pods UI manage table column output
+     *
+     * @param int $id
+     * @param mixed $value
+     * @param string $name
+     * @param array $options
+     * @param array $fields
+     * @param array $pod
+     *
+     * @since 2.0
+     */
+    public function ui ( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
+        if ( 'link' == pods_var( self::$type . '_format_type', $options ) && 0 < strlen( pods_var( self::$type . '_format', $options ) ) )
+            $value = make_clickable( $value );
+
+        return $value;
+    }
+
+    /**
+     * Validate an URL with the options
+     *
+     * @param string $value
+     * @param array $options
+     *
+     * @since 2.0
+     */
+    public function validate_url( $value, $options = null ) {
+        if ( empty( $value ) )
+            return $value;
+        
+        if ( 'none' != pods_var( self::$type . '_format', $options ) ) {
+            
+            if ( is_array( $value ) ) {
+                if ( isset( $value[ 'scheme' ] ) )
+                    $value = $this->build_url( $value );
+                else
+                    $value = implode( '', $value );
+            }
+    
+            if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
+                $value = 'http://' . $value;
+    
+            $url = @parse_url( $value );
+    
+            if ( empty( $url ) || count( $url ) < 2 )
+                $value = '';
+            else {
+                $defaults = array(
+                    'scheme' => 'http',
+                    'host' => '',
+                    'path' => '/',
+                    'query' => '',
+                    'fragment' => ''
+                );
+    
+                $url = array_merge( $defaults, $url );
+    
+                if ( 'normal' == pods_var( self::$type . '_format', $options ) )
+                    $value = $this->build_url( $url );
+                elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
+                    if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+                        $url[ 'host' ] = substr( $url[ 'host' ], 4 );
+    
+                    $value = $this->build_url( $url );
+                }
+                elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
+                    if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+                        $url[ 'host' ] = 'www.' . $url[ 'host' ];
+    
+                    $value = $this->build_url( $url );
+                }
+                elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
+                    $value = $this->build_url( $url );
+                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+    
+                    if ( '/' == $url[ 'path' ] )
+                        $value = trim( $value, '/' );
+                }
+                elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
+                    if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+                        $url[ 'host' ] = substr( $url[ 'host' ], 4 );
+    
+                    $value = $this->build_url( $url );
+                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+    
+                    if ( '/' == $url[ 'path' ] )
+                        $value = trim( $value, '/' );
+                }
+                elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
+                    if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+                        $url[ 'host' ] = 'www.' . $url[ 'host' ];
+    
+                    $value = $this->build_url( $url );
+                    $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+    
+                    if ( '/' == $url[ 'path' ] )
+                        $value = trim( $value, '/' );
+                }
+            }
+        } else {
+            $value = $this->strip_html( $value, $options );
+        }
+
+        $value = esc_url( $value );
+
+        return $value;
+    }
+
+    /**
+     * Validate an targit attribute with the options
+     *
+     * @param string $value
+     * @param array $options
+     *
+     * @since 2.0
+     */
+    public function validate_target( $value, $options = null ) {
+        if ( ! empty( $value ) && $value == '_blank' ) {
+            $value = '_blank';
+        } else {
+            $value = '';
+        }
+        return $value;
+    }
+
+    /**
+     * Build an url
+     *
+     * @param array|string $url
+     *
+     * @return string
+     */
+    public function build_url ( $url ) {
+        if ( function_exists( 'http_build_url' ) )
+            return http_build_url( $url );
+
+        $defaults = array(
+            'scheme' => 'http',
+            'host' => '',
+            'path' => '/',
+            'query' => '',
+            'fragment' => ''
+        );
+
+        $url = array_merge( $defaults, (array) $url );
+
+        $new_url = trim( $url[ 'scheme' ] . '://', ':' ) . $url[ 'host' ] . '/' . ltrim( $url[ 'path' ], '/' );
+
+        if ( !empty( $url[ 'query' ] ) )
+            $new_url .= '?' . ltrim( $url[ 'query' ], '?' );
+
+        if ( !empty( $url[ 'fragment' ] ) )
+            $new_url .= '#' . ltrim( $url[ 'fragment' ], '#' );
+
+        return $new_url;
+    }
+	
+
+    /**
+     * Strip HTML based on options
+     *
+     * @param string $value
+     * @param array $options
+     *
+     * @return string
+     */
+    public function strip_html ( $value, $options = null ) {
+        if ( is_array( $value ) )
+            $value = @implode( ' ', $value );
+
+        $value = trim( $value );
+
+        if ( empty( $value ) )
+            return $value;
+
+        $options = (array) $options;
+
+        if ( 1 == pods_var( self::$type . '_allow_html', $options, 0, null, true ) ) {
+            $allowed_html_tags = '';
+
+            if ( 0 < strlen( pods_var( self::$type . '_allowed_html_tags', $options ) ) ) {
+                $allowed_html_tags = explode( ' ', trim( pods_var( self::$type . '_allowed_html_tags', $options ) ) );
+                $allowed_html_tags = '<' . implode( '><', $allowed_html_tags ) . '>';
+            }
+
+            if ( !empty( $allowed_html_tags ) && '<>' != $allowed_html_tags )
+                $value = strip_tags( $value, $allowed_html_tags );
+        }
+        else
+            $value = strip_tags( $value );
+
+        return $value;
+    }
+
+}

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -56,15 +56,6 @@ class PodsField_Link extends PodsField_Website {
 	 */
 	public function options () {
 		$options = array(
-			self::$type . '_repeatable' => array(
-				'label' => __( 'Repeatable Field', 'pods' ),
-				'default' => 0,
-				'type' => 'boolean',
-				'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
-				'boolean_yes_label' => '',
-				'dependency' => true,
-				'developer_mode' => true
-			),
 			self::$type . '_format' => array(
 				'label' => __( 'Format', 'pods' ),
 				'default' => 'normal',
@@ -79,8 +70,14 @@ class PodsField_Link extends PodsField_Website {
 					'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
 				)
 			),
+			self::$type . '_select_existing' => array(
+				'label' => __( 'Enable Selecting from Existing Links?', 'pods' ),
+				'default' => 1,
+				'type' => 'boolean',
+				'dependency' => true
+			),
 			'output_options' => array(
-				'label' => __( 'Output Options', 'pods' ),
+				'label' => __( 'Link Text Output Options', 'pods' ),
 				'group' => array(
 					self::$type . '_allow_shortcode' => array(
 						'label' => __( 'Allow Shortcodes?', 'pods' ),

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -2,7 +2,7 @@
 /**
  * @package Pods\Fields
  */
-class PodsField_Link extends PodsField {
+class PodsField_Link extends PodsField_Website {
 
     /**
      * Field Type Group
@@ -42,9 +42,9 @@ class PodsField_Link extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-		
+
     }
-	
+
     /**
      * Add options and set defaults to
      *
@@ -137,7 +137,7 @@ class PodsField_Link extends PodsField {
         $schema = 'LONGTEXT';
         return $schema;
     }
-    
+
 	/**
 	 * Change the value of the field
 	 *
@@ -153,7 +153,7 @@ class PodsField_Link extends PodsField {
 	public function value ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 		return $value;
 	}
-	
+
     /**
      * Change the way the value of the field is displayed with Pods::get
      *
@@ -175,7 +175,7 @@ class PodsField_Link extends PodsField {
 
         // Ensure proper format
         $value = $this->pre_save( $value, $id, $name, $options, null, $pod );
-        
+
         if ( isset( $value['url'] ) ) {
 
             $link = '<a href="%s"%s>%s</a>';
@@ -245,11 +245,11 @@ class PodsField_Link extends PodsField {
      */
     public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
         $errors = array();
-		
+
         $label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
 
         $check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
-		
+
         if ( is_array( $check['url'] ) )
             $errors = $check['url'];
         else {
@@ -263,7 +263,7 @@ class PodsField_Link extends PodsField {
 
         if ( !empty( $errors ) )
             return $errors;
-		
+
         return true;
     }
 
@@ -282,12 +282,12 @@ class PodsField_Link extends PodsField {
      */
     public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
         $options = (array) $options;
-		
+
 		// Start URL format
         if ( isset ($value['url']) ) {
 	       $value['url'] = $this->validate_url( $value['url'], $options );
         }
-		
+
 		// Start Title format
         if ( isset ($value['text']) ) {
             $value['text'] = $this->strip_html( $value['text'], $options );
@@ -297,10 +297,10 @@ class PodsField_Link extends PodsField {
         if ( isset ($value['target']) ) {
            $value['target'] = $this->validate_target( $value['target'], $options );
         }
-		
+
         return $value;
     }
-	
+
     /**
      * Customize the Pods UI manage table column output
      *
@@ -331,21 +331,21 @@ class PodsField_Link extends PodsField {
     public function validate_url( $value, $options = null ) {
         if ( empty( $value ) )
             return $value;
-        
+
         if ( 'none' != pods_var( self::$type . '_format', $options ) ) {
-            
+
             if ( is_array( $value ) ) {
                 if ( isset( $value[ 'scheme' ] ) )
                     $value = $this->build_url( $value );
                 else
                     $value = implode( '', $value );
             }
-    
+
             if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
                 $value = 'http://' . $value;
-    
+
             $url = @parse_url( $value );
-    
+
             if ( empty( $url ) || count( $url ) < 2 )
                 $value = '';
             else {
@@ -356,47 +356,47 @@ class PodsField_Link extends PodsField {
                     'query' => '',
                     'fragment' => ''
                 );
-    
+
                 $url = array_merge( $defaults, $url );
-    
+
                 if ( 'normal' == pods_var( self::$type . '_format', $options ) )
                     $value = $this->build_url( $url );
                 elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
                     if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
                         $url[ 'host' ] = substr( $url[ 'host' ], 4 );
-    
+
                     $value = $this->build_url( $url );
                 }
                 elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
                     if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
                         $url[ 'host' ] = 'www.' . $url[ 'host' ];
-    
+
                     $value = $this->build_url( $url );
                 }
                 elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
                     $value = $this->build_url( $url );
                     $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-    
+
                     if ( '/' == $url[ 'path' ] )
                         $value = trim( $value, '/' );
                 }
                 elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
                     if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
                         $url[ 'host' ] = substr( $url[ 'host' ], 4 );
-    
+
                     $value = $this->build_url( $url );
                     $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-    
+
                     if ( '/' == $url[ 'path' ] )
                         $value = trim( $value, '/' );
                 }
                 elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
                     if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
                         $url[ 'host' ] = 'www.' . $url[ 'host' ];
-    
+
                     $value = $this->build_url( $url );
                     $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-    
+
                     if ( '/' == $url[ 'path' ] )
                         $value = trim( $value, '/' );
                 }
@@ -427,38 +427,6 @@ class PodsField_Link extends PodsField {
         return $value;
     }
 
-    /**
-     * Build an url
-     *
-     * @param array|string $url
-     *
-     * @return string
-     */
-    public function build_url ( $url ) {
-        if ( function_exists( 'http_build_url' ) )
-            return http_build_url( $url );
-
-        $defaults = array(
-            'scheme' => 'http',
-            'host' => '',
-            'path' => '/',
-            'query' => '',
-            'fragment' => ''
-        );
-
-        $url = array_merge( $defaults, (array) $url );
-
-        $new_url = trim( $url[ 'scheme' ] . '://', ':' ) . $url[ 'host' ] . '/' . ltrim( $url[ 'path' ], '/' );
-
-        if ( !empty( $url[ 'query' ] ) )
-            $new_url .= '?' . ltrim( $url[ 'query' ], '?' );
-
-        if ( !empty( $url[ 'fragment' ] ) )
-            $new_url .= '#' . ltrim( $url[ 'fragment' ], '#' );
-
-        return $new_url;
-    }
-	
 
     /**
      * Strip HTML based on options

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -43,7 +43,7 @@ class PodsField_Link extends PodsField_Website {
 	 *
 	 * @since 2.0
 	 */
-	public function __construct () {
+	public function __construct() {
 
 	}
 
@@ -54,50 +54,51 @@ class PodsField_Link extends PodsField_Website {
 	 *
 	 * @since 2.0
 	 */
-	public function options () {
+	public function options() {
+
 		$options = array(
-			self::$type . '_format' => array(
-				'label' => __( 'Format', 'pods' ),
+			self::$type . '_format'            => array(
+				'label'   => __( 'Format', 'pods' ),
 				'default' => 'normal',
-				'type' => 'pick',
-				'data' => array(
-					'none' => __( 'No URL format restrictions', 'pods' ),
-					'normal' => __( 'http://example.com/', 'pods' ),
-					'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
-					'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
-					'no-http' => __( 'example.com', 'pods' ),
-					'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
+				'type'    => 'pick',
+				'data'    => array(
+					'none'              => __( 'No URL format restrictions', 'pods' ),
+					'normal'            => __( 'http://example.com/', 'pods' ),
+					'no-www'            => __( 'http://example.com/ (remove www)', 'pods' ),
+					'force-www'         => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
+					'no-http'           => __( 'example.com', 'pods' ),
+					'no-http-no-www'    => __( 'example.com (force removal of www)', 'pods' ),
 					'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
 				)
 			),
-			self::$type . '_select_existing' => array(
-				'label' => __( 'Enable Selecting from Existing Links?', 'pods' ),
-				'default' => 1,
-				'type' => 'boolean',
+			self::$type . '_select_existing'   => array(
+				'label'      => __( 'Enable Selecting from Existing Links?', 'pods' ),
+				'default'    => 1,
+				'type'       => 'boolean',
 				'dependency' => true
 			),
-			'output_options' => array(
+			'output_options'                   => array(
 				'label' => __( 'Link Text Output Options', 'pods' ),
 				'group' => array(
 					self::$type . '_allow_shortcode' => array(
-						'label' => __( 'Allow Shortcodes?', 'pods' ),
-						'default' => 0,
-						'type' => 'boolean',
+						'label'      => __( 'Allow Shortcodes?', 'pods' ),
+						'default'    => 0,
+						'type'       => 'boolean',
 						'dependency' => true
 					),
-					self::$type . '_allow_html' => array(
-						'label' => __( 'Allow HTML?', 'pods' ),
-						'default' => 0,
-						'type' => 'boolean',
+					self::$type . '_allow_html'      => array(
+						'label'      => __( 'Allow HTML?', 'pods' ),
+						'default'    => 0,
+						'type'       => 'boolean',
 						'dependency' => true
 					)
 				)
 			),
 			self::$type . '_allowed_html_tags' => array(
-				'label' => __( 'Allowed HTML Tags', 'pods' ),
+				'label'      => __( 'Allowed HTML Tags', 'pods' ),
 				'depends-on' => array( self::$type . '_allow_html' => true ),
-				'default' => 'strong em a ul ol li b i',
-				'type' => 'text'
+				'default'    => 'strong em a ul ol li b i',
+				'type'       => 'text'
 			),
 			/*self::$type . '_max_length' => array(
 				'label' => __( 'Maximum Length', 'pods' ),
@@ -105,10 +106,10 @@ class PodsField_Link extends PodsField_Website {
 				'type' => 'number',
 				'help' => __( 'Set to -1 for no limit', 'pods' )
 			),*/
-			self::$type . '_html5' => array(
-				'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
+			self::$type . '_html5'             => array(
+				'label'   => __( 'Enable HTML5 Input Field?', 'pods' ),
 				'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
-				'type' => 'boolean'
+				'type'    => 'boolean'
 			)/*,
 			self::$type . '_size' => array(
 				'label' => __( 'Field Size', 'pods' ),
@@ -121,7 +122,9 @@ class PodsField_Link extends PodsField_Website {
 				)
 			)*/
 		);
+
 		return $options;
+
 	}
 
 	/**
@@ -132,40 +135,45 @@ class PodsField_Link extends PodsField_Website {
 	 * @return array
 	 * @since 2.0
 	 */
-	public function schema ( $options = null ) {
+	public function schema( $options = null ) {
+
 		$schema = 'LONGTEXT';
+
 		return $schema;
+
 	}
 
 	/**
 	 * Change the value of the field
 	 *
-	 * @param mixed $value
+	 * @param mixed  $value
 	 * @param string $name
-	 * @param array $options
-	 * @param array $pod
-	 * @param int $id
+	 * @param array  $options
+	 * @param array  $pod
+	 * @param int    $id
 	 *
 	 * @return mixed|null|string
 	 * @since 2.3
 	 */
-	public function value ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+	public function value( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+
 		return $value;
+
 	}
 
 	/**
 	 * Change the way the value of the field is displayed with Pods::get
 	 *
-	 * @param mixed $value
+	 * @param mixed  $value
 	 * @param string $name
-	 * @param array $options
-	 * @param array $pod
-	 * @param int $id
+	 * @param array  $options
+	 * @param array  $pod
+	 * @param int    $id
 	 *
 	 * @return mixed|null|string
 	 * @since 2.0
 	 */
-	public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
 		// Validate for an array because display is also used for the get_post_meta filters along the function chain
 		if ( ! is_array( $value ) ) {
@@ -215,39 +223,43 @@ class PodsField_Link extends PodsField_Website {
 
 		// Return database value or display value if above conditions are met
 		return $value;
+
 	}
 
 	/**
 	 * Customize output of the form field
 	 *
 	 * @param string $name
-	 * @param mixed $value
-	 * @param array $options
-	 * @param array $pod
-	 * @param int $id
+	 * @param mixed  $value
+	 * @param array  $options
+	 * @param array  $pod
+	 * @param int    $id
 	 *
 	 * @since 2.0
 	 */
-	public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
-		$options = (array) $options;
+	public function input( $name, $value = null, $options = null, $pod = null, $id = null ) {
+
+		$options         = (array) $options;
 		$form_field_type = PodsForm::$field_type;
-		$field_type = 'link';
+		$field_type      = 'link';
 		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
+
 	}
 
 	/**
 	 * Validate a value before it's saved
 	 *
-	 * @param mixed $value
+	 * @param mixed  $value
 	 * @param string $name
-	 * @param array $options
-	 * @param array $fields
-	 * @param array $pod
-	 * @param int $id
+	 * @param array  $options
+	 * @param array  $fields
+	 * @param array  $pod
+	 * @param int    $id
 	 *
 	 * @since 2.0
 	 */
-	public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+
 		$errors = array();
 
 		$label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
@@ -256,37 +268,41 @@ class PodsField_Link extends PodsField_Website {
 
 		$check = $check['url'];
 
-		if ( is_array( $check ) )
+		if ( is_array( $check ) ) {
 			$errors = $check;
-		else {
+		} else {
 			if ( ! empty( $value['url'] ) && 0 < strlen( $value['url'] ) && strlen( $check ) < 1 ) {
-				if ( 1 == pods_var( 'required', $options ) )
+				if ( 1 == pods_var( 'required', $options ) ) {
 					$errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
-				else
+				} else {
 					$errors[] = sprintf( __( 'Invalid link provided for the field %s.', 'pods' ), $label );
+				}
 			}
 		}
 
-		if ( !empty( $errors ) )
+		if ( ! empty( $errors ) ) {
 			return $errors;
+		}
 
 		return true;
+
 	}
 
 	/**
 	 * Change the value or perform actions after validation but before saving to the DB
 	 *
-	 * @param mixed $value
-	 * @param int $id
+	 * @param mixed  $value
+	 * @param int    $id
 	 * @param string $name
-	 * @param array $options
-	 * @param array $fields
-	 * @param array $pod
+	 * @param array  $options
+	 * @param array  $fields
+	 * @param array  $pod
 	 * @param object $params
 	 *
 	 * @since 2.0
 	 */
-	public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
+	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
+
 		$options = (array) $options;
 
 		$value = array_merge( (array) $value, array( 'url' => '', 'text' => '', 'target' => '' ) );
@@ -307,6 +323,7 @@ class PodsField_Link extends PodsField_Website {
 		}
 
 		return $value;
+
 	}
 
 }

--- a/classes/fields/website.php
+++ b/classes/fields/website.php
@@ -4,322 +4,256 @@
  */
 class PodsField_Website extends PodsField {
 
-    /**
-     * Field Type Group
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $group = 'Text';
+	/**
+	 * Field Type Group
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $group = 'Text';
 
-    /**
-     * Field Type Identifier
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $type = 'website';
+	/**
+	 * Field Type Identifier
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $type = 'website';
 
-    /**
-     * Field Type Label
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $label = 'Website';
+	/**
+	 * Field Type Label
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $label = 'Website';
 
-    /**
-     * Field Type Preparation
-     *
-     * @var string
-     * @since 2.0
-     */
-    public static $prepare = '%s';
+	/**
+	 * Field Type Preparation
+	 *
+	 * @var string
+	 * @since 2.0
+	 */
+	public static $prepare = '%s';
 
-    /**
-     * Do things like register/enqueue scripts and stylesheets
-     *
-     * @since 2.0
-     */
-    public function __construct () {
+	/**
+	 * Do things like register/enqueue scripts and stylesheets
+	 *
+	 * @since 2.0
+	 */
+	public function __construct () {
 
-    }
+	}
 
-    /**
-     * Add options and set defaults to
-     *
-     * @param array $options
-     *
-     * @since 2.0
-     */
-    public function options () {
-        $options = array(
-            self::$type . '_repeatable' => array(
-                'label' => __( 'Repeatable Field', 'pods' ),
-                'default' => 0,
-                'type' => 'boolean',
-                'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
-                'boolean_yes_label' => '',
-                'dependency' => true,
-                'developer_mode' => true
-            ),
-            self::$type . '_format' => array(
-                'label' => __( 'Format', 'pods' ),
-                'default' => 'normal',
-                'type' => 'pick',
-                'data' => array(
-                    'normal' => __( 'http://example.com/', 'pods' ),
-                    'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
-                    'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
-                    'no-http' => __( 'example.com', 'pods' ),
-                    'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
-                    'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
-                )
-            ),
-            self::$type . '_clickable' => array(
-                'label' => __( 'Output as a link?', 'pods' ),
-                'default' => apply_filters( 'pods_form_ui_field_website_clickable', 0, self::$type ),
-                'type' => 'boolean',
-                'dependency' => true,
-            ),
-            self::$type . '_new_window' => array(
-                'label' => __( 'Open link in new window?', 'pods' ),
-                'default' => apply_filters( 'pods_form_ui_field_website_new_window', 0, self::$type ),
-                'type' => 'boolean',
-                'depends-on' => array( self::$type . '_clickable' => true ),
-            ),
-            self::$type . '_max_length' => array(
-                'label' => __( 'Maximum Length', 'pods' ),
-                'default' => 255,
-                'type' => 'number',
-                'help' => __( 'Set to -1 for no limit', 'pods' )
-            ),
-            self::$type . '_html5' => array(
-                'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
-                'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
-                'type' => 'boolean'
-            )/*,
-            self::$type . '_size' => array(
-                'label' => __( 'Field Size', 'pods' ),
-                'default' => 'medium',
-                'type' => 'pick',
-                'data' => array(
-                    'small' => __( 'Small', 'pods' ),
-                    'medium' => __( 'Medium', 'pods' ),
-                    'large' => __( 'Large', 'pods' )
-                )
-            )*/
-        );
-        return $options;
-    }
+	/**
+	 * Add options and set defaults to
+	 *
+	 * @param array $options
+	 *
+	 * @since 2.0
+	 */
+	public function options () {
+		$options = array(
+			self::$type . '_repeatable' => array(
+				'label' => __( 'Repeatable Field', 'pods' ),
+				'default' => 0,
+				'type' => 'boolean',
+				'help' => __( 'Making a field repeatable will add controls next to the field which allows users to Add/Remove/Reorder additional values. These values are saved in the database as an array, so searching and filtering by them may require further adjustments".', 'pods' ),
+				'boolean_yes_label' => '',
+				'dependency' => true,
+				'developer_mode' => true
+			),
+			self::$type . '_format' => array(
+				'label' => __( 'Format', 'pods' ),
+				'default' => 'normal',
+				'type' => 'pick',
+				'data' => array(
+					'normal' => __( 'http://example.com/', 'pods' ),
+					'no-www' => __( 'http://example.com/ (remove www)', 'pods' ),
+					'force-www' => __( 'http://www.example.com/ (force www if no sub-domain provided)', 'pods' ),
+					'no-http' => __( 'example.com', 'pods' ),
+					'no-http-no-www' => __( 'example.com (force removal of www)', 'pods' ),
+					'no-http-force-www' => __( 'www.example.com (force www if no sub-domain provided)', 'pods' )
+				)
+			),
+			self::$type . '_clickable' => array(
+				'label' => __( 'Output as a link?', 'pods' ),
+				'default' => apply_filters( 'pods_form_ui_field_website_clickable', 0, self::$type ),
+				'type' => 'boolean',
+				'dependency' => true,
+			),
+			self::$type . '_new_window' => array(
+				'label' => __( 'Open link in new window?', 'pods' ),
+				'default' => apply_filters( 'pods_form_ui_field_website_new_window', 0, self::$type ),
+				'type' => 'boolean',
+				'depends-on' => array( self::$type . '_clickable' => true ),
+			),
+			self::$type . '_max_length' => array(
+				'label' => __( 'Maximum Length', 'pods' ),
+				'default' => 255,
+				'type' => 'number',
+				'help' => __( 'Set to -1 for no limit', 'pods' )
+			),
+			self::$type . '_html5' => array(
+				'label' => __( 'Enable HTML5 Input Field?', 'pods' ),
+				'default' => apply_filters( 'pods_form_ui_field_html5', 0, self::$type ),
+				'type' => 'boolean'
+			)/*,
+			self::$type . '_size' => array(
+				'label' => __( 'Field Size', 'pods' ),
+				'default' => 'medium',
+				'type' => 'pick',
+				'data' => array(
+					'small' => __( 'Small', 'pods' ),
+					'medium' => __( 'Medium', 'pods' ),
+					'large' => __( 'Large', 'pods' )
+				)
+			)*/
+		);
+		return $options;
+	}
 
-    /**
-     * Define the current field's schema for DB table storage
-     *
-     * @param array $options
-     *
-     * @return array
-     * @since 2.0
-     */
-    public function schema ( $options = null ) {
-        $length = (int) pods_var( self::$type . '_max_length', $options, 255 );
+	/**
+	 * Define the current field's schema for DB table storage
+	 *
+	 * @param array $options
+	 *
+	 * @return array
+	 * @since 2.0
+	 */
+	public function schema ( $options = null ) {
+		$length = (int) pods_var( self::$type . '_max_length', $options, 255 );
 
-        $schema = 'VARCHAR(' . $length . ')';
+		$schema = 'VARCHAR(' . $length . ')';
 
-        if ( 255 < $length || $length < 1 )
-            $schema = 'LONGTEXT';
+		if ( 255 < $length || $length < 1 )
+			$schema = 'LONGTEXT';
 
-        return $schema;
-    }
+		return $schema;
+	}
 
-    /**
-     * Change the way the value of the field is displayed with Pods::get
-     *
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $pod
-     * @param int $id
-     *
-     * @return mixed|null
-     * @since 2.0
-     */
-    public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
-        // Ensure proper format
-        $value = $this->pre_save( $value, $id, $name, $options, null, $pod );
+	/**
+	 * Change the way the value of the field is displayed with Pods::get
+	 *
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @return mixed|null
+	 * @since 2.0
+	 */
+	public function display ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
+		// Ensure proper format
+		$value = $this->pre_save( $value, $id, $name, $options, null, $pod );
 
-        if ( 1 == pods_v( self::$type . '_clickable', $options ) && 0 < strlen( $value ) ) {
-            $link = '<a href="%s"%s>%s</a>';
+		if ( 1 == pods_v( self::$type . '_clickable', $options ) && 0 < strlen( $value ) ) {
+			$link = '<a href="%s"%s>%s</a>';
 
-            $atts = '';
+			$atts = '';
 
-            if ( 1 == pods_v( self::$type . '_new_window', $options ) ) {
-            	$atts .= ' target="_blank"';
-            }
+			if ( 1 == pods_v( self::$type . '_new_window', $options ) ) {
+				$atts .= ' target="_blank"';
+			}
 
-            $value = sprintf( $link, esc_url( $value ), $atts, esc_html( $value ) );
-        }
+			$value = sprintf( $link, esc_url( $value ), $atts, esc_html( $value ) );
+		}
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Customize output of the form field
-     *
-     * @param string $name
-     * @param mixed $value
-     * @param array $options
-     * @param array $pod
-     * @param int $id
-     *
-     * @since 2.0
-     */
-    public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
-        $options = (array) $options;
-        $form_field_type = PodsForm::$field_type;
+	/**
+	 * Customize output of the form field
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @since 2.0
+	 */
+	public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
+		$options = (array) $options;
+		$form_field_type = PodsForm::$field_type;
 
-        if ( is_array( $value ) )
-            $value = implode( ' ', $value );
+		if ( is_array( $value ) )
+			$value = implode( ' ', $value );
 
-        $field_type = 'website';
+		$field_type = 'website';
 
-        if ( isset( $options[ 'name' ] ) && false === PodsForm::permission( self::$type, $options[ 'name' ], $options, null, $pod, $id ) ) {
-            if ( pods_var( 'read_only', $options, false ) ) {
-                $options[ 'readonly' ] = true;
+		if ( isset( $options[ 'name' ] ) && false === PodsForm::permission( self::$type, $options[ 'name' ], $options, null, $pod, $id ) ) {
+			if ( pods_var( 'read_only', $options, false ) ) {
+				$options[ 'readonly' ] = true;
 
-                $field_type = 'text';
-            }
-            else
-                return;
-        }
-        elseif ( !pods_has_permissions( $options ) && pods_var( 'read_only', $options, false ) ) {
-            $options[ 'readonly' ] = true;
+				$field_type = 'text';
+			}
+			else
+				return;
+		}
+		elseif ( !pods_has_permissions( $options ) && pods_var( 'read_only', $options, false ) ) {
+			$options[ 'readonly' ] = true;
 
-            $field_type = 'text';
-        }
+			$field_type = 'text';
+		}
 
-        pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
-    }
+		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
+	}
 
-    /**
-     * Validate a value before it's saved
-     *
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     * @param int $id
-     *
-     * @since 2.0
-     */
-    public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
-        $errors = array();
+	/**
+	 * Validate a value before it's saved
+	 *
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @since 2.0
+	 */
+	public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+		$errors = array();
 
-        $label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
+		$label = strip_tags( pods_var_raw( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) ) );
 
-        $check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
+		$check = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
 
-        if ( is_array( $check ) )
-            $errors = $check;
-        else {
-            if ( 0 < strlen( $value ) && strlen( $check ) < 1 ) {
-                if ( 1 == pods_var( 'required', $options ) )
-                    $errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
-                else
-                    $errors[] = sprintf( __( 'Invalid website provided for the field %s.', 'pods' ), $label );
-            }
-        }
+		if ( is_array( $check ) )
+			$errors = $check;
+		else {
+			if ( 0 < strlen( $value ) && strlen( $check ) < 1 ) {
+				if ( 1 == pods_var( 'required', $options ) )
+					$errors[] = sprintf( __( 'The %s field is required.', 'pods' ), $label );
+				else
+					$errors[] = sprintf( __( 'Invalid website provided for the field %s.', 'pods' ), $label );
+			}
+		}
 
-        if ( !empty( $errors ) )
-            return $errors;
+		if ( !empty( $errors ) )
+			return $errors;
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Change the value or perform actions after validation but before saving to the DB
-     *
-     * @param mixed $value
-     * @param int $id
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     * @param object $params
-     *
-     * @since 2.0
-     */
-    public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
-        $options = (array) $options;
+	/**
+	 * Change the value or perform actions after validation but before saving to the DB
+	 *
+	 * @param mixed $value
+	 * @param int $id
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 * @param object $params
+	 *
+	 * @since 2.0
+	 */
+	public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
+		$options = (array) $options;
 
-        if ( is_array( $value ) ) {
-            if ( isset( $value[ 'scheme' ] ) )
-                $value = $this->build_url( $value );
-            else
-                $value = implode( '', $value );
-        }
-
-        if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
-            $value = 'http://' . $value;
-
-        $url = @parse_url( $value );
-
-        if ( empty( $url ) || count( $url ) < 2 )
-            $value = '';
-        else {
-            $defaults = array(
-                'scheme' => 'http',
-                'host' => '',
-                'path' => '/',
-                'query' => '',
-                'fragment' => ''
-            );
-
-            $url = array_merge( $defaults, $url );
-
-            if ( 'normal' == pods_var( self::$type . '_format', $options ) )
-                $value = $this->build_url( $url );
-            elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
-                if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
-                    $url[ 'host' ] = substr( $url[ 'host' ], 4 );
-
-                $value = $this->build_url( $url );
-            }
-            elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
-                if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
-                    $url[ 'host' ] = 'www.' . $url[ 'host' ];
-
-                $value = $this->build_url( $url );
-            }
-            elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
-                $value = $this->build_url( $url );
-                $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-
-                if ( '/' == $url[ 'path' ] )
-                    $value = trim( $value, '/' );
-            }
-            elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
-                if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
-                    $url[ 'host' ] = substr( $url[ 'host' ], 4 );
-
-                $value = $this->build_url( $url );
-                $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-
-                if ( '/' == $url[ 'path' ] )
-                    $value = trim( $value, '/' );
-            }
-            elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
-                if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
-                    $url[ 'host' ] = 'www.' . $url[ 'host' ];
-
-                $value = $this->build_url( $url );
-                $value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
-
-                if ( '/' == $url[ 'path' ] )
-                    $value = trim( $value, '/' );
-            }
-        }
+		$value = $this->validate_url( $value, $options );
 
 		$length = (int) pods_var( self::$type . '_max_length', $options, 255 );
 
@@ -327,56 +261,201 @@ class PodsField_Website extends PodsField {
 			$value = pods_mb_substr( $value, 0, $length );
 		}
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Customize the Pods UI manage table column output
-     *
-     * @param int $id
-     * @param mixed $value
-     * @param string $name
-     * @param array $options
-     * @param array $fields
-     * @param array $pod
-     *
-     * @since 2.0
-     */
-    public function ui ( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
-        $value = $this->display( $value, $name, $options, $pod, $id );
+	/**
+	 * Customize the Pods UI manage table column output
+	 *
+	 * @param int $id
+	 * @param mixed $value
+	 * @param string $name
+	 * @param array $options
+	 * @param array $fields
+	 * @param array $pod
+	 *
+	 * @since 2.0
+	 */
+	public function ui ( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
+		$value = $this->display( $value, $name, $options, $pod, $id );
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Build an url
-     *
-     * @param array|string $url
-     *
-     * @return string
-     */
-    public function build_url ( $url ) {
-        if ( function_exists( 'http_build_url' ) )
-            return http_build_url( $url );
+	/**
+	 * Validate an URL with the options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @since 2.7
+	 */
+	public function validate_url( $value, $options = null ) {
+		if ( empty( $value ) )
+			return $value;
 
-        $defaults = array(
-            'scheme' => 'http',
-            'host' => '',
-            'path' => '/',
-            'query' => '',
-            'fragment' => ''
-        );
+		if ( 'none' != pods_var( self::$type . '_format', $options ) ) {
+			if ( is_array( $value ) ) {
+				if ( isset( $value[ 'scheme' ] ) )
+					$value = $this->build_url( $value );
+				else
+					$value = implode( '', $value );
+			}
 
-        $url = array_merge( $defaults, (array) $url );
+			if ( false === strpos( $value, '://' ) && 0 !== strpos( $value, '//' ) )
+				$value = 'http://' . $value;
 
-        $new_url = trim( $url[ 'scheme' ] . '://', ':' ) . $url[ 'host' ] . '/' . ltrim( $url[ 'path' ], '/' );
+			$url = @parse_url( $value );
 
-        if ( !empty( $url[ 'query' ] ) )
-            $new_url .= '?' . ltrim( $url[ 'query' ], '?' );
+			if ( empty( $url ) || count( $url ) < 2 )
+				$value = '';
+			else {
+				$defaults = array(
+					'scheme' => 'http',
+					'host' => '',
+					'path' => '/',
+					'query' => '',
+					'fragment' => ''
+				);
 
-        if ( !empty( $url[ 'fragment' ] ) )
-            $new_url .= '#' . ltrim( $url[ 'fragment' ], '#' );
+				$url = array_merge( $defaults, $url );
 
-        return $new_url;
-    }
+				if ( 'normal' == pods_var( self::$type . '_format', $options ) )
+					$value = $this->build_url( $url );
+				elseif ( 'no-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+						$url[ 'host' ] = substr( $url[ 'host' ], 4 );
+
+					$value = $this->build_url( $url );
+				}
+				elseif ( 'force-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+						$url[ 'host' ] = 'www.' . $url[ 'host' ];
+
+					$value = $this->build_url( $url );
+				}
+				elseif ( 'no-http' == pods_var( self::$type . '_format', $options ) ) {
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+				elseif ( 'no-http-no-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( 0 === strpos( $url[ 'host' ], 'www.' ) )
+						$url[ 'host' ] = substr( $url[ 'host' ], 4 );
+
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+				elseif ( 'no-http-force-www' == pods_var( self::$type . '_format', $options ) ) {
+					if ( false !== strpos( $url[ 'host' ], '.' ) && false === strpos( $url[ 'host' ], '.', 1 ) )
+						$url[ 'host' ] = 'www.' . $url[ 'host' ];
+
+					$value = $this->build_url( $url );
+					$value = str_replace( trim( $url[ 'scheme' ] . '://', ':' ), '', $value );
+
+					if ( '/' == $url[ 'path' ] )
+						$value = trim( $value, '/' );
+				}
+			}
+		} else {
+			$value = $this->strip_html( $value, $options );
+		}
+
+		$value = esc_url( $value );
+
+		return $value;
+	}
+
+	/**
+	 * Strip HTML based on options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @return string
+	 *
+	 * @since 2.7
+	 */
+	public function strip_html ( $value, $options = null ) {
+		if ( is_array( $value ) )
+			$value = @implode( ' ', $value );
+
+		$value = trim( $value );
+
+		if ( empty( $value ) )
+			return $value;
+
+		$options = (array) $options;
+
+		if ( 1 == pods_var( self::$type . '_allow_html', $options, 0, null, true ) ) {
+			$allowed_html_tags = '';
+
+			if ( 0 < strlen( pods_var( self::$type . '_allowed_html_tags', $options ) ) ) {
+				$allowed_html_tags = explode( ' ', trim( pods_var( self::$type . '_allowed_html_tags', $options ) ) );
+				$allowed_html_tags = '<' . implode( '><', $allowed_html_tags ) . '>';
+			}
+
+			if ( !empty( $allowed_html_tags ) && '<>' != $allowed_html_tags )
+				$value = strip_tags( $value, $allowed_html_tags );
+		}
+		else
+			$value = strip_tags( $value );
+
+		return $value;
+	}
+
+	/**
+	 * Validate an target attribute with the options
+	 *
+	 * @param string $value
+	 * @param array $options
+	 *
+	 * @since 2.7
+	 */
+	public function validate_target( $value, $options = null ) {
+		if ( ! empty( $value ) && $value == '_blank' ) {
+			$value = '_blank';
+		} else {
+			$value = '';
+		}
+		return $value;
+	}
+
+	/**
+	 * Build an url
+	 *
+	 * @param array|string $url
+	 *
+	 * @return string
+	 */
+	public function build_url ( $url ) {
+		if ( function_exists( 'http_build_url' ) )
+			return http_build_url( $url );
+
+		$defaults = array(
+			'scheme' => 'http',
+			'host' => '',
+			'path' => '/',
+			'query' => '',
+			'fragment' => ''
+		);
+
+		$url = array_merge( $defaults, (array) $url );
+
+		$new_url = trim( $url[ 'scheme' ] . '://', ':' ) . $url[ 'host' ] . '/' . ltrim( $url[ 'path' ], '/' );
+
+		if ( !empty( $url[ 'query' ] ) )
+			$new_url .= '?' . ltrim( $url[ 'query' ], '?' );
+
+		if ( !empty( $url[ 'fragment' ] ) )
+			$new_url .= '#' . ltrim( $url[ 'fragment' ], '#' );
+
+		return $new_url;
+	}
+
 }

--- a/ui/css/pods-form.css
+++ b/ui/css/pods-form.css
@@ -64,6 +64,11 @@
     padding-top: 1px;
 }
 
+.pods-link-options {
+    padding: 5px 10px 10px;
+    border: 1px solid #dfdfdf;
+}
+
 .pods-pick-values {
     background: #fff;
     border: 1px solid #dfdfdf;

--- a/ui/fields-mv/js/pods-fields-ready.min.js
+++ b/ui/fields-mv/js/pods-fields-ready.min.js
@@ -33,7 +33,7 @@ var PodsUI = (function () {
   	model: FileUploadModel
   });
 
-  var fileUploadItem = "<input\n\tname=\"<%- attr.name %>[<%- id %>][id]\"\n\tdata-name-clean=\"<%- attr.name_clean %>-id\"\n\tid=\"<%- attr.id %>-<%- id %>-id\"\n\tclass=\"<%- attr.class %>\"\n\ttype=\"hidden\"\n\tvalue=\"<%- id %>\" />\n<ul class=\"pods-flex-meta media-item\">\n\t<% if ( 1 != options.file_limit ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-handle\"><span title=\""+pods_localized_strings.__reorder+"\">"+pods_localized_strings.__reorder+"</span></li>\n\t<% } %>\n\t<li class=\"pods-flex-col pods-flex-icon\"><img class=\"pinkynail\" src=\"<%- icon %>\" alt=\"Icon\"></li>\n\t<li class=\"pods-flex-col pods-flex-name\">\n\t\t<% if ( 0 != options.file_edit_title ) { %>\n\t\t\t<input\n\t\t\t\tname=\"<%- attr.name %>[<%- id %>][title]\"\n\t\t\t\tdata-name-clean=\"<%- attr.name_clean %>-title\"\n\t\t\t\tid=\"pods-form-ui-<%- attr.name_clean %>-<%- id %>-title\"\n\t\t\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-<%- attr.name_clean %>-title\"\n\t\t\t\ttype=\"text\"\n\t\t\t\tvalue=\"<%- name %>\"\n\t\t\t\ttabindex=\"2\"\n\t\t\t\tmaxlength=\"255\" />\n\t\t<% } else { %>\n\t\t\t<%- name %>\n\t\t<% } %>\n\t</li>\n\t<li class=\"pods-flex-col pods-flex-actions\"><ul><li class=\"pods-flex-col pods-flex-remove\"><a href=\"#remove\" title=\""+pods_localized_strings.__remove+"\">"+pods_localized_strings.__remove+"</a></li>\n\t<% if ( 1 == options.file_linked && '' != download ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-download\"><a href=\"<%- download %>\" target=\"_blank\" title=\""+pods_localized_strings.__download+"\" download>"+pods_localized_strings.__download+"</a></li>\n\t<% } %>\n\t<% if ( 1 == options.file_show_view_link && '' != link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-link\"><a href=\"<%- link %>\" target=\"_blank\" title=\""+pods_localized_strings.__view+"\">"+pods_localized_strings.__view+"</a></li>\n\t<% } %>\n\t<% if ( 1 == options.file_show_edit_link && '' != edit_link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-edit\"><a href=\"<%- edit_link %>\" target=\"_blank\" title=\""+pods_localized_strings.__edit+"\">"+pods_localized_strings.__edit+"</a></li></ul></li>\n\t<% } %>\n</ul>\n";
+  var fileUploadItem = "<input\n\tname=\"<%- attr.name %>[<%- id %>][id]\"\n\tdata-name-clean=\"<%- attr.name_clean %>-id\"\n\tid=\"<%- attr.id %>-<%- id %>-id\"\n\tclass=\"<%- attr.class %>\"\n\ttype=\"hidden\"\n\tvalue=\"<%- id %>\" />\n<ul class=\"pods-flex-meta media-item\">\n\t<% if ( 1 != options.file_limit ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-handle\"><span>Reorder</span></li>\n\t<% } %>\n\t<li class=\"pods-flex-col pods-flex-icon\"><img class=\"pinkynail\" src=\"<%- icon %>\" alt=\"Icon\"></li>\n\t<li class=\"pods-flex-col pods-flex-name\">\n\t\t<% if ( 0 != options.file_edit_title ) { %>\n\t\t\t<input\n\t\t\t\tname=\"<%- attr.name %>[<%- id %>][title]\"\n\t\t\t\tdata-name-clean=\"<%- attr.name_clean %>-title\"\n\t\t\t\tid=\"pods-form-ui-<%- attr.name_clean %>-<%- id %>-title\"\n\t\t\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-<%- attr.name_clean %>-title\"\n\t\t\t\ttype=\"text\"\n\t\t\t\tvalue=\"<%- name %>\"\n\t\t\t\ttabindex=\"2\"\n\t\t\t\tmaxlength=\"255\" />\n\t\t<% } else { %>\n\t\t\t<%- name %>\n\t\t<% } %>\n\t</li>\n\t<li class=\"pods-flex-col pods-flex-remove\"><a href=\"#remove\">Remove</a></li>\n\t<% if ( 1 == options.file_linked && '' != download ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-download\"><a href=\"<%- download %>\" target=\"_blank\">Download</a></li>\n\t<% } %>\n\t<% if ( 1 == options.file_show_view_link && '' != link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-link\"><a href=\"<%- link %>\" target=\"_blank\">View</a></li>\n\t<% } %>\n\t<% if ( 1 == options.file_show_edit_link && '' != edit_link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-edit\"><a href=\"<%- edit_link %>\" target=\"_blank\">Edit</a></li>\n\t<% } %>\n</ul>\n";
 
   /*global jQuery, _, Backbone, Mn */
 
@@ -346,7 +346,7 @@ var Queue = Object.freeze({
 
   					model.set({
   						progress: 0,
-  						errorMsg: pods_localized_strings.__there_was_an_issue_with_the_file_upload_please_try_again
+  						errorMsg: 'There was an issue with the file upload, please try again.'
   					});
   					return;
   				}
@@ -593,7 +593,7 @@ var Queue = Object.freeze({
   	},
 
   	initState: function initState() {
-  		var title = this.options.title || pods_localized_strings.__add_new_record;
+  		var title = this.options.title || 'Add New Record';
   		var src = this.options.src || '/';
 
   		this.states.add([new wp.media.controller.State({
@@ -761,7 +761,7 @@ var Queue = Object.freeze({
   	}
   });
 
-  var flexItem = "<input name=\"pods_meta_file_test[<%- attr.id %>][attr.id]\"\n\t\tdata-name-clean=\"pods-meta-file-test-id-id\"\n\t\tid=\"pods-form-ui-pods-meta-file-test-id-id\"\n\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-pods-meta-file-test-id-id\"\n\t\ttype=\"hidden\"\n\t\tvalue=\"<%- attr.id %>>\">\n<ul class=\"pods-flex-meta relationship-item\">\n\t<li class=\"pods-flex-col pods-flex-handle\"><span title=\""+pods_localized_strings.__reorder+"\">"+pods_localized_strings.__reorder+"</span></li>\n\t<% if ( 1 == options.pick_show_icon && '' != icon ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-icon\">\n\t\t\t<img class=\"pinkynail\" src=\"<%- icon %>\" alt=\"Icon\">\n\t\t</li>\n\t<% } %>\n\t<li class=\"pods-flex-col pods-flex-name\">\n\t\t<input name=\"pods_meta_file_test[<%- attr.id %>][title]\"\n\t\t\t\tdata-name-clean=\"pods-meta-file-test-id-title\"\n\t\t\t\tid=\"pods-form-ui-pods-meta-file-test-id-title\"\n\t\t\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-pods-meta-file-test-id-title\"\n\t\t\t\ttype=\"text\"\n\t\t\t\tvalue=\"<%= name %>\"\n\t\t\t\ttabindex=\"2\"\n\t\t\t\tmaxlength=\"255\">\n\t</li>\n\t<li class=\"pods-flex-col pods-flex-remove\"><a href=\"#remove\" title=\""+pods_localized_strings.__remove+"\">"+pods_localized_strings.__remove+"</a></li>\n\t<% if ( 1 == options.pick_show_view_link && '' != link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-link\"><a href=\"<%- link %>\" target=\"_blank\" title=\""+pods_localized_strings.__view+"\">"+pods_localized_strings.__view+"</a></li>\n\t<% } %>\n\t<% if ( 1 == options.pick_show_edit_link && '' != edit_link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-edit\"><a href=\"<%- edit_link %>\" target=\"_blank\" title=\""+pods_localized_strings.__edit+"\">"+pods_localized_strings.__edit+"</a></li>\n\t<% } %>\n</ul>\n";
+  var flexItem = "<input name=\"pods_meta_file_test[<%- attr.id %>][attr.id]\"\n\t\tdata-name-clean=\"pods-meta-file-test-id-id\"\n\t\tid=\"pods-form-ui-pods-meta-file-test-id-id\"\n\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-pods-meta-file-test-id-id\"\n\t\ttype=\"hidden\"\n\t\tvalue=\"<%- attr.id %>>\">\n<ul class=\"pods-flex-meta relationship-item\">\n\t<li class=\"pods-flex-col pods-flex-handle\"><span>Reorder</span></li>\n\t<% if ( 1 == options.pick_show_icon && '' != icon ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-icon\">\n\t\t\t<img class=\"pinkynail\" src=\"<%- icon %>\" alt=\"Icon\">\n\t\t</li>\n\t<% } %>\n\t<li class=\"pods-flex-col pods-flex-name\">\n\t\t<input name=\"pods_meta_file_test[<%- attr.id %>][title]\"\n\t\t\t\tdata-name-clean=\"pods-meta-file-test-id-title\"\n\t\t\t\tid=\"pods-form-ui-pods-meta-file-test-id-title\"\n\t\t\t\tclass=\"pods-form-ui-field-type-text pods-form-ui-field-name-pods-meta-file-test-id-title\"\n\t\t\t\ttype=\"text\"\n\t\t\t\tvalue=\"<%= name %>\"\n\t\t\t\ttabindex=\"2\"\n\t\t\t\tmaxlength=\"255\">\n\t</li>\n\t<li class=\"pods-flex-col pods-flex-remove\"><a href=\"#remove\">Remove</a></li>\n\t<% if ( 1 == options.pick_show_view_link && '' != link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-link\"><a href=\"<%- link %>\" target=\"_blank\">View</a></li>\n\t<% } %>\n\t<% if ( 1 == options.pick_show_edit_link && '' != edit_link ) { %>\n\t\t<li class=\"pods-flex-col pods-flex-edit\"><a href=\"<%- edit_link %>\" target=\"_blank\">Edit</a></li>\n\t<% } %>\n</ul>\n";
 
   /**
    *
@@ -830,7 +830,7 @@ var Queue = Object.freeze({
    */
   });
 
-  var addNew = "<a href=\"/wp-admin/?pods_modal=1\"\n\t\tclass=\"button pods-related-add-new pods-modal\"\n\t\tdata-pod-id=\"<%- options.pod_id %>\"\n\t\tdata-field-id=\"<%- options.id %>\"\n\t\tdata-item-id=\"<%- options.item_id %>\">\n\t"+pods_localized_strings.__add_new+"\n</a>";
+  var addNew = "<a href=\"/wp-admin/?pods_modal=1\"\n\t\tclass=\"button pods-related-add-new pods-modal\"\n\t\tdata-pod-id=\"<%- options.pod_id %>\"\n\t\tdata-field-id=\"<%- options.id %>\"\n\t\tdata-item-id=\"<%- options.item_id %>\">\n\tAdd New\n</a>";
 
   var AddNew = PodsFieldView.extend({
   	tagName: 'div',

--- a/ui/fields/link.php
+++ b/ui/fields/link.php
@@ -3,10 +3,12 @@
 wp_enqueue_script( 'wplink' );
 wp_enqueue_script( 'pods-link-picker', PODS_URL . 'ui/js/pods-link-picker.js', array( 'jquery' ), '1.0.0' );
 
+PodsForm::field_method( 'link', 'init_link_editor' );
+
 $url_attributes = array();
 $url_type = 'text';
 if ( 1 == pods_var( 'link_html5', $options ) ) {
-    $url_type = 'url';
+	$url_type = 'url';
 }
 $url_attributes[ 'type' ] = $url_type;
 $url_attributes[ 'class' ] = 'linkPickerUrl';
@@ -40,26 +42,26 @@ $target_attributes = PodsForm::merge_attributes( $target_attributes, $target_nam
 ?>
 
 <div class="pods-link-options">
-    <p class="howto"><?php _e('Enter the destination URL') ?></p>
-    <p>
-        <div class="alignleft">
-            <label><span><?php _e('URL') ?></span><input<?php PodsForm::attributes( $url_attributes, $url_name, $form_field_type, $options ); ?> /></label>
-        </div>
-        <div class="alignleft">
-            <label><span><?php _e('Link Text') ?></span><input<?php PodsForm::attributes( $text_attributes, $text_name, $form_field_type, $options ); ?> /></label>
-        </div>
-        <div class="link-target">
-            <label><div>&nbsp;</div><input<?php PodsForm::attributes( $target_attributes, $target_name, $form_field_type, $options ); ?> /> <?php _e('Open link in a new tab') ?></label>
-        </div>
-    </p>
-    <br clear="both">
+	<p class="howto"><?php _e('Enter the destination URL') ?></p>
+	<p>
+		<div class="alignleft">
+			<label><span><?php _e('URL') ?></span><input<?php PodsForm::attributes( $url_attributes, $url_name, $form_field_type, $options ); ?> /></label>
+		</div>
+		<div class="alignleft">
+			<label><span><?php _e('Link Text') ?></span><input<?php PodsForm::attributes( $text_attributes, $text_name, $form_field_type, $options ); ?> /></label>
+		</div>
+		<div class="link-target">
+			<label><div>&nbsp;</div><input<?php PodsForm::attributes( $target_attributes, $target_name, $form_field_type, $options ); ?> /> <?php _e('Open link in a new tab') ?></label>
+		</div>
+	</p>
+	<br clear="both">
 
-    <?php if ( 1 == pods_v( 'link_select_existing', $options, 1 ) ) { ?>
-        <div class="howto link-existing-content">
-            <a href="#" class="podsLinkPopup"><?php _e('Or link to existing content') ?></a>
-            <textarea id="podsLinkPopupDummyTextarea" disabled="disabled" style="display: none;"></textarea>
-        </div>
-    <?php } ?>
+	<?php if ( 1 == pods_v( 'link_select_existing', $options, 1 ) ) { ?>
+		<div class="howto link-existing-content">
+			<a href="#" class="podsLinkPopup"><?php _e('Or link to existing content') ?></a>
+			<textarea id="podsLinkPopupDummyTextarea" disabled="disabled" style="display: none;"></textarea>
+		</div>
+	<?php } ?>
 </div>
 
 <?php

--- a/ui/fields/link.php
+++ b/ui/fields/link.php
@@ -1,0 +1,63 @@
+<?php
+
+wp_enqueue_script( 'wplink' );
+wp_enqueue_script( 'pods-link-picker', PODS_URL . 'ui/js/pods-link-picker.js', array( 'jquery' ), '1.0.0' );
+
+$url_attributes = array();
+$url_type = 'text';
+if ( 1 == pods_var( 'link_html5', $options ) ) {
+    $url_type = 'url';
+}
+$url_attributes[ 'type' ] = $url_type;
+$url_attributes[ 'class' ] = 'linkPickerUrl';
+$url_attributes[ 'value' ] = (isset($value['url'])?$value['url']:'');
+$url_attributes[ 'tabindex' ] = 2;
+$url_name = $name.'[url]';
+$url_attributes = PodsForm::merge_attributes( $url_attributes, $url_name, $form_field_type, $options );
+
+$text_attributes = array();
+$text_type = 'text';
+$text_attributes[ 'type' ] = $text_type;
+$text_attributes[ 'class' ] = 'linkPickerText';
+$text_attributes[ 'value' ] = (isset($value['text'])?$value['text']:'');
+$text_attributes[ 'tabindex' ] = 2;
+$text_name = $name.'[text]';
+$text_attributes = PodsForm::merge_attributes( $text_attributes, $text_name, $form_field_type, $options );
+
+$target_attributes = array();
+$target_type = 'checkbox';
+$target_attributes[ 'type' ] = $target_type;
+$target_attributes[ 'class' ] = 'linkPickerTarget';
+$target_attributes[ 'value' ] = '_blank';
+$target_attributes[ 'tabindex' ] = 2;
+$target_attributes[ 'style' ] = 'display: inline-block;';
+if (isset($value['target']) && $value['target'] == '_blank') {
+	$target_attributes[ 'checked' ] = 'checked';
+}
+$target_name = $name.'[target]';
+$target_attributes = PodsForm::merge_attributes( $target_attributes, $target_name, $form_field_type, $options );
+
+?>
+
+<div class="pods-link-options">
+    <p class="howto"><?php _e('Enter the destination URL') ?></p>
+    <p>
+        <div class="alignleft">
+            <label><span><?php _e('URL') ?></span><input<?php PodsForm::attributes( $url_attributes, $url_name, $form_field_type, $options ); ?> /></label>
+        </div>
+        <div class="alignleft">
+            <label><span><?php _e('Link Text') ?></span><input<?php PodsForm::attributes( $text_attributes, $text_name, $form_field_type, $options ); ?> /></label>
+        </div>
+        <div class="link-target">
+            <label><div>&nbsp;</div><input<?php PodsForm::attributes( $target_attributes, $target_name, $form_field_type, $options ); ?> /> <?php _e('Open link in a new tab') ?></label>
+        </div>
+    </p>
+    <br clear="both">
+    <div class="howto link-existing-content">
+        <a href="#" class="podsLinkPopup"><?php _e('Or link to existing content') ?></a>
+        <textarea id="podsLinkPopupDummyTextarea" disabled="disabled" style="display: none;"></textarea>
+    </div>
+</div>
+
+<?php
+PodsForm::regex( $form_field_type, $options );

--- a/ui/fields/link.php
+++ b/ui/fields/link.php
@@ -53,10 +53,13 @@ $target_attributes = PodsForm::merge_attributes( $target_attributes, $target_nam
         </div>
     </p>
     <br clear="both">
-    <div class="howto link-existing-content">
-        <a href="#" class="podsLinkPopup"><?php _e('Or link to existing content') ?></a>
-        <textarea id="podsLinkPopupDummyTextarea" disabled="disabled" style="display: none;"></textarea>
-    </div>
+
+    <?php if ( 1 == pods_v( 'link_select_existing', $options, 1 ) ) { ?>
+        <div class="howto link-existing-content">
+            <a href="#" class="podsLinkPopup"><?php _e('Or link to existing content') ?></a>
+            <textarea id="podsLinkPopupDummyTextarea" disabled="disabled" style="display: none;"></textarea>
+        </div>
+    <?php } ?>
 </div>
 
 <?php

--- a/ui/js/pods-link-picker.js
+++ b/ui/js/pods-link-picker.js
@@ -1,0 +1,63 @@
+// JavaScript Document
+
+jQuery(document).ready(function($){
+	
+	// Variable to store the active link picker field
+	var activeLinkPicker;
+	
+	// Open wpLink modal
+	$('body').on('click', '.pods-field .podsLinkPopup', function (e) {
+		activeLinkPicker = $(this).parents('.pods-link-options');
+		$('body').addClass('modal-open-pods-field-link');
+		wpActiveEditor = true;
+		wpLink.open('podsLinkPopupDummyTextarea'); // Open modal in the dummy textarea
+		$('#wp-link #wp-link-url').val(activeLinkPicker.find('.linkPickerUrl').val());
+		$('#wp-link #wp-link-text').val(activeLinkPicker.find('.linkPickerText').val());
+		if (activeLinkPicker.find('.linkPickerTarget').is(':checked')) {
+			$('#wp-link #wp-link-target').prop('checked', true);
+		}
+		return false;
+	});
+	
+	// Save changes in the selected field
+	$('body').on('click', '#wp-link-submit', function(event) {
+		if ($('body').hasClass('modal-open-pods-field-link')) {
+			//get the href attribute and add to a textfield, or use as you see fit
+			//the links attributes (href, target) are stored in an object, which can be access via  wpLink.getAttrs()
+			var linkAtts = wpLink.getAttrs();
+			if (linkAtts.href != '') {
+				activeLinkPicker.find('.linkPickerUrl').val(linkAtts.href);
+			}
+			//get the target attribute
+			if (linkAtts.target == '_blank') {
+				activeLinkPicker.find('.linkPickerTarget').prop('checked', true);
+			} else {
+				activeLinkPicker.find('.linkPickerTarget').prop('checked', false);
+			}
+			//get the text attribute
+			var linkText = $('#wp-link #wp-link-text').val();
+			if (linkText != '') {
+				activeLinkPicker.find('.linkPickerText').val(linkText);
+			}
+		}
+		$('body').removeClass('modal-open-pods-field-link');
+		wpLink.textarea = $('body'); //to close the link dialogue, it is again expecting an wp_editor instance, so you need to give it something to set focus back to. In this case, I'm using body, but the textfield with the URL would be fine
+		wpLink.close();//close the dialogue
+		//trap any events
+		event.preventDefault ? event.preventDefault() : event.returnValue = false;
+		event.stopPropagation();
+		return false;
+	});
+	
+	// Close modal without any changes
+	$('body').on('click', '#wp-link-cancel, #wp-link-close', function(event) {
+		$('body').removeClass('modal-open-pods-field-link');
+		wpLink.textarea = $('body');
+		wpLink.close();
+		event.preventDefault ? event.preventDefault() : event.returnValue = false;
+		event.stopPropagation();
+		return false;
+	});	
+	
+});
+

--- a/ui/js/pods-link-picker.js
+++ b/ui/js/pods-link-picker.js
@@ -15,6 +15,8 @@ jQuery(document).ready(function($){
 		$('#wp-link #wp-link-text').val(activeLinkPicker.find('.linkPickerText').val());
 		if (activeLinkPicker.find('.linkPickerTarget').is(':checked')) {
 			$('#wp-link #wp-link-target').prop('checked', true);
+		} else {
+			$('#wp-link #wp-link-target').prop('checked', false);
 		}
 		return false;
 	});


### PR DESCRIPTION
See: https://github.com/pods-framework/pods/issues/2655
New PR for 2.7 (old: https://github.com/pods-framework/pods/pull/3588)

Adds a link field type with options to add a link with a title and
target.
Validation similar to website field.

UI has the option to open the WordPress link modal to search for
existing content and autofill the fields for this field.

pods_field_display() will show a formatted link.

![link field](https://cloud.githubusercontent.com/assets/826148/16306281/6d4d8064-395d-11e6-954e-dbadd605e5ab.png)

![link field-modal](https://cloud.githubusercontent.com/assets/826148/16306285/706e6b82-395d-11e6-8510-a7f624f862c2.png)
