### PR TITLE
WYSIWYG editor type option is used as dependency by the editor options

### DIFF
--- a/classes/fields/wysiwyg.php
+++ b/classes/fields/wysiwyg.php
@@ -74,7 +74,8 @@ class PodsField_WYSIWYG extends PodsField {
                             'tinymce' => __( 'TinyMCE (WP Default)', 'pods' ),
                             'cleditor' => __( 'CLEditor', 'pods' )
                         )
-                    )
+                    ),
+                'dependency' => true
             ),
             'editor_options' => array(
                 'label' => __( 'Editor Options', 'pods' ),


### PR DESCRIPTION
https://github.com/pods-framework/pods/pull/3610
https://github.com/pods-framework/pods/issues/3549