### PR TITLE
Allow extra meta/option boxes to be added in the pod-edit screens

### DIFF
--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -146,8 +146,10 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
  */
 do_action( 'pods_add_meta_boxes', '_pods_pod', $pod );
 
+$pod_post = get_post( $pod['id'] );
+
 /** This action is documented in wp-admin/edit-form-advanced.php */
-do_action( 'add_meta_boxes', '_pods_pod', get_post( $pod['id'] ) );
+do_action( 'add_meta_boxes', $pod_post->post_type, $pod_post );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -144,7 +144,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
  * @see https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes
  * @param array $pod The Pod object as an array
  */
-do_action( 'add_meta_boxes', 'pods_edit', $pod );
+do_action( 'pods_add_meta_boxes', '_pods_pod-edit-fields', $pod );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>
@@ -887,7 +887,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
             </div>
             <!-- /#submitdiv -->
             <div class="pods-submittable-fields">
-            <?php do_meta_boxes( 'pods_edit', 'side', $pod ); ?>
+            <?php do_meta_boxes( '_pods_pod-edit-fields', 'side', $pod ); ?>
             </div>
         </div>
     </div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -875,6 +875,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
                 </div>
             </div>
             <!-- /#submitdiv -->
+            <?php do_action( 'pods_admin_ui_setup_edit_meta_boxes', $pod, $obj ) ?>
         </div>
     </div>
 </div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -135,7 +135,15 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
         $no_additional[] = $field_type;
 }
 
-// Make use of the WP core meta box functionality
+/**
+ * Make use of the WP core meta box functionality
+ * 
+ * Currently only context 'side' is available
+ * 
+ * @since 2.7
+ * @see https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes
+ * @param array $pod The Pod object as an array
+ */
 do_action( 'add_meta_boxes', 'pods_edit', $pod );
 ?>
 <div class="wrap pods-admin">
@@ -878,7 +886,9 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
                 </div>
             </div>
             <!-- /#submitdiv -->
+            <div class="pods-submittable-fields">
             <?php do_meta_boxes( 'pods_edit', 'side', $pod ); ?>
+            </div>
         </div>
     </div>
 </div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -145,6 +145,9 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
  * @param array $pod The Pod object as an array
  */
 do_action( 'pods_add_meta_boxes', '_pods_pod', $pod );
+
+/** This action is documented in wp-admin/edit-form-advanced.php */
+do_action( 'add_meta_boxes', '_pods_pod', get_post( $pod['id'] ) );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -134,6 +134,9 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
     if ( empty( $field_type_fields ) )
         $no_additional[] = $field_type;
 }
+
+// Make use of the WP core meta box functionality
+do_action( 'add_meta_boxes' );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>
@@ -875,7 +878,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
                 </div>
             </div>
             <!-- /#submitdiv -->
-            <?php do_action( 'pods_admin_ui_setup_edit_meta_boxes', $pod, $obj ) ?>
+            <?php do_meta_boxes( 'pods_edit', 'side', $pod ); ?>
         </div>
     </div>
 </div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -136,7 +136,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
 }
 
 // Make use of the WP core meta box functionality
-do_action( 'add_meta_boxes' );
+do_action( 'add_meta_boxes', 'pods_edit', $pod );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -144,7 +144,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
  * @see https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes
  * @param array $pod The Pod object as an array
  */
-do_action( 'pods_add_meta_boxes', '_pods_pod-edit-fields', $pod );
+do_action( 'pods_add_meta_boxes', '_pods_pod', $pod );
 ?>
 <div class="wrap pods-admin">
 <div id="icon-pods" class="icon32"><br /></div>
@@ -887,7 +887,7 @@ if ( isset( $tabs[ 'extra-fields' ] ) ) {
             </div>
             <!-- /#submitdiv -->
             <div class="pods-submittable-fields">
-            <?php do_meta_boxes( '_pods_pod-edit-fields', 'side', $pod ); ?>
+            <?php do_meta_boxes( '_pods_pod', 'side', $pod ); ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Handy to add meta/option boxes to the side of the pod edit page

Bringing over PR from #3609