### PR TITLE
Improve field alignment on setting pages

### DIFF
--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -329,9 +329,8 @@ div.pods-manage-field .pods-field-option-group .pods-field-option-group-label {
 .pods-manage-field .pods-slider-field {
     display: block;
     float: left;
-    margin-left: 22px;
     width: 65%;
-    max-width: 300px;
+    max-width: 25em;
 }
 
 


### PR DESCRIPTION
I can't find any actual need of the `margin-left` property. It only breaks alignment.

Changed `max-width` to `25em` to match with the default WP setting fields css class "regular-text" as seen in the general settings.

This:
![testsetting wp pods development wordpress](https://cloud.githubusercontent.com/assets/826148/16650213/56351a32-443d-11e6-8047-ced9cacd4940.png)

Becomes this:
![testsetting fixed wp pods development wordpress](https://cloud.githubusercontent.com/assets/826148/16650223/66eb1a3e-443d-11e6-9a8b-0d4401f948c8.png)
