### PR TITLE
Properly update bidirectional taggable relations

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3759,7 +3759,7 @@ class PodsAPI {
                         $this->save_relationships( $params->id, $value_ids, $pod, $fields[ $field ] );
 
                     // Run save function for field type (where needed)
-                    PodsForm::save( $type, $values, $params->id, $field, array_merge( $fields[ $field ], $fields[ $field ][ 'options' ] ), array_merge( $fields, $object_fields ), $pod, $params );
+                    PodsForm::save( $type, $value_ids, $params->id, $field, array_merge( $fields[ $field ], $fields[ $field ][ 'options' ] ), array_merge( $fields, $object_fields ), $pod, $params );
                 }
 
                 // Unset data no longer needed


### PR DESCRIPTION
Fixes #3477

When editing an object's bidirectional taggable relation, and you add a related object that doesn't exist, the reverse relation is now correctly set up.

I just learned about Pods today so this fix could be completely off base, but it works for me.

The problem was that the `save` method for the `pick` field was being passed the original array of ids instead of the new variable that contains the id of any newly added objects.

(I'm using Pods 2.6.6 and Wordpress 4.5.3)

Cheers!
