### PR TITLE
Validate field option dependencies based on location within in tabs

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -844,6 +844,27 @@
 					$field = $el,
 					val = $el.val();
 
+                /**
+                 * Check if this element is a child from an 'advanced field options' group.
+                 * If so, set the value to empty if this is not the current field type group
+                 * Fixes dependency compatibility
+                 *
+                 * @todo Validate & improve this
+                 */
+                // Are we in the "Fields" tab?
+                if ( $current.parents('#pods-manage-fields').length ) {
+                    // And are we also in the "Additional Field Options" tab?
+                    if ( $el.parents('.pods-additional-field-options').length ) {
+                        // Get this field's type
+                        var $field_type = $current.find( '.pods-form-ui-field-name-field-data-type' ).val();
+                        // Check if this element resides within the correct "Additional Field Options" tab
+                        if ( ! $el.parents( '.pods-additional-field-options > .pods-depends-on-field-data-type-' + $field_type ).length ) {
+                            // This is not an option for this field. Empty the value
+                            val = '';
+                        }
+                    }
+                }
+
 				if ( null === val ) {
 					val = '';
 				}


### PR DESCRIPTION
Check if this element is a child from an 'Advanced Field Options' group.
If so, set the value to empty if this is not the current field type group.

Fixes dependency compatibility of https://github.com/pods-framework/pods/issues/3707 and https://github.com/pods-framework/pods-seo/pull/6