### PR TITLE
UI: Hierarchical taxonomies as checkboxes in attachment modal

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1420,24 +1420,6 @@ class PodsMeta {
             pods_no_conflict_off( 'post' );
         }
 
-        /**
-         * Update taxonomies when changed to checkboxes in the attachment modal
-         * @since 2.6.8
-         */
-        if ( ! empty( $_POST['tax_input'] ) && defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-            foreach ( $_POST['tax_input'] as $tax => $terms ) {
-                /**
-                 * Validate for an array
-                 * Otherwise we didn't change this functionality since this is a string by default
-                 */
-                if ( is_taxonomy_hierarchical( $tax ) && is_array( $terms ) ) {
-                    $tax = sanitize_title( $tax );
-                    $terms = array_map( 'intval', $terms );
-                    wp_set_post_terms( $id, $terms, $tax );
-                }
-            }
-        }
-
         do_action( 'pods_meta_save_media', $data, $pod, $id, $groups, $post, $attachment );
 
         return $post;
@@ -1472,6 +1454,24 @@ class PodsMeta {
 
         if ( empty( $_REQUEST[ 'attachments' ][ $id ] ) )
             $_REQUEST[ 'attachments' ][ $id ][ '_fix_wp' ] = 1;
+
+        /**
+         * Update taxonomies when changed to checkboxes in the attachment modal
+         * @since 2.6.8
+         */
+        if ( ! empty( $_POST['tax_input'] ) ) {
+            foreach ( $_POST['tax_input'] as $tax => $terms ) {
+                /**
+                 * Validate for an array
+                 * Otherwise we didn't change this functionality since this is a string by default in WP core
+                 */
+                if ( is_taxonomy_hierarchical( $tax ) && is_array( $terms ) ) {
+                    $tax = sanitize_title( $tax );
+                    $terms = array_map( 'intval', $terms );
+                    wp_set_post_terms( $id, $terms, $tax );
+                }
+            }
+        }
     }
 
     /**

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1323,6 +1323,16 @@ class PodsMeta {
 
                     ob_end_clean();
 
+                    /**
+                     * Ensure data is send and saved.
+                     * Default array structures not working in update
+                     * @todo file bug at WP trac?
+                     */
+                    $counter = 0;
+                    while( false !== strpos( $html, '['.$field.'][]' ) ) {
+                        $html = preg_replace( '/\['.$field.'\]\[\]/', '['.$field.']['.($counter++).']', $html, 1 );
+                    }
+
                     unset( $form_fields[ $field ][ 'value' ] );
 
                     $form_fields[ $field ][ 'input' ] = 'html';

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1410,6 +1410,24 @@ class PodsMeta {
             pods_no_conflict_off( 'post' );
         }
 
+        /**
+         * Update taxonomies when changed to checkboxes in the attachment modal
+         * @since 2.6.8
+         */
+        if ( ! empty( $_POST['tax_input'] ) && defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+            foreach ( $_POST['tax_input'] as $tax => $terms ) {
+                /**
+                 * Validate for an array
+                 * Otherwise we didn't change this functionality since this is a string by default
+                 */
+                if ( is_taxonomy_hierarchical( $tax ) && is_array( $terms ) ) {
+                    $tax = sanitize_title( $tax );
+                    $terms = array_map( 'intval', $terms );
+                    wp_set_post_terms( $id, $terms, $tax );
+                }
+            }
+        }
+
         do_action( 'pods_meta_save_media', $data, $pod, $id, $groups, $post, $attachment );
 
         return $post;

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -304,9 +304,26 @@ class PodsMeta {
         if ( function_exists( 'pll_current_language' ) )
             add_action( 'init', array( $this, 'cache_pods' ), 101 );
 
+        // Priority 20 because PodsInit has priority 15
+        add_action( 'admin_enqueue_scripts', array( $this, 'assets' ), 20 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'assets' ), 20 );
+
         do_action( 'pods_meta_init' );
 
         return $this;
+    }
+
+    /**
+     * Add styles and scripts globally or conditionally
+     * @since 2.6.8
+     */
+    public function assets() {
+
+        // Add Pods form styles to the Media Library
+        if ( is_admin() && get_current_screen()->base == 'upload' ) {
+            wp_enqueue_style( 'pods-form' );
+            //wp_enqueue_script( 'pods' );
+        }
     }
 
     public static function enqueue () {

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1301,6 +1301,36 @@ class PodsMeta {
             }
         }
 
+        /**
+         * Add hierarchical taxonomies as checkboxes
+         * Based on Enhanced Media Library
+         */
+        if ( function_exists( 'wp_terms_checklist' ) ) {
+            foreach ( $form_fields as $field => $args ) {
+                if ( ! empty( $args[ 'hierarchical' ] ) && ( ! isset( $form_fields[ $field ][ 'input' ] ) || $form_fields[ $field ][ 'input' ] != 'html' ) ) {
+
+                    ob_start();
+
+                    wp_terms_checklist( $post->ID, array( 'taxonomy' => $field, 'checked_ontop' => false ) );
+
+                    $content = ob_get_contents();
+
+                    if ( $content ) {
+                        $html = '<ul class="term-list pods-term-list">' . $content . '</ul>';
+                    } else {
+                        $html = '<ul class="term-list pods-term-list"><li>No ' . $args[ 'label' ] . ' found.</li></ul>';
+                    }
+
+                    ob_end_clean();
+
+                    unset( $form_fields[ $field ][ 'value' ] );
+
+                    $form_fields[ $field ][ 'input' ] = 'html';
+                    $form_fields[ $field ][ 'html' ]  = $html;
+                }
+            }
+        }
+
         $form_fields = apply_filters( 'pods_meta_' . __FUNCTION__, $form_fields );
 
         return $form_fields;

--- a/ui/css/pods-form.css
+++ b/ui/css/pods-form.css
@@ -314,20 +314,20 @@ input.pods-form-ui-field-type-color {
 /**
  * Modal fields
  */
-.media-modal .media-sidebar .pods-term-list {
+.media-modal .compat-item .pods-term-list {
     margin: 0;
     padding: 3px;
     background: #fff;
     border: 1px solid #dfdfdf;
 }
-.media-modal .media-sidebar .pods-term-list input {
+.media-modal .compat-item .pods-term-list input {
     vertical-align: text-bottom;
     margin: 3px 3px 0;
 }
-.media-modal .media-sidebar .pods-term-list > li:last-child {
+.media-modal .compat-item .pods-term-list > li:last-child {
     margin-bottom: 3px;
 }
-.media-modal .media-sidebar .pods-term-list ul.children {
+.media-modal .compat-item .pods-term-list ul.children {
     margin: 6px 0 0 18px;
 }
 }

--- a/ui/css/pods-form.css
+++ b/ui/css/pods-form.css
@@ -310,4 +310,24 @@ input.pods-form-ui-field-type-color {
     content: “\00a0”;
     clear: both;
     display: block;
+
+/**
+ * Modal fields
+ */
+.media-modal .media-sidebar .pods-term-list {
+    margin: 0;
+    padding: 3px;
+    background: #fff;
+    border: 1px solid #dfdfdf;
+}
+.media-modal .media-sidebar .pods-term-list input {
+    vertical-align: text-bottom;
+    margin: 3px 3px 0;
+}
+.media-modal .media-sidebar .pods-term-list > li:last-child {
+    margin-bottom: 3px;
+}
+.media-modal .media-sidebar .pods-term-list ul.children {
+    margin: 6px 0 0 18px;
+}
 }


### PR DESCRIPTION
See: https://github.com/pods-framework/pods/issues/3765

TODO:

- [ ] Maybe make this a Pods option since it's not WP core?