### PR TITLE
Keep Plupload instances in `windows.pods_uploader`

### DIFF
--- a/ui/fields/plupload.php
+++ b/ui/fields/plupload.php
@@ -205,17 +205,23 @@ else
             } );
         } );
 
-        var pods_uploader_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> = new plupload.Uploader( <?php echo json_encode( $plupload_init ); ?> ),
-            list_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> = $( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-list' ),
-            queue_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> = $( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-queue' ),
-            maxFiles_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> = <?php echo esc_js( $file_limit ); ?>;
+        var pods_uploader = new plupload.Uploader( <?php echo json_encode( $plupload_init ); ?> ),
+            list = $( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-list' ),
+            queue = $( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-queue' ),
+            maxFiles = <?php echo esc_js( $file_limit ); ?>;
 
-        pods_uploader_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.init();
+        pods_uploader.init();
+
+        // Store a reference to this Plupload instance in window.pods_uploaders
+        if (!('pods_uploaders' in window)) {
+            pods_uploaders = {};
+        }
+        pods_uploaders['<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>'] = pods_uploader;
 
         // Plupload FilesAdded Event Handler
-        pods_uploader_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.bind( 'FilesAdded', function ( up, files ) {
+        pods_uploader.bind( 'FilesAdded', function ( up, files ) {
             // Hide any existing files (for use in single/limited field configuration)
-            if ( 1 == maxFiles_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> ) {
+            if ( 1 == maxFiles ) {
                 jQuery( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-list li.pods-file' ).remove();
                 jQuery( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-list' ).hide();
             }
@@ -225,7 +231,7 @@ else
                     tmpl = Handlebars.compile( $( '#<?php echo esc_js( $css_id ); ?>-progress-template' ).html() ),
                     html = tmpl( binding );
 
-                queue_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.append( html );
+                queue.append( html );
                 //$('#' + file.id).show('slide', {direction: 'up'}, 1000);
                 $( '#' + file.id ).fadeIn( 800 );
 
@@ -237,14 +243,14 @@ else
         } );
 
         // Plupload UploadProgress Event Handler
-        pods_uploader_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.bind( 'UploadProgress', function ( up, file ) {
+        pods_uploader.bind( 'UploadProgress', function ( up, file ) {
             var prog_bar = $( '#' + file.id ).find( '.progress-bar' );
 
             prog_bar.css( 'width', file.percent + '%' );
         } );
 
         // Plupload FileUploaded Event Handler
-        pods_uploader_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.bind( 'FileUploaded', function ( up, file, resp ) {
+        pods_uploader.bind( 'FileUploaded', function ( up, file, resp ) {
             var file_div = jQuery( '#' + file.id ),
                 response = resp.response;
 
@@ -274,7 +280,7 @@ else
                 }
 
                 file_div.fadeOut( 800, function () {
-                    list_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.show();
+                    list.show();
 
                     if ( $( this ).parent().children().length == 1 )
                         jQuery( '#<?php echo esc_js( $css_id ); ?> ul.pods-files-queue' ).hide();
@@ -293,15 +299,15 @@ else
 
                 var html = tmpl( binding );
 
-                list_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.prepend( html );
-                list_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.find( 'li.pods-file:first' ).slideDown( 'fast' );
+                list.prepend( html );
+                list.find( 'li.pods-file:first' ).slideDown( 'fast' );
 
-                var items = list_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>.find( 'li.pods-file' ),
+                var items = list.find( 'li.pods-file' ),
                     itemCount = items.size();
 
-                if ( 0 < maxFiles_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> && itemCount > maxFiles_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> ) {
+                if ( 0 < maxFiles && itemCount > maxFiles ) {
                     items.each( function ( idx, elem ) {
-                        if ( idx + 1 > maxFiles_<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?> ) {
+                        if ( idx + 1 > maxFiles ) {
                             jQuery( elem ).remove();
                         }
                     } );


### PR DESCRIPTION
This change fixes #3763 by making Plupload instances available to other code by storing them in `windows.pods_uploader[id]`.

It also removes `<?php echo esc_js( pods_js_name( $attributes[ 'id' ] ) ); ?>` from the variable names used in this scope, as these variables are only available in this closure.
