### PR TITLE
Changed from deprecated .live() to .on().

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -1625,7 +1625,7 @@
                 } );
             },
             toggled : function () {
-                $( '.pods-toggled .handlediv, .pods-toggled h3' ).live( 'click', function () {
+                $( 'body' ).on( 'click', '.pods-toggled .handlediv, .pods-toggled h3', function () {
                     $( this ).parent().find( '.inside' ).slideToggle();
                     return false;
                 } );


### PR DESCRIPTION
Discussed in [Issue 3771](https://github.com/pods-framework/pods/issues/3771).