### PR TITLE
Patch the responsive markup WP edit.php UI to Pods UI

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3644,7 +3644,7 @@ class PodsUI {
                                         <input type="hidden" name="order[]" value="<?php echo esc_attr( $row[ $this->sql[ 'field_id' ] ] ); ?>" />
                                         <?php
                                     }
-                                    ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button>
+                                    ?><button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'pods' ); ?></span></button>
                 </td>
 <?php
                                 }
@@ -3657,7 +3657,7 @@ class PodsUI {
                                     ?>
                                     <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo esc_attr( $attributes['label'] ); ?>">
                                         <abbr title="<?php echo esc_attr( $row_value ); ?>"><?php echo wp_kses_post( $row_value ); ?></abbr>
-                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
+                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'pods' ); ?></span></button><?php }; ?>
                                     </td>
                                     <?php
                                 }
@@ -3669,7 +3669,7 @@ class PodsUI {
                                     ?>
                                     <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo esc_attr( $attributes['label'] ); ?>">
                                         <span><?php echo wp_kses_post( $row_value ); ?></span>
-                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
+                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text"><?php esc_html_e( 'Show more details', 'pods' ); ?></span></button><?php }; ?>
                                     </td>
                                     <?php
                                 }

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3270,19 +3270,28 @@ class PodsUI {
 
                             $width = '';
 
+                            $column_classes = array(
+                                'manage-column',
+                                'column-' . esc_attr( $id )
+                            );
+                            if ( $id == 'title' ) {
+                                $column_classes[] = 'column-primary';
+                            }
+
                             if ( isset( $attributes[ 'width' ] ) && !empty( $attributes[ 'width' ] ) )
                                 $width = ' style="width: ' . esc_attr( $attributes[ 'width' ] ) . '"';
 
                             if ( $fields[ $field ][ 'sortable' ] ) {
+                                $column_classes[] = 'sortable' . $current_sort;
                                 ?>
-                                <th scope="col"<?php echo $att_id; ?> class="manage-column column-<?php echo esc_attr( $id ); ?> sortable<?php echo esc_attr( $current_sort ); ?>"<?php echo $width; ?>>
+                                <th scope="col"<?php echo $att_id; ?> class="<?php echo esc_attr( implode( ' ', $column_classes ) ); ?>"<?php echo $width; ?>>
                                     <a href="<?php echo esc_url_raw( pods_query_arg( array( 'orderby' . $this->num => $field, 'orderby_dir' . $this->num => $dir ), array( 'limit' . $this->num, 'search' . $this->num, 'pg' . $this->num, 'page' ), $this->exclusion() ) ); ?>"> <span><?php echo $attributes[ 'label' ]; ?></span> <span class="sorting-indicator"></span> </a>
                                 </th>
                                 <?php
                             }
                             else {
                                 ?>
-                                <th scope="col"<?php echo $att_id; ?> class="manage-column column-<?php echo esc_attr( $id ); ?>"<?php echo $width; ?>><?php echo $attributes[ 'label' ]; ?></th>
+                                <th scope="col"<?php echo $att_id; ?> class="<?php echo esc_attr( implode( ' ', $column_classes ) ); ?>"<?php echo $width; ?>><?php echo $attributes[ 'label' ]; ?></th>
                                 <?php
                             }
                         }
@@ -3361,7 +3370,9 @@ class PodsUI {
                                 <th scope="row" class="check-column"><input type="checkbox" name="action_bulk_ids<?php echo esc_attr( $this->num ); ?>[]" value="<?php echo esc_attr( $row[$this->sql['field_id']] ); ?>"></th>
             <?php
                                 }
-
+                            // Boolean for the first field to output after the check-column
+                            // will be set to false at the end of the first loop
+                            $first_field = true;
                             foreach ( $fields as $field => $attributes ) {
                                 if ( false === $attributes[ 'display' ] )
                                     continue;
@@ -3432,7 +3443,9 @@ class PodsUI {
                                     }
                                 }
 
-								$css_classes = ' pods-ui-col-field-' . sanitize_title( $field );
+                                $css_classes = array(
+                                    'pods-ui-col-field-' . sanitize_title( $field )
+                                );
 
 								if ( $attributes[ 'css_values' ] ) {
 									$css_field_value = $row[ $field ];
@@ -3453,16 +3466,16 @@ class PodsUI {
 														$css_field_v = get_object_vars( $css_field_v );
 													}
 
-													$css_classes .= ' pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_v ) ) );
+													$css_classes[] = 'pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_v ) ) );
 												}
 											}
 											else {
-												$css_classes .= ' pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_val ) ) );
+												$css_classes[] = ' pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_val ) ) );
 											}
 										}
 									}
 									else {
-										$css_classes .= ' pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_value ) ) );
+										$css_classes[] = ' pods-ui-css-value-' . sanitize_title( str_replace( array( "\n", "\r" ), ' ', strip_tags( (string) $css_field_value ) ) );
 									}
 								}
 
@@ -3474,13 +3487,20 @@ class PodsUI {
                                 if ( 'title' == $attributes[ 'field_id' ] ) {
 									$default_action = $this->do_hook( 'default_action', 'edit', $row );
 
+                                    if ( $first_field ) {
+                                        $css_classes[] = 'column-primary';
+                                    }
+                                    $css_classes[] = 'post-title';
+                                    $css_classes[] = 'page-title';
+                                    $css_classes[] = 'column-title';
+
                                     if ( !in_array( 'edit', $this->actions_disabled ) && !in_array( 'edit', $this->actions_hidden ) && ( false === $reorder || in_array( 'reorder', $this->actions_disabled ) || false === $this->reorder[ 'on' ] ) && 'edit' == $default_action ) {
                                         $link = pods_query_arg( array( 'action' . $this->num => 'edit', 'id' . $this->num => $row[ $this->sql[ 'field_id' ] ] ), self::$allowed, $this->exclusion() );
 
                                         if ( !empty( $this->action_links[ 'edit' ] ) )
                                             $link = $this->do_template( $this->action_links[ 'edit' ], $row );
                                         ?>
-                <td class="post-title page-title column-title<?php echo esc_attr( $css_classes ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'Edit this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'Edit this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
                                         <?php
                                     }
                                     elseif ( !in_array( 'view', $this->actions_disabled ) && !in_array( 'view', $this->actions_hidden ) && ( false === $reorder || in_array( 'reorder', $this->actions_disabled ) || false === $this->reorder[ 'on' ] ) && 'view' == $default_action ) {
@@ -3489,12 +3509,15 @@ class PodsUI {
                                         if ( !empty( $this->action_links[ 'view' ] ) )
                                             $link = $this->do_template( $this->action_links[ 'view' ], $row );
                                         ?>
-                <td class="post-title page-title column-title<?php echo esc_attr( $css_classes ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'View this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'View this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
                                         <?php
                                     }
                                     else {
+                                        if ( 1 == $reorder && $this->reorder ) {
+                                            $css_classes[] = 'dragme';
+                                        }
                                         ?>
-                <td class="post-title page-title column-title<?php echo esc_attr( $css_classes ); ?><?php echo esc_attr( ( 1 == $reorder && $this->reorder ) ? ' dragme' : '' ); ?>"><strong><?php echo $row_value; ?></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><?php echo $row_value; ?></strong>
                                         <?php
                                     }
 
@@ -3611,20 +3634,36 @@ class PodsUI {
                                         <input type="hidden" name="order[]" value="<?php echo esc_attr( $row[ $this->sql[ 'field_id' ] ] ); ?>" />
                                         <?php
                                     }
-                                    ?>
+                                    ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button>
                 </td>
 <?php
                                 }
                                 elseif ( 'date' == $attributes[ 'type' ] ) {
+                                    if ( $first_field ) {
+                                        $css_classes[] = 'column-primary';
+                                    }
+                                    $css_classes[] = 'date';
+                                    $css_classes[] = 'column-date';
                                     ?>
-                                    <td class="date column-date<?php echo esc_attr( $css_classes ); ?>"><abbr title="<?php echo esc_attr( $row_value ); ?>"><?php echo $row_value; ?></abbr></td>
+                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo $attributes['label'] ?>">
+                                        <abbr title="<?php echo esc_attr( $row_value ); ?>"><?php echo $row_value; ?></abbr>
+                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
+                                    </td>
                                     <?php
                                 }
                                 else {
+                                    if ( $first_field ) {
+                                        $css_classes[] = 'column-primary';
+                                    }
+                                    $css_classes[] = 'author';
                                     ?>
-                                    <td class="author<?php echo esc_attr( $css_classes ); ?>"><span><?php echo $row_value; ?></span></td>
+                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo $attributes['label'] ?>">
+                                        <span><?php echo $row_value; ?></span>
+                                        <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
+                                    </td>
                                     <?php
                                 }
+                                $first_field = false;
                             }
                             ?>
                         </tr>

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1423,7 +1423,7 @@ class PodsUI {
         <div id="icon-edit-pages" class="icon32"<?php if ( false !== $this->icon ) { ?> style="background-position:0 0;background-size:100%;background-image:url(<?php echo esc_url( $this->icon ); ?>);"<?php } ?>><br /></div>
         <h2>
             <?php
-            echo $this->header[ 'add' ];
+            echo wp_kses_post( $this->header[ 'add' ] );
 
 			$link = pods_query_arg( array( 'action' . $this->num => 'manage', 'id' . $this->num => '' ), self::$allowed, $this->exclusion() );
 
@@ -1462,7 +1462,7 @@ class PodsUI {
         <div id="icon-edit-pages" class="icon32"<?php if ( false !== $this->icon ) { ?> style="background-position:0 0;background-size:100%;background-image:url(<?php echo esc_url( $this->icon ); ?>);"<?php } ?>><br /></div>
         <h2>
             <?php
-            echo $this->do_template( $duplicate ? $this->header[ 'duplicate' ] : $this->header[ 'edit' ] );
+            echo wp_kses_post( $this->do_template( $duplicate ? $this->header[ 'duplicate' ] : $this->header[ 'edit' ] ) );
 
             if ( !in_array( 'add', $this->actions_disabled ) && !in_array( 'add', $this->actions_hidden ) ) {
                 $link = pods_query_arg( array( 'action' . $this->num => 'add', 'id' . $this->num => '', 'do' . $this->num = '' ), self::$allowed, $this->exclusion() );
@@ -1470,7 +1470,7 @@ class PodsUI {
                 if ( !empty( $this->action_links[ 'add' ] ) )
                     $link = $this->action_links[ 'add' ];
                 ?>
-                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo $this->heading[ 'add' ]; ?></a>
+                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo wp_kses_post( $this->heading[ 'add' ] ); ?></a>
                 <?php
             }
             elseif ( !in_array( 'manage', $this->actions_disabled ) && !in_array( 'manage', $this->actions_hidden ) ) {
@@ -1740,7 +1740,7 @@ class PodsUI {
 			<div id="icon-edit-pages" class="icon32"<?php if ( false !== $this->icon ) { ?> style="background-position:0 0;background-size:100%;background-image:url(<?php echo esc_url( $this->icon ); ?>);"<?php } ?>><br /></div>
 			<h2>
 				<?php
-					echo $this->do_template( $this->header[ 'view' ] );
+					echo wp_kses_post( $this->do_template( $this->header[ 'view' ] ) );
 
 					if ( !in_array( 'add', $this->actions_disabled ) && !in_array( 'add', $this->actions_hidden ) ) {
 						$link = pods_query_arg( array( 'action' . $this->num => 'add', 'id' . $this->num => '', 'do' . $this->num = '' ), self::$allowed, $this->exclusion() );
@@ -1749,7 +1749,7 @@ class PodsUI {
 							$link = $this->action_links[ 'add' ];
 						}
 				?>
-					<a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo $this->heading[ 'add' ]; ?></a>
+					<a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo wp_kses_post( $this->heading[ 'add' ] ); ?></a>
 				<?php
 					}
 					elseif ( !in_array( 'manage', $this->actions_disabled ) && !in_array( 'manage', $this->actions_hidden ) ) {
@@ -2369,7 +2369,7 @@ class PodsUI {
         <h2>
             <?php
             if ( true === $reorder ) {
-                echo $this->header[ 'reorder' ];
+                echo wp_kses_post( $this->header[ 'reorder' ] );
 
 				$link = pods_query_arg( array( 'action' . $this->num => 'manage', 'id' . $this->num => '' ), self::$allowed, $this->exclusion() );
 
@@ -2380,7 +2380,7 @@ class PodsUI {
                 <?php
             }
             else
-                echo $this->header[ 'manage' ];
+                echo wp_kses_post( $this->header[ 'manage' ] );
 
             if ( !in_array( 'add', $this->actions_disabled ) && !in_array( 'add', $this->actions_hidden ) ) {
                 $link = pods_query_arg( array( 'action' . $this->num => 'add', 'id' . $this->num => '', 'do' . $this->num => '' ), self::$allowed, $this->exclusion() );
@@ -2388,7 +2388,7 @@ class PodsUI {
                 if ( !empty( $this->action_links[ 'add' ] ) )
                     $link = $this->action_links[ 'add' ];
                 ?>
-                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo $this->label[ 'add_new' ]; ?></a>
+                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo wp_kses_post( $this->label[ 'add_new' ] ); ?></a>
                 <?php
             }
             if ( !in_array( 'reorder', $this->actions_disabled ) && !in_array( 'reorder', $this->actions_hidden ) && false !== $this->reorder[ 'on' ] ) {
@@ -2397,7 +2397,7 @@ class PodsUI {
                 if ( !empty( $this->action_links[ 'reorder' ] ) )
                     $link = $this->action_links[ 'reorder' ];
                 ?>
-                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo $this->label[ 'reorder' ]; ?></a>
+                <a href="<?php echo esc_url( $link ); ?>" class="add-new-h2"><?php echo wp_kses_post( $this->label[ 'reorder' ] ); ?></a>
                 <?php
             }
             ?>
@@ -2510,7 +2510,7 @@ class PodsUI {
                                 $end = PodsForm::field_method( $filter_field[ 'type' ], 'convert_date', $end, 'n/j/Y' );
                     ?>
                         <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>_start">
-                            <?php echo $filter_field[ 'label' ]; ?>
+                            <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                         </label>
                         <?php echo PodsForm::field( 'filter_' . $filter . '_start', $start, $filter_field[ 'type' ], $filter_field ); ?>
 
@@ -2538,7 +2538,7 @@ class PodsUI {
                             $options = array_merge( $filter_field, $filter_field[ 'options' ] );
                     ?>
                         <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                            <?php echo $filter_field[ 'label' ]; ?>
+                            <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                         </label>
                     <?php
                             echo PodsForm::field( 'filter_' . $filter, $value, 'pick', $options );
@@ -2567,7 +2567,7 @@ class PodsUI {
                             $options = array_merge( $filter_field, $filter_field[ 'options' ] );
                     ?>
                         <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                            <?php echo $filter_field[ 'label' ]; ?>
+                            <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                         </label>
                     <?php
                             echo PodsForm::field( 'filter_' . $filter, $value, 'pick', $options );
@@ -2586,7 +2586,7 @@ class PodsUI {
                             $options[ 'input_helper' ] = pods_var_raw( 'ui_input_helper', $options, $options[ 'input_helper' ], null, true );
                     ?>
                         <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                            <?php echo $filter_field[ 'label' ]; ?>
+                            <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                         </label>
                     <?php
                             echo PodsForm::field( 'filter_' . $filter, $value, 'text', $options );
@@ -2776,7 +2776,7 @@ class PodsUI {
                 if ( !empty( $this->views ) ) {
             ?>
                 <ul class="subsubsub">
-                    <li class="pods-ui-filter-view-label"><strong><?php echo $this->heading[ 'views' ]; ?></strong></li>
+                    <li class="pods-ui-filter-view-label"><strong><?php echo wp_kses_post( $this->heading[ 'views' ] ); ?></strong></li>
 
                     <?php
                         foreach ( $this->views as $view => $label ) {
@@ -2784,12 +2784,12 @@ class PodsUI {
                                 $link = pods_query_arg( array( 'view' . $this->num => $view, 'pg' . $this->num => '' ), self::$allowed, $this->exclusion() );
 
                                 if ( $this->view == $view )
-                                    $label = '<a href="' . esc_url( $link ) . '" class="current">' . $label . '</a>';
+                                    $label = '<a href="' . esc_url( $link ) . '" class="current">' . esc_html( $label ) . '</a>';
                                 else
-                                    $label = '<a href="' . esc_url( $link ) . '">' . $label . '</a>';
+                                    $label = '<a href="' . esc_url( $link ) . '">' . esc_html( $label ) . '</a>';
                             }
                     ?>
-                        <li class="<?php echo esc_attr( $view ); ?>"><?php echo $label; ?></li>
+                        <li class="<?php echo esc_attr( $view ); ?>"><?php echo esc_html( $label ); ?></li>
                     <?php
                         }
                     ?>
@@ -2909,7 +2909,7 @@ class PodsUI {
                     ?>
                         <li class="pods-ui-filter-bar-filter" data-filter="<?php echo esc_attr( $data_filter ); ?>">
                             <a href="#TB_inline?width=640&inlineId=pods-ui-posts-filter-popup" class="thickbox" title="<?php esc_attr_e( 'Advanced Filters', 'pods' ); ?>">
-                                <strong><?php echo $filter_field[ 'label' ]; ?>:</strong>
+                                <strong><?php echo esc_html( $filter_field[ 'label' ] ); ?>:</strong>
                                 <?php echo esc_html( $value_label ); ?>
                             </a>
 
@@ -3029,7 +3029,7 @@ class PodsUI {
                             <span class="pods-ui-posts-filter-toggle toggle-off<?php echo esc_attr( ( empty( $start ) && empty( $end ) ) ? ' hidden' : '' ); ?>"><?php _e( 'Clear', 'pods' ); ?></span>
 
                             <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>_start">
-                                <?php echo $filter_field[ 'label' ]; ?>
+                                <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                             </label>
 
                             <span class="pods-ui-posts-filter<?php echo esc_attr( ( empty( $start ) && empty( $end ) ) ? ' hidden' : '' ); ?>">
@@ -3061,7 +3061,7 @@ class PodsUI {
                             <span class="pods-ui-posts-filter-toggle toggle-off<?php echo esc_attr( empty( $value ) ? ' hidden' : '' ); ?>"><?php _e( 'Clear', 'pods' ); ?></span>
 
                             <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                                <?php echo $filter_field[ 'label' ]; ?>
+                                <?php echo esc$filter_field[ 'label' ]; ?>
                             </label>
 
                             <span class="pods-ui-posts-filter<?php echo esc_attr( strlen( $value ) < 1 ? ' hidden' : '' ); ?>">
@@ -3096,7 +3096,7 @@ class PodsUI {
                             <span class="pods-ui-posts-filter-toggle toggle-off<?php echo esc_attr( empty( $value ) ? ' hidden' : '' ); ?>"><?php _e( 'Clear', 'pods' ); ?></span>
 
                             <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                                <?php echo $filter_field[ 'label' ]; ?>
+                                <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                             </label>
 
                             <span class="pods-ui-posts-filter<?php echo esc_attr( strlen( $value ) < 1 ? ' hidden' : '' ); ?>">
@@ -3121,7 +3121,7 @@ class PodsUI {
                             <span class="pods-ui-posts-filter-toggle toggle-off<?php echo esc_attr( empty( $value ) ? ' hidden' : '' ); ?>"><?php _e( 'Clear', 'pods' ); ?></span>
 
                             <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                                <?php echo $filter_field[ 'label' ]; ?>
+                                <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                             </label>
 
                             <span class="pods-ui-posts-filter<?php echo esc_attr( empty( $value ) ? ' hidden' : '' ); ?>">
@@ -3290,13 +3290,13 @@ class PodsUI {
                                 $column_classes[] = 'sortable' . $current_sort;
                                 ?>
                                 <th scope="col"<?php echo $att_id; ?> class="<?php echo esc_attr( implode( ' ', $column_classes ) ); ?>"<?php echo $width; ?>>
-                                    <a href="<?php echo esc_url_raw( pods_query_arg( array( 'orderby' . $this->num => $field, 'orderby_dir' . $this->num => $dir ), array( 'limit' . $this->num, 'search' . $this->num, 'pg' . $this->num, 'page' ), $this->exclusion() ) ); ?>"> <span><?php echo $attributes[ 'label' ]; ?></span> <span class="sorting-indicator"></span> </a>
+                                    <a href="<?php echo esc_url_raw( pods_query_arg( array( 'orderby' . $this->num => $field, 'orderby_dir' . $this->num => $dir ), array( 'limit' . $this->num, 'search' . $this->num, 'pg' . $this->num, 'page' ), $this->exclusion() ) ); ?>"> <span><?php echo esc_html( $attributes[ 'label' ] ); ?></span> <span class="sorting-indicator"></span> </a>
                                 </th>
                                 <?php
                             }
                             else {
                                 ?>
-                                <th scope="col"<?php echo $att_id; ?> class="<?php echo esc_attr( implode( ' ', $column_classes ) ); ?>"<?php echo $width; ?>><?php echo $attributes[ 'label' ]; ?></th>
+                                <th scope="col"<?php echo $att_id; ?> class="<?php echo esc_attr( implode( ' ', $column_classes ) ); ?>"<?php echo $width; ?>><?php echo esc_html( $attributes[ 'label' ] ); ?></th>
                                 <?php
                             }
                         }
@@ -3334,12 +3334,12 @@ class PodsUI {
 
                                 if ( $fields[ $field ][ 'sortable' ] ) {
                                     ?>
-                                    <th scope="col" class="manage-column column-<?php echo esc_attr( $id ); ?> sortable <?php echo esc_attr( $current_sort ); ?>"<?php echo $width; ?>><a href="<?php echo esc_url_raw( pods_query_arg( array( 'orderby' . $this->num => $field, 'orderby_dir' . $this->num => $dir ), array( 'limit' . $this->num, 'search' . $this->num, 'pg' . $this->num, 'page' ), $this->exclusion() ) ); ?>"><span><?php echo $attributes[ 'label' ]; ?></span><span class="sorting-indicator"></span></a></th>
+                                    <th scope="col" class="manage-column column-<?php echo esc_attr( $id ); ?> sortable <?php echo esc_attr( $current_sort ); ?>"<?php echo $width; ?>><a href="<?php echo esc_url_raw( pods_query_arg( array( 'orderby' . $this->num => $field, 'orderby_dir' . $this->num => $dir ), array( 'limit' . $this->num, 'search' . $this->num, 'pg' . $this->num, 'page' ), $this->exclusion() ) ); ?>"><span><?php echo esc_html( $attributes[ 'label' ] ); ?></span><span class="sorting-indicator"></span></a></th>
                                     <?php
                                 }
                                 else {
                                     ?>
-                                    <th scope="col" class="manage-column column-<?php echo esc_attr( $id ); ?>"<?php echo $width; ?>><?php echo $attributes[ 'label' ]; ?></th>
+                                    <th scope="col" class="manage-column column-<?php echo esc_attr( $id ); ?>"<?php echo $width; ?>><?php echo esc_html( $attributes[ 'label' ] ); ?></th>
                                     <?php
                                 }
                             }
@@ -3510,7 +3510,7 @@ class PodsUI {
                                         if ( !empty( $this->action_links[ 'edit' ] ) )
                                             $link = $this->do_template( $this->action_links[ 'edit' ], $row );
                                         ?>
-                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'Edit this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'Edit this item', 'pods' ); ?>"><?php echo wp_kses_post( $row_value ); ?></a></strong>
                                         <?php
                                     }
                                     elseif ( !in_array( 'view', $this->actions_disabled ) && !in_array( 'view', $this->actions_hidden ) && ( false === $reorder || in_array( 'reorder', $this->actions_disabled ) || false === $this->reorder[ 'on' ] ) && 'view' == $default_action ) {
@@ -3519,7 +3519,7 @@ class PodsUI {
                                         if ( !empty( $this->action_links[ 'view' ] ) )
                                             $link = $this->do_template( $this->action_links[ 'view' ], $row );
                                         ?>
-                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'View this item', 'pods' ); ?>"><?php echo $row_value; ?></a></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><a class="row-title" href="<?php echo esc_url_raw( $link ); ?>" title="<?php esc_attr_e( 'View this item', 'pods' ); ?>"><?php echo wp_kses_post( $row_value ); ?></a></strong>
                                         <?php
                                     }
                                     else {
@@ -3527,7 +3527,7 @@ class PodsUI {
                                             $css_classes[] = 'dragme';
                                         }
                                         ?>
-                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><?php echo $row_value; ?></strong>
+                <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>"><strong><?php echo wp_kses_post( $row_value ); ?></strong>
                                         <?php
                                     }
 
@@ -3655,8 +3655,8 @@ class PodsUI {
                                     $css_classes[] = 'date';
                                     $css_classes[] = 'column-date';
                                     ?>
-                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo $attributes['label'] ?>">
-                                        <abbr title="<?php echo esc_attr( $row_value ); ?>"><?php echo $row_value; ?></abbr>
+                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo esc_attr( $attributes['label'] ); ?>">
+                                        <abbr title="<?php echo esc_attr( $row_value ); ?>"><?php echo wp_kses_post( $row_value ); ?></abbr>
                                         <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
                                     </td>
                                     <?php
@@ -3667,8 +3667,8 @@ class PodsUI {
                                     }
                                     $css_classes[] = 'author';
                                     ?>
-                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo $attributes['label'] ?>">
-                                        <span><?php echo $row_value; ?></span>
+                                    <td class="<?php echo esc_attr( implode( ' ', $css_classes ) ); ?>" data-colname="<?php echo esc_attr( $attributes['label'] ); ?>">
+                                        <span><?php echo wp_kses_post( $row_value ); ?></span>
                                         <?php if ( $first_field ) { ?><button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button><?php }; ?>
                                     </td>
                                     <?php
@@ -3779,7 +3779,7 @@ class PodsUI {
                                             continue;
                                         ?>
                                         <label for="<?php echo esc_attr( $field ); ?>-hide">
-                                            <input class="hide-column-tog" name="<?php echo esc_attr( $this->unique_identifier ); ?>_<?php echo esc_attr( $field ); ?>-hide" type="checkbox" id="<?php echo esc_attr( $field ); ?>-hide" value="<?php echo esc_attr( $field ); ?>" checked="checked"><?php echo $attributes[ 'label' ]; ?></label>
+                                            <input class="hide-column-tog" name="<?php echo esc_attr( $this->unique_identifier ); ?>_<?php echo esc_attr( $field ); ?>-hide" type="checkbox" id="<?php echo esc_attr( $field ); ?>-hide" value="<?php echo esc_attr( $field ); ?>" checked="checked"><?php echo esc_html( $attributes[ 'label' ] ); ?></label>
                                         <?php
                                     }
                                     ?>
@@ -3793,7 +3793,7 @@ class PodsUI {
                                 <?php
                                 if ( true === $this->pagination ) {
                                     ?>
-                                    <input type="text" class="screen-per-page" name="wp_screen_options[value]" id="<?php echo esc_attr( $this->unique_identifier ); ?>_per_page" maxlength="3" value="20"> <label for="<?php echo esc_attr( $this->unique_identifier ); ?>_per_page"><?php echo $this->items; ?> per page</label>
+                                    <input type="text" class="screen-per-page" name="wp_screen_options[value]" id="<?php echo esc_attr( $this->unique_identifier ); ?>_per_page" maxlength="3" value="20"> <label for="<?php echo esc_attr( $this->unique_identifier ); ?>_per_page"><?php echo esc_html( $this->items ); ?> per page</label>
                                     <?php
                                 }
                                 $this->do_hook( 'screen_meta_screen_submit' );
@@ -3903,7 +3903,7 @@ class PodsUI {
             <?php
                 if ( true == $header ) {
                     ?>
-                <span class="paging-input"><input class="current-page" title="<?php esc_attr_e( 'Current page', 'pods' ); ?>" type="text" name="pg<?php echo esc_attr( $this->num ); ?>" value="<?php echo esc_attr( $this->page ); ?>" size="<?php echo esc_attr( strlen( $total_pages ) ); ?>"> <?php _e( 'of', 'pods' ); ?> <span class="total-pages"><?php echo $total_pages; ?></span></span>
+                <span class="paging-input"><input class="current-page" title="<?php esc_attr_e( 'Current page', 'pods' ); ?>" type="text" name="pg<?php echo esc_attr( $this->num ); ?>" value="<?php echo esc_attr( absint( $this->page ) ); ?>" size="<?php echo esc_attr( strlen( $total_pages ) ); ?>"> <?php _e( 'of', 'pods' ); ?> <span class="total-pages"><?php echo absint( $total_pages ); ?></span></span>
                 <script>
 
                     jQuery( document ).ready( function ( $ ) {
@@ -3925,7 +3925,7 @@ class PodsUI {
                 }
                 else {
                     ?>
-                <span class="paging-input"><?php echo $this->page; ?> <?php _e( 'of', 'pods' ); ?> <span class="total-pages"><?php echo number_format_i18n( $total_pages ); ?></span></span>
+                <span class="paging-input"><?php echo absint( $this->page ); ?> <?php _e( 'of', 'pods' ); ?> <span class="total-pages"><?php echo number_format_i18n( $total_pages ); ?></span></span>
                 <?php
                 }
                 ?>

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3276,7 +3276,7 @@ class PodsUI {
                             );
 
                             // Merge with the classes taken from the UI call
-                            if ( is_array( $attributes['classes'] ) ) {
+                            if ( ! empty( $attributes['classes'] ) && is_array( $attributes['classes'] ) ) {
                                 $column_classes = array_merge( $column_classes, $attributes['classes'] );
                             }
                             if ( $id == 'title' ) {
@@ -3453,7 +3453,7 @@ class PodsUI {
                                 );
 
                                 // Merge with the classes taken from the UI call
-                                if ( is_array( $attributes['classes'] ) ) {
+                                if ( ! empty( $attributes['classes'] ) && is_array( $attributes['classes'] ) ) {
                                     $css_classes = array_merge( $css_classes, $attributes['classes'] );
                                 }
 

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3272,9 +3272,9 @@ class PodsUI {
 
                             $column_classes = array(
                                 'manage-column',
-                                'column-' . esc_attr( $id )
+                                'column-' . $id
                             );
-                            
+
                             // Merge with the classes taken from the UI call
                             if ( is_array( $attributes['classes'] ) ) {
                                 $column_classes = array_merge( $column_classes, $attributes['classes'] );

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3274,6 +3274,11 @@ class PodsUI {
                                 'manage-column',
                                 'column-' . esc_attr( $id )
                             );
+                            
+                            // Merge with the classes taken from the UI call
+                            if ( is_array( $attributes['classes'] ) ) {
+                                $column_classes = array_merge( $column_classes, $attributes['classes'] );
+                            }
                             if ( $id == 'title' ) {
                                 $column_classes[] = 'column-primary';
                             }
@@ -3446,6 +3451,11 @@ class PodsUI {
                                 $css_classes = array(
                                     'pods-ui-col-field-' . sanitize_title( $field )
                                 );
+
+                                // Merge with the classes taken from the UI call
+                                if ( is_array( $attributes['classes'] ) ) {
+                                    $css_classes = array_merge( $css_classes, $attributes['classes'] );
+                                }
 
 								if ( $attributes[ 'css_values' ] ) {
 									$css_field_value = $row[ $field ];

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3061,7 +3061,7 @@ class PodsUI {
                             <span class="pods-ui-posts-filter-toggle toggle-off<?php echo esc_attr( empty( $value ) ? ' hidden' : '' ); ?>"><?php _e( 'Clear', 'pods' ); ?></span>
 
                             <label for="pods-form-ui-filter-<?php echo esc_attr( $filter ); ?>">
-                                <?php echo esc$filter_field[ 'label' ]; ?>
+                                <?php echo esc_html( $filter_field[ 'label' ] ); ?>
                             </label>
 
                             <span class="pods-ui-posts-filter<?php echo esc_attr( strlen( $value ) < 1 ? ' hidden' : '' ); ?>">

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -379,10 +379,8 @@ div.pods-manage-field .pods-field-option-group .pods-field-option-group-label {
 .pods-manage-field input[type="radio"] {
 	display: inline-block;
     left: 2px;
-    margin: 1px 7px 0 0;
+    margin: 1px 2px 1px 0;
     float: none;
-    margin-right: 2px;
-    margin-left: 0;
     vertical-align: middle;
 }
 

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -372,13 +372,12 @@ div.pods-manage-field .pods-field-option-group .pods-field-option-group-label {
 .pods-manage-field .pods-field.pods-boolean label,
 .pods-manage-field .pods-pick-values label {
     padding-top: 0;
-    display: block;
-    margin-left: 20px;
+    display: inline-block;
 }
 
 .pods-manage-field input[type="checkbox"],
 .pods-manage-field input[type="radio"] {
-    position: absolute;
+	display: inline-block;
     left: 2px;
     margin: 1px 7px 0 0;
     float: none;

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -489,3 +489,14 @@ div.row-actions.row-actions-toggle {
         width: auto;
     }
 }
+
+@media screen and (max-width: 782px) {
+    /*
+     * Pods wp-list-table
+     */
+    .wp-list-table td.column-secondary {
+        display: block !important;
+        margin-top: -10px;
+        margin-bottom: 5px;
+    }
+}

--- a/ui/css/pods-admin.css
+++ b/ui/css/pods-admin.css
@@ -499,4 +499,8 @@ div.row-actions.row-actions-toggle {
         margin-top: -10px;
         margin-bottom: 5px;
     }
+    .wp-list-table .is-expanded td.column-secondary {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }


### PR DESCRIPTION
Adds the required classes and attributes to form nice responsive view for PodsUI pages.
- Adds the `column-primary` class to the first field (ignores a possible first checkbox field)
- Adds the `data-colname` attributes
- Adds our own `column-secondary` that can be passed with a field when calling PodsUI. A secondary field will always be show so the user won't need to toggle
- Reformatted the code to work with arrays of classes instead of strings. (Easier to manage)
# Edit Pods screen

**Before:**
![image](https://cloud.githubusercontent.com/assets/826148/19000724/8139bfe0-8744-11e6-9760-93a7b6cc07e3.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/826148/19000753/9c8f553e-8744-11e6-9f8f-4445c361c6db.png)
# Manage roles screen

**Before:**
![image](https://cloud.githubusercontent.com/assets/826148/19000833/eb51ed80-8744-11e6-9531-5fe40ddd96db.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/826148/19000838/f246723c-8744-11e6-8e28-1f26334ea3ad.png)
