### PR TITLE
When preloading config after flushing cache, bypass cache

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5351,6 +5351,7 @@ class PodsAPI {
      * $params['id'] int The Pod ID
      * $params['name'] string The Pod name
      * $params['fields'] bool Whether to load fields (default is true)
+     * $params['bypass_cache'] boolean Bypass the cache when getting data
      *
      * @param array|object $params An associative array of parameters or pod name as a string
      * @param bool $strict Makes sure the pod exists, throws an error if it doesn't work
@@ -5368,6 +5369,7 @@ class PodsAPI {
 
         $current_language = false;
         $load_fields = true;
+	    $bypass_cache = false;
 
 	    // Get current language data
 		$lang_data = self::get_current_language();
@@ -5442,6 +5444,10 @@ class PodsAPI {
                 return false;
             }
 
+		    if ( ! empty( $params->bypass_cache ) ) {
+		        $bypass_cache = true;
+		    }
+
             if ( isset( $params->name ) ) {
                 $pod = false;
 
@@ -5471,7 +5477,7 @@ class PodsAPI {
 						'fields' => array()
 					);
 				}
-                elseif ( pods_api_cache() )
+                elseif ( ! $bypass_cache & pods_api_cache() )
                     $pod = pods_transient_get( $transient . '_' . $params->name );
 
                 if ( false !== $pod && ( ! $table_info || isset( $pod[ 'table' ] ) ) ) {
@@ -5508,7 +5514,7 @@ class PodsAPI {
 
         $pod = false;
 
-        if ( pods_api_cache() )
+        if ( ! $bypass_cache || pods_api_cache() )
             $pod = pods_transient_get( $transient . '_' . $_pod[ 'post_name' ] );
 
         if ( false !== $pod && ( ! $table_info || isset( $pod[ 'table' ] ) ) ) {
@@ -5601,6 +5607,7 @@ class PodsAPI {
             foreach ( $fields as $field ) {
                 $field->pod = $pod[ 'name' ];
                 $field->table_info = $table_info;
+                $field->bypass_cache = $bypass_cache;
 
                 if ( $load_fields ) {
                     $field = $this->load_field( $field );
@@ -5641,6 +5648,7 @@ class PodsAPI {
      * $params['ids'] boolean Return only an array of ID => label
      * $params['fields'] boolean Return pod fields with Pods (default is true)
      * $params['key_names'] boolean Return pods keyed by name
+     * $params['bypass_cache'] boolean Bypass the cache when getting data
      *
      * @param array $params An associative array of parameters
      *
@@ -5672,6 +5680,10 @@ class PodsAPI {
 
         $meta_query = array();
         $cache_key = '';
+
+	    if ( ! isset( $params->bypass_cache ) ) {
+	    	$params->bypass_cache = false;
+	    }
 
         if ( isset( $params->type ) && !empty( $params->type ) ) {
             if ( !is_array( $params->type ) )
@@ -5781,7 +5793,7 @@ class PodsAPI {
         else
             $cache_key = 'pods' . $pre_key . $cache_key;
 
-        if ( pods_api_cache() && !empty( $cache_key ) && ( 'pods' . ( !empty( $current_language ) ? '_' . $current_language : '' ) . '_get_all' != $cache_key || empty( $meta_query ) ) && $limit < 1 && ( empty( $orderby ) || 'menu_order title' == $orderby ) && empty( $ids ) ) {
+        if ( ! $params->bypass_cache && pods_api_cache() && !empty( $cache_key ) && ( 'pods' . ( !empty( $current_language ) ? '_' . $current_language : '' ) . '_get_all' != $cache_key || empty( $meta_query ) ) && $limit < 1 && ( empty( $orderby ) || 'menu_order title' == $orderby ) && empty( $ids ) ) {
             $the_pods = pods_transient_get( $cache_key );
 
             if ( false === $the_pods )
@@ -5859,7 +5871,7 @@ class PodsAPI {
                     if ( isset( $params->fields ) && !$params->fields )
                         $pod->fields = false;
 
-                    $pod = $this->load_pod( array( 'pod' => $pod, 'table_info' => ! empty( $params->table_info ) ) );
+                    $pod = $this->load_pod( array( 'pod' => $pod, 'table_info' => ! empty( $params->table_info ), 'bypass_cache' => $params->bypass_cache ) );
 
                     // Remove extra data not needed
                     if ( pods_var( 'export', $params, false ) && ( !isset( $params->fields ) || $params->fields ) ) {
@@ -5954,6 +5966,7 @@ class PodsAPI {
      * $params['id'] int The field ID
      * $params['name'] string The field name
      * $params['table_info'] boolean Whether to lookup a pick field's table info
+     * $params['bypass_cache'] boolean Bypass the cache when getting data
      *
      * @param array $params An associative array of parameters
      * @param boolean $strict Whether to require a field exist or not when loading the info
@@ -5966,6 +5979,9 @@ class PodsAPI {
 
         if ( !isset( $params->table_info ) )
             $params->table_info = false;
+
+        if ( !isset( $params->bypass_cache ) )
+            $params->bypass_cache = false;
 
         $pod = array();
         $field = array();
@@ -5984,7 +6000,7 @@ class PodsAPI {
             if ( isset( $params->pod_data ) )
                 $pod = $params->pod_data;
             else {
-                $pod = $this->load_pod( array( 'name' => $params->pod, 'id' => $params->pod_id, 'table_info' => false ), false );
+                $pod = $this->load_pod( array( 'name' => $params->pod, 'id' => $params->pod_id, 'table_info' => false, 'bypass_cache' => $params->bypass_cache ), false );
 
                 if ( false === $pod ) {
                     if ( $strict )
@@ -6007,7 +6023,7 @@ class PodsAPI {
 
             $field = false;
 
-            if ( pods_api_cache() )
+            if ( ! $params->bypass_cache && pods_api_cache() )
                 $field = pods_transient_get( 'pods_field_' . $params->pod . '_' . $params->name );
 
             if ( empty( $field ) ) {
@@ -6053,7 +6069,7 @@ class PodsAPI {
         }
 
         if ( empty( $field ) ) {
-            if ( pods_api_cache() && ( isset( $pod[ 'name' ] ) || isset( $_field[ 'pod' ] ) ) )
+            if ( ! $params->bypass_cache && pods_api_cache() && ( isset( $pod[ 'name' ] ) || isset( $_field[ 'pod' ] ) ) )
                 $field = pods_transient_get( 'pods_field_' . pods_var( 'name', $pod, pods_var( 'pod', $_field ), null, true ) . '_' . $_field[ 'post_name' ] );
 
             if ( empty( $field ) ) {

--- a/ui/admin/settings-tools.php
+++ b/ui/admin/settings-tools.php
@@ -6,7 +6,7 @@
             $api->cache_flush_pods();
 
 			if ( defined( 'PODS_PRELOAD_CONFIG_AFTER_FLUSH' ) && PODS_PRELOAD_CONFIG_AFTER_FLUSH ) {
-				$api->load_pods();
+				$api->load_pods( array( 'bypass_cache' => true ) );
 			}
 
             pods_redirect( pods_query_arg( array( 'pods_clearcache' => 1 ), array( 'page', 'tab' ) ) );


### PR DESCRIPTION
This solves the issue when running multisite and you’ve got an object cache drop-in that won’t flush cache for multisite when wp_cache_flush is called