### PR TITLE
Update the attachment parent if updating a post type

### DIFF
--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -406,13 +406,24 @@ class PodsField_File extends PodsField {
             if ( empty( $id ) )
                 continue;
 
+            $attachment_data = array();
+
             // Update the title if set
             if ( false !== $title && 1 == pods_var( self::$type . '_edit_title', $options, 0 ) ) {
-                $attachment_data = array(
-                    'ID' => $id,
-                    'post_title' => $title
-                );
+                $attachment_data['post_title'] = $title;
+            }
 
+            // Update attachment parent if it's not set yet and we're updating a post
+            if ( ! empty( $params->id ) && ! empty( $pod['type'] ) && 'post_type' == $pod['type'] ) {
+                $attachment = get_post( $id );
+                if ( isset( $attachment->post_parent ) && 0 === (int) $attachment->post_parent ) {
+                    $attachment_data['post_parent'] = (int) $params->id;
+                }
+            }
+
+            // Update the attachment if it the data array is not still empty
+            if ( ! empty( $attachment_data ) ) {
+                $attachment_data['ID'] = $id;
                 self::$api->save_wp_object( 'media', $attachment_data );
             }
         }


### PR DESCRIPTION
- Only updates if the parent isn't set yet.
- Small rewrite of the `save` logic for the file field.

Fixes/Related: https://github.com/pods-framework/pods/issues/3808

Possible improvements:
- Delete the attachment when removing >> Can give some problems if the file is used multiple times in the post... I personally don't think we should do this. (Related: https://github.com/pods-framework/pods/issues/3793)
