### PR TITLE
Fix slash problem with LIKE statements

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -111,7 +111,7 @@ function pods_sanitize_like( $input ) {
 	}
 	else {
 		global $wpdb;
-		$input = wp_unslash( $input );
+		$input = pods_unslash( $input );
 
 		if ( pods_version_check( 'wp', '4.0' ) ) {
 			$output = pods_sanitize( $wpdb->esc_like( $input ) );

--- a/includes/data.php
+++ b/includes/data.php
@@ -111,13 +111,14 @@ function pods_sanitize_like( $input ) {
 	}
 	else {
 		global $wpdb;
+		$input = wp_unslash( $input );
 
 		if ( pods_version_check( 'wp', '4.0' ) ) {
-			$output = $wpdb->esc_like( pods_sanitize( $input ) );
+			$output = pods_sanitize( $wpdb->esc_like( $input ) );
 		}
 		else {
 			// like_escape is deprecated in WordPress 4.0
-			$output = like_escape( pods_sanitize( $input ) );
+			$output = pods_sanitize( like_escape( $input ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #3823 

About sanitizing `$wpdb->esc_like()` input:

> This needs to be done **after** using $wpdb->esc_like(), to ensure correct and secure slashing of the string.

https://codex.wordpress.org/Class_Reference/wpdb/esc_like
