### PR TITLE
Add Magic Tag reference for Templates

### DIFF
--- a/components/Templates/class-pods_templates.php
+++ b/components/Templates/class-pods_templates.php
@@ -212,6 +212,13 @@ class Pods_Templates_Frontier {
 			'slug' => 'pod_reference',
 			'groups' => array()
 		) );
+		add_meta_box( 'pod_reference', __( 'Magic Tag Reference', 'pods' ), array(
+			$this,
+			'render_metaboxes_custom'
+		), '_pods_template', 'side', 'default', array(
+			'slug' => 'tag_reference',
+			'groups' => array()
+		) );
 
 	}
 


### PR DESCRIPTION
We should add brief information about the magic tags on the Template screen.