### PR TITLE
Make field labels translatable

### DIFF
--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -42,7 +42,7 @@ class PodsField_Avatar extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+        self::$label = __( 'Avatar', 'pods' );
     }
 
     /**

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -36,7 +36,7 @@ class PodsField_Boolean extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Yes / No', 'pods' );
     }
 
     /**

--- a/classes/fields/code.php
+++ b/classes/fields/code.php
@@ -44,7 +44,7 @@ class PodsField_Code extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Code (Syntax Highlighting)', 'pods' );
     }
 
     /**

--- a/classes/fields/color.php
+++ b/classes/fields/color.php
@@ -34,7 +34,7 @@ class PodsField_Color extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Color Picker', 'pods' );
     }
 
     /**

--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -72,9 +72,8 @@ class PodsField_Currency extends PodsField {
 	 * @since 2.0
 	 */
 	public function __construct() {
-
+		self::$label = __( 'Currency', 'pods' );
 		self::$currencies = apply_filters( 'pods_form_ui_field_currency_currencies', self::$currencies );
-		
 	}
 
 	/**

--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -42,7 +42,7 @@ class PodsField_Date extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Date', 'pods' );
     }
 
     /**

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -42,7 +42,7 @@ class PodsField_DateTime extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Date / Time', 'pods' );
     }
 
     /**

--- a/classes/fields/email.php
+++ b/classes/fields/email.php
@@ -42,7 +42,7 @@ class PodsField_Email extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'E-mail', 'pods' );
     }
 
     /**

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -42,7 +42,7 @@ class PodsField_File extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+        self::$label = __( 'File / Image / Video', 'pods' );
     }
 
     /**

--- a/classes/fields/html.php
+++ b/classes/fields/html.php
@@ -42,7 +42,7 @@ class PodsField_HTML extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'HTML', 'pods' );
     }
 
     /**

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -42,7 +42,7 @@ class PodsField_Number extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Plain Number', 'pods' );
     }
 
     /**

--- a/classes/fields/paragraph.php
+++ b/classes/fields/paragraph.php
@@ -42,7 +42,7 @@ class PodsField_Paragraph extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Plain Paragraph Text', 'pods' );
     }
 
     /**

--- a/classes/fields/password.php
+++ b/classes/fields/password.php
@@ -42,7 +42,7 @@ class PodsField_Password extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Password', 'pods' );
     }
 
     /**

--- a/classes/fields/phone.php
+++ b/classes/fields/phone.php
@@ -42,7 +42,7 @@ class PodsField_Phone extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Phone', 'pods' );
     }
 
     /**

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -98,7 +98,7 @@ class PodsField_Pick extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Relationship', 'pods' );
     }
 
     /**

--- a/classes/fields/slug.php
+++ b/classes/fields/slug.php
@@ -42,7 +42,7 @@ class PodsField_Slug extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Permalink (url-friendly)', 'pods' );
     }
 
     /**

--- a/classes/fields/taxonomy.php
+++ b/classes/fields/taxonomy.php
@@ -12,6 +12,7 @@ class PodsField_Taxonomy extends PodsField_Pick {
      * @since 2.0
      */
     public function __construct () {
+	    parent::__construct();
 		// this field type just maps to the relationship field
     }
 

--- a/classes/fields/text.php
+++ b/classes/fields/text.php
@@ -42,7 +42,7 @@ class PodsField_Text extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Plain Text', 'pods' );
     }
 
     /**

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -42,7 +42,7 @@ class PodsField_Time extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'Time', 'pods' );
     }
 
     /**

--- a/classes/fields/website.php
+++ b/classes/fields/website.php
@@ -42,7 +42,7 @@ class PodsField_Website extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+        self::$label = __( 'Website', 'pods' );
     }
 
     /**

--- a/classes/fields/wysiwyg.php
+++ b/classes/fields/wysiwyg.php
@@ -42,7 +42,7 @@ class PodsField_WYSIWYG extends PodsField {
      * @since 2.0
      */
     public function __construct () {
-
+	    self::$label = __( 'WYSIWYG (Visual Editor)', 'pods' );
     }
 
     /**


### PR DESCRIPTION
Fixes #3849

**Todo for 2.7:**
- [ ] Make `Link` field label translatable
- [x] Make `oEmbed` field label translatable #3803 
- [x] Make `Address` field label translatable #3634 