### PR TITLE
Make sure self::$field_data is set in all cases

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -1401,6 +1401,13 @@ class PodsField_Pick extends PodsField {
                     self::$related_objects[ $options[ self::$type . '_object' ] ][ 'data_callback' ],
                     array( $name, $value, $options, $pod, $id )
                 );
+                if ( 'data' == $context ) {
+                    self::$field_data = array(
+                        'field' => $name,
+                        'id' => $options[ 'id' ],
+                        'autocomplete' => false
+                    );
+                }
 
 				$simple = true;
 


### PR DESCRIPTION
What is happening in the situation that a data_callback is set (like with a predefined list) is the check in PodsField_Pick->input() that sets $ajax properly is not working because
self::$field_data[ 'id' ] == $options[ 'id' ] is not true since the $field_data contains data from the previous field that was loaded

Resolves #3862