### PR TITLE
Pass audio_args to audio shortcode

### DIFF
--- a/includes/media.php
+++ b/includes/media.php
@@ -350,7 +350,7 @@ function pods_audio( $url, $args = false ) {
 		$audio_args = array_merge(  $audio_args, $args );
 	}
 
-	return wp_audio_shortcode( $args );
+	return wp_audio_shortcode( $audio_args );
 
 }
 


### PR DESCRIPTION
Noticed that having multiple audio files using this on one page played the same file, turns out the 'src' wasn't getting passed into wp_audio_shortcode