### PR TITLE
Add new singular capabilities for taxonomies (WP 4.7)

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -2331,16 +2331,18 @@ class PodsAdmin {
                     $capabilities[] = 'delete_' . $capability_type;
 
                     if ( 1 == pods_var( 'capability_type_extra', $pod[ 'options' ], 1 ) ) {
-                        $capabilities[] = 'read_private_' . $capability_type . 's';
-                        $capabilities[] = 'edit_' . $capability_type . 's';
-                        $capabilities[] = 'edit_others_' . $capability_type . 's';
-                        $capabilities[] = 'edit_private_' . $capability_type . 's';
-                        $capabilities[] = 'edit_published_' . $capability_type . 's';
-                        $capabilities[] = 'publish_' . $capability_type . 's';
-                        $capabilities[] = 'delete_' . $capability_type . 's';
-                        $capabilities[] = 'delete_private_' . $capability_type . 's';
-                        $capabilities[] = 'delete_published_' . $capability_type . 's';
-                        $capabilities[] = 'delete_others_' . $capability_type . 's';
+	                    $capability_type_plural = $capability_type . 's';
+
+                        $capabilities[] = 'read_private_' . $capability_type_plural;
+                        $capabilities[] = 'edit_' . $capability_type_plural;
+                        $capabilities[] = 'edit_others_' . $capability_type_plural;
+                        $capabilities[] = 'edit_private_' . $capability_type_plural;
+                        $capabilities[] = 'edit_published_' . $capability_type_plural;
+                        $capabilities[] = 'publish_' . $capability_type_plural;
+                        $capabilities[] = 'delete_' . $capability_type_plural;
+                        $capabilities[] = 'delete_private_' . $capability_type_plural;
+                        $capabilities[] = 'delete_published_' . $capability_type_plural;
+                        $capabilities[] = 'delete_others_' . $capability_type_plural;
                     }
                 }
             }
@@ -2348,12 +2350,18 @@ class PodsAdmin {
                 if ( 'custom' == pods_var( 'capability_type', $pod[ 'options' ], 'terms' ) ) {
                     $capability_type = pods_var( 'capability_type_custom', $pod[ 'options' ], pods_var_raw( 'name', $pod ) . 's' );
 
-                    $capability_type .= '_terms';
+	                $capability_type .= '_term';
+	                $capability_type_plural = $capability_type . 's';
 
-                    $capabilities[] = 'manage_' . $capability_type;
-                    $capabilities[] = 'edit_' . $capability_type;
-                    $capabilities[] = 'delete_' . $capability_type;
-                    $capabilities[] = 'assign_' . $capability_type;
+	                // Singular
+	                $capabilities[] = 'edit_' . $capability_type;
+	                $capabilities[] = 'delete_' . $capability_type;
+	                $capabilities[] = 'assign_' . $capability_type;
+	                // Plural
+                    $capabilities[] = 'manage_' . $capability_type_plural;
+                    $capabilities[] = 'edit_' . $capability_type_plural;
+                    $capabilities[] = 'delete_' . $capability_type_plural;
+                    $capabilities[] = 'assign_' . $capability_type_plural;
                 }
             }
             else {

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -2331,7 +2331,7 @@ class PodsAdmin {
                     $capabilities[] = 'delete_' . $capability_type;
 
                     if ( 1 == pods_var( 'capability_type_extra', $pod[ 'options' ], 1 ) ) {
-	                    $capability_type_plural = $capability_type . 's';
+                        $capability_type_plural = $capability_type . 's';
 
                         $capabilities[] = 'read_private_' . $capability_type_plural;
                         $capabilities[] = 'edit_' . $capability_type_plural;
@@ -2350,14 +2350,14 @@ class PodsAdmin {
                 if ( 'custom' == pods_var( 'capability_type', $pod[ 'options' ], 'terms' ) ) {
                     $capability_type = pods_var( 'capability_type_custom', $pod[ 'options' ], pods_var_raw( 'name', $pod ) . 's' );
 
-	                $capability_type .= '_term';
-	                $capability_type_plural = $capability_type . 's';
+                    $capability_type .= '_term';
+                    $capability_type_plural = $capability_type . 's';
 
-	                // Singular
-	                $capabilities[] = 'edit_' . $capability_type;
-	                $capabilities[] = 'delete_' . $capability_type;
-	                $capabilities[] = 'assign_' . $capability_type;
-	                // Plural
+                    // Singular
+                    $capabilities[] = 'edit_' . $capability_type;
+                    $capabilities[] = 'delete_' . $capability_type;
+                    $capabilities[] = 'assign_' . $capability_type;
+                    // Plural
                     $capabilities[] = 'manage_' . $capability_type_plural;
                     $capabilities[] = 'edit_' . $capability_type_plural;
                     $capabilities[] = 'delete_' . $capability_type_plural;

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -659,12 +659,18 @@ class PodsInit {
 				if ( 'custom' == $capability_type ) {
 					$capability_type = pods_var( 'capability_type_custom', $taxonomy, 'default' );
 					if ( ! empty( $capability_type ) && 'default' != $capability_type ) {
-						$capability_type .=  '_terms';
+						$capability_type .=  '_term';
+						$capability_type_plural =  $capability_type . 's';
 						$tax_capabilities = array(
-							'manage_terms' => 'manage_' . $capability_type,
-							'edit_terms'   => 'edit_' . $capability_type,
-							'delete_terms' => 'delete_' . $capability_type,
-							'assign_terms' => 'assign_' . $capability_type,
+							// Singular
+							'edit_term'   => 'edit_' . $capability_type,
+							'delete_term' => 'delete_' . $capability_type,
+							'assign_term' => 'assign_' . $capability_type,
+							// Plural
+							'manage_terms' => 'manage_' . $capability_type_plural,
+							'edit_terms'   => 'edit_' . $capability_type_plural,
+							'delete_terms' => 'delete_' . $capability_type_plural,
+							'assign_terms' => 'assign_' . $capability_type_plural,
 						);
 					}
 				}


### PR DESCRIPTION
Quick fixes #3896 

For Pods 2.7 (or later) I think we should revisit the capability handling for Pods.
Since WP 4.7 there are two default capabilities for taxonomies: `category` & `tag`, just like with posts (`post` & `page`).
I'll create a new ticket for this (not a high priority issue).