### PR TITLE
Allow pod_exists() to work if passed a post_type name

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5324,6 +5324,7 @@ class PodsAPI {
                     'post_type' => '_pods_pod',
                     'posts_per_page' => 1
                 ) );
+
                 if ( is_array( $pod ) ) {
                     $pod = $pod[0];
                 }

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5324,6 +5324,9 @@ class PodsAPI {
                     'post_type' => '_pods_pod',
                     'posts_per_page' => 1
                 ) );
+                if ( is_array( $pod ) ) {
+                    $pod = $pod[0];
+                }
             }
 
             if ( !empty( $pod ) && ( empty( $type ) || $type == get_post_meta( $pod->ID, 'type', true ) ) )


### PR DESCRIPTION
get_posts() returns an array with the results even if you are only asking for 1 post per page.