### PR TITLE
Only allow admins access to the 'pq_loadpod' AJAX action

### DIFF
--- a/components/Templates/includes/functions-pod_reference.php
+++ b/components/Templates/includes/functions-pod_reference.php
@@ -3,6 +3,9 @@
 add_action( 'wp_ajax_pq_loadpod', 'pq_loadpod' );
 
 function pq_loadpod($podname = false) {
+	if ( !pods_is_admin() ) {
+		pods_error( __( 'Unauthorized request', 'pods' ) );
+	}
 	if(!empty($_POST['pod_reference']['pod'])){
 		$podname = $_POST['pod_reference']['pod'];
 	}


### PR DESCRIPTION
Currently any logged in user can execute this AJAX action which would allow them to return a list of the names of all of the elements on any Pod.

Not a major issue, but should be protected anyways.