### PR TITLE
Change method of short circuiting WordPress shortcodes

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -1015,6 +1015,7 @@ function pods_do_shortcode( $content, $shortcodes ) {
 	if ( isset( $temp_shortcode_filter ) ) {
 		remove_filter( 'pre_do_shortcode_tag', $temp_shortcode_filter );
 	}
+	
 	return $content;
 
 }

--- a/includes/general.php
+++ b/includes/general.php
@@ -1001,7 +1001,7 @@ function pods_do_shortcode( $content, $shortcodes ) {
 	if ( !empty( $shortcodes ) ) {
 		$temp_shortcode_filter = function ( $return, $tag, $attr, $m ) use ( $shortcodes ) {
 			if ( in_array( $m[2], $shortcodes ) ) {
-				// If shortcode being called is is list, return false to allow it to run
+				// If shortcode being called is in list, return false to allow it to run
 				return false;
 			}
 			// Return original shortcode string if we aren't going to handle at this time

--- a/includes/general.php
+++ b/includes/general.php
@@ -1015,7 +1015,7 @@ function pods_do_shortcode( $content, $shortcodes ) {
 	if ( isset( $temp_shortcode_filter ) ) {
 		remove_filter( 'pre_do_shortcode_tag', $temp_shortcode_filter );
 	}
-	
+
 	return $content;
 
 }

--- a/includes/general.php
+++ b/includes/general.php
@@ -998,25 +998,23 @@ function pods_do_shortcode( $content, $shortcodes ) {
 		return $content;
 	}
 
-	// Store all shortcodes, to restore later
-	$temp_shortcode_tags = $shortcode_tags;
-
-	// Loop through all shortcodes and remove those not being used right now
-	foreach ( $shortcode_tags as $tag => $callback ) {
-		if ( ! in_array( $tag, $shortcodes ) ) {
-			unset( $shortcode_tags[ $tag ] );
-		}
+	if ( !empty( $shortcodes ) ) {
+		$temp_shortcode_filter = function ( $return, $tag, $attr, $m ) use ( $shortcodes ) {
+			if ( in_array( $m[2], $shortcodes ) ) {
+				// If shortcode being called is is list, return false to allow it to run
+				return false;
+			}
+			// Return original shortcode string if we aren't going to handle at this time
+			return $m[0];
+		};
+		add_filter( 'pre_do_shortcode_tag', $temp_shortcode_filter, 10, 4 );
 	}
 
-	// Build Shortcode regex pattern just for the shortcodes we want
-	$pattern = get_shortcode_regex();
+	$content = do_shortcode( $content );
 
-	// Call shortcode callbacks just for the shortcodes we want
-	$content = preg_replace_callback( "/$pattern/s", 'do_shortcode_tag', $content );
-
-	// Restore all shortcode tags
-	$shortcode_tags = $temp_shortcode_tags;
-
+	if ( isset( $temp_shortcode_filter ) ) {
+		remove_filter( 'pre_do_shortcode_tag', $temp_shortcode_filter );
+	}
 	return $content;
 
 }


### PR DESCRIPTION
In this new way we don't unset all of the un-needed shortcodes, just add a temporary filter that stops it from executing.