### PR TITLE
Tame the template reference recursion

### DIFF
--- a/components/Templates/includes/functions-pod_reference.php
+++ b/components/Templates/includes/functions-pod_reference.php
@@ -3,31 +3,19 @@
 add_action( 'wp_ajax_pq_loadpod', 'pq_loadpod' );
 
 function pq_loadpod($podname = false) {
+	if ( !pods_is_admin() ) {
+		pods_error( __( 'Unauthorized request', 'pods' ) );
+	}
 	if(!empty($_POST['pod_reference']['pod'])){
 		$podname = $_POST['pod_reference']['pod'];
 	}
 	if(!empty($_POST['pod'])){
 		$podname = $_POST['pod'];
-
 	}
-	$fields = array('No reference Pod selected');
+	$fields = array( __( 'No reference Pod selected', 'pods' ) );
+
 	if(!empty($podname)){
-		$pod = pods( $podname );
-		$fields = array();
-		foreach( $pod->pod_data['object_fields'] as $name=>$field ){
-			$fields[] = $name;
-		}
-		$pod_fields = $pod->fields();
-		if( post_type_supports( $podname, 'thumbnail' ) ){
-			$fields[] = 'post_thumbnail';
-			$fields[] = 'post_thumbnail_url';
-			$sizes = get_intermediate_image_sizes();
-			foreach( $sizes as &$size){
-				$fields[] = 'post_thumbnail.'.$size;
-				$fields[] = 'post_thumbnail_url.'.$size;
-			}
-		}
-		$fields = array_merge( $fields, pq_tunnel_pod_field( $pod_fields ) );
+		$fields = pq_recurse_pod_fields( $podname );
 	}
 	if(!empty($_POST['pod_reference']['pod']) || !empty($_POST['pod'])){
 		header("Content-Type:application/json");
@@ -37,69 +25,59 @@ function pq_loadpod($podname = false) {
 	return $fields;
 }
 
-function pq_tunnel_pod_field( $fields, $prefix = null ){
-
-	$out = array();
-	// return out if fields are empty
-	if(empty($fields)){
-		return $out;
+function pq_recurse_pod_fields( $pod_name, $prefix = '', &$pods_visited = array() ) {
+	$fields = array();
+	if ( empty( $pod_name ) ) {
+		return $fields;
 	}
-	foreach($fields as $name=>$field){
-		$out[] = $prefix . $name;
-		if($field['type'] === 'file' && $field['options']['file_uploader'] == 'attachment'){
+	$pod = pods( $pod_name );
+	$recurse_queue = array();
 
-		$out[] = $prefix . $name .'._src';
-		$out[] = $prefix . $name .'._img';
+	foreach( $pod->pod_data['object_fields'] as $name => $field ){
+		// Add WordPress object fields
+		$fields[] = $prefix . $name;
+	}
+	if ( post_type_supports( $pod_name, 'thumbnail' ) ) {
+		$fields[] = '{$prefix}post_thumbnail';
+		$fields[] = '{$prefix}post_thumbnail_url';
+		$sizes = get_intermediate_image_sizes();
+		foreach ( $sizes as $size ) {
+			$fields[] = "{$prefix}post_thumbnail.{$size}";
+			$fields[] = "{$prefix}post_thumbnail_url.{$size}";
+		}
+	}
+	$pod_fields = $pod->fields();
+	foreach ( $pod_fields as $name => $field ) {
+		// Add base field name
+		$fields[] = $prefix . $name;
+
+		// Field type specific handling
+		if ( 'file' === $field['type'] && 'attachment' === $field['options']['file_uploader'] ) {
+			$fields[] = $prefix . $name . '._src';
+			$fields[] = $prefix . $name . '._img';
 
 			$sizes = get_intermediate_image_sizes();
-			foreach( $sizes as &$size){
-				$out[] = $prefix . $name . '._src.'.$size;
-			}
-			if( 'multi' != $field['options']['file_format_type']){
-				foreach( $sizes as &$size){
-					$out[] = $prefix . $name . '._src_relative.'.$size;
+			foreach ( $sizes as $size ) {
+				$fields[] = "{$prefix}{$name}._src.{$size}";
+				if ( 'multi' != $field['options']['file_format_type'] ) {
+					$fields[] = "{$prefix}{$name}._src_relative.{$size}";
+					$fields[] = "{$prefix}{$name}._src_schemeless.{$size}";
 				}
-				foreach( $sizes as &$size){
-					$out[] = $prefix . $name . '._src_schemeless.'.$size;
-				}
+				$fields[] = "{$prefix}{$name}._img.{$size}";
 			}
-			foreach( $sizes as &$size){
-				$out[] = $prefix . $name . '._img.'.$size;
-			}
-		}
-		if( !empty( $field['table_info'] ) ){
-			if( !empty( $field['table_info']['pod'] ) ){
-				if( false === strpos( $prefix, $name . '.' ) ){
 
-					$pod = pods( $field['table_info']['pod']['name'] );
-					// only tunnel in if there are object fields
-					if(!empty($field['table_info']['object_fields'])){
-						$out = array_merge( $out, pq_tunnel_pod_field( $field['table_info']['object_fields'], $prefix . $name . '.' ) );
-					}
-					if( post_type_supports( $field['table_info']['pod']['name'], 'thumbnail' ) ){
-						$out[] = 'post_thumbnail';
-						$out[] = 'post_thumbnail_url';
-						$sizes = get_intermediate_image_sizes();
-						foreach( $sizes as &$size){
-							$out[] = 'post_thumbnail.'.$size;
-							$out[] = 'post_thumbnail_url.'.$size;
-						}
-					}
-					$pod_fields = $pod->fields();
-					$out = array_merge( $out, pq_tunnel_pod_field( $pod_fields, $prefix . $name . '.') );
-				}
-			}else{
-				
-				if(!empty($field['table_info']['object_fields'])){
-				
-					$out = array_merge( $out, pq_tunnel_pod_field( $field['table_info']['object_fields'], $prefix . $name . '.') );
-				
-				}
-
+		} elseif ( ! empty( $field['table_info'] ) && ! empty( $field['table_info']['pod'] ) ) {
+			$linked_pod = $field['table_info']['pod']['name'];
+			if (  !isset( $pods_visited[ $linked_pod ] ) || !in_array( $name, $pods_visited[ $linked_pod ] ) ) {
+				$pods_visited[ $linked_pod ][] = $name;
+				$recurse_queue[ $linked_pod ] = "{$prefix}{$name}.";
 			}
+
 		}
 	}
-
-	return $out;
+	foreach ( $recurse_queue as $recurse_name => $recurse_prefix ) {
+		$fields = array_merge( $fields, pq_recurse_pod_fields( $recurse_name, $recurse_prefix, $pods_visited ) );
+	}
+	return $fields;
 }
 


### PR DESCRIPTION
Fixes #3370, #3992
This cleans up the code quite a bit.  Still not perfect and the ordering might need to be adjusted a bit but it will keep everything from exploding.

Related to #3370

Also includes #3992 since it covers the same functions

Replaces #3999 which was a PR from my own fork