### PR TITLE
Search the proper SQL column with 'search' and meta based CPT

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1028,7 +1028,7 @@ class PodsData {
                         }
                         elseif ( isset( $params->fields[ $field ] ) ) {
                             if ( $params->meta_fields )
-                                $fieldfield = $fieldfield . '.`' . $params->pod_table_prefix . '`';
+                                $fieldfield = $fieldfield . '.`meta_value`';
                             else
                                 $fieldfield = '`' . $params->pod_table_prefix . '`.' . $fieldfield;
                         }


### PR DESCRIPTION
Ran into this issue myself.  The field traversal tests currently do not cover testing the 'search' type of find.
Search works fine on Table based CPT or ACT but not on Meta based CPT.

Fixes #3858