### PR TITLE
Correct usage of single and double quotes

### DIFF
--- a/components/Templates/includes/functions-pod_reference.php
+++ b/components/Templates/includes/functions-pod_reference.php
@@ -38,8 +38,8 @@ function pq_recurse_pod_fields( $pod_name, $prefix = '', &$pods_visited = array(
 		$fields[] = $prefix . $name;
 	}
 	if ( post_type_supports( $pod_name, 'thumbnail' ) ) {
-		$fields[] = '{$prefix}post_thumbnail';
-		$fields[] = '{$prefix}post_thumbnail_url';
+		$fields[] = "{$prefix}post_thumbnail";
+		$fields[] = "{$prefix}post_thumbnail_url";
 		$sizes = get_intermediate_image_sizes();
 		foreach ( $sizes as $size ) {
 			$fields[] = "{$prefix}post_thumbnail.{$size}";


### PR DESCRIPTION
Pod Reference in the Template admin does output {$prefix} in Plain Text due to incorrect ' usage!