### PR TITLE
Number/Currency field enhancements

### DIFF
--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -1,9 +1,10 @@
 <?php
+require_once( PODS_DIR . 'classes/fields/number.php' );
 
 /**
  * @package Pods\Fields
  */
-class PodsField_Currency extends PodsField {
+class PodsField_Currency extends PodsField_Number {
 
 	/**
 	 * Field Type Group
@@ -52,7 +53,7 @@ class PodsField_Currency extends PodsField {
 	 */
 	public function __construct() {
 		self::$label = __( 'Currency', 'pods' );
-		self::data_currencies();
+		static::data_currencies();
 	}
 
 	/**
@@ -65,7 +66,7 @@ class PodsField_Currency extends PodsField {
 	public function options() {
 
 		$currency_options = array();
-		foreach ( self::$currencies as $key => $value ) {
+		foreach ( static::$currencies as $key => $value ) {
 			$currency = $value['label'];
 			if ( $value['label'] != $value['name'] ) {
 				$currency .= ': ' . $value['name'];
@@ -75,7 +76,7 @@ class PodsField_Currency extends PodsField {
 		}
 
 		$options = array(
-			self::$type . '_repeatable' => array(
+			static::$type . '_repeatable' => array(
 				'label' => __( 'Repeatable Field', 'pods' ),
 				'default' => 0,
 				'type' => 'boolean',
@@ -84,7 +85,7 @@ class PodsField_Currency extends PodsField {
 				'dependency' => true,
 				'developer_mode' => true
 			),
-			self::$type . '_format_type' => array(
+			static::$type . '_format_type' => array(
 				'label' => __( 'Input Type', 'pods' ),
 				'default' => 'number',
 				'type' => 'pick',
@@ -94,13 +95,14 @@ class PodsField_Currency extends PodsField {
 				),
 				'dependency' => true
 			),
-			self::$type . '_format_sign' => array(
+			static::$type . '_format_sign' => array(
 				'label' => __( 'Currency Sign', 'pods' ),
 				'default' => apply_filters( 'pods_form_ui_field_number_currency_default', 'usd' ),
 				'type' => 'pick',
+				//'pick_format_single' => 'autocomplete',
 				'data' => apply_filters( 'pods_form_ui_field_number_currency_options', $currency_options )
 			),
-			self::$type . '_format_placement' => array(
+			static::$type . '_format_placement' => array(
 				'label' => __( 'Currency Placement', 'pods' ),
 				'default' => apply_filters( 'pods_form_ui_field_number_currency_placement_default', 'before' ),
 				'type' => 'pick',
@@ -111,7 +113,7 @@ class PodsField_Currency extends PodsField {
 					'beforeaftercode' => __( 'Before with Currency Code after (ex. $100 USD)', 'pods' )
 				)
 			),
-			self::$type . '_format' => array(
+			static::$type . '_format' => array(
 				'label' => __( 'Format', 'pods' ),
 				'default' => apply_filters( 'pods_form_ui_field_number_currency_format_default', 'i18n' ),
 				'type' => 'pick',
@@ -125,12 +127,12 @@ class PodsField_Currency extends PodsField {
 					'9999,99' => '1234,00'
 				)
 			),
-			self::$type . '_decimals' => array(
+			static::$type . '_decimals' => array(
 				'label' => __( 'Decimals', 'pods' ),
 				'default' => 2,
 				'type' => 'number'
 			),
-			self::$type . '_decimal_handling' => array(
+			static::$type . '_decimal_handling' => array(
 				'label' => __( 'Decimal handling when zero', 'pods' ),
 				'default' => 'none',
 				'type' => 'pick',
@@ -140,32 +142,32 @@ class PodsField_Currency extends PodsField {
 					'dash' => __( 'Convert to dash', 'pods' ) . ' (-)',
 				)
 			),
-			self::$type . '_step' => array(
+			static::$type . '_step' => array(
 				'label' => __( 'Slider Increment (Step)', 'pods' ),
-				'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+				'depends-on' => array( static::$type . '_format_type' => 'slider' ),
 				'default' => 1,
 				'type' => 'text'
 			),
-			self::$type . '_min' => array(
+			static::$type . '_min' => array(
 				'label' => __( 'Minimum Number', 'pods' ),
-				'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+				'depends-on' => array( static::$type . '_format_type' => 'slider' ),
 				'default' => 0,
 				'type' => 'text'
 			),
-			self::$type . '_max' => array(
+			static::$type . '_max' => array(
 				'label' => __( 'Maximum Number', 'pods' ),
-				'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+				'depends-on' => array( static::$type . '_format_type' => 'slider' ),
 				'default' => 1000,
 				'type' => 'text'
 			),
-			self::$type . '_max_length' => array(
+			static::$type . '_max_length' => array(
 				'label' => __( 'Maximum Length', 'pods' ),
 				'default' => 12,
 				'type' => 'number',
 				'help' => __( 'Set to -1 for no limit', 'pods' )
 			)
 			/*,
-			self::$type . '_size' => array(
+			static::$type . '_size' => array(
 				'label' => __( 'Field Size', 'pods' ),
 				'default' => 'medium',
 				'type' => 'pick',
@@ -178,83 +180,6 @@ class PodsField_Currency extends PodsField {
 		);
 
 		return $options;
-
-	}
-
-	/**
-	 * Define the current field's schema for DB table storage
-	 *
-	 * @param array $options
-	 *
-	 * @return string
-	 * @since 2.0
-	 */
-	public function schema( $options = null ) {
-
-		$length = (int) pods_v( self::$type . '_max_length', $options, 12, true );
-
-		if ( $length < 1 || 64 < $length ) {
-			$length = 64;
-		}
-
-		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2, true );
-
-		if ( $decimals < 1 ) {
-			$decimals = 0;
-		}
-		elseif ( 30 < $decimals ) {
-			$decimals = 30;
-		}
-
-		if ( $length < $decimals ) {
-			$decimals = $length;
-		}
-
-		$schema = 'DECIMAL(' . $length . ',' . $decimals . ')';
-
-		return $schema;
-
-	}
-
-	/**
-	 * Define the current field's preparation for sprintf
-	 *
-	 * @param array $options
-	 *
-	 * @return string
-	 * @since 2.0
-	 */
-	public function prepare( $options = null ) {
-
-		$format = self::$prepare;
-
-		$length = (int) pods_v( self::$type . '_max_length', $options, 12, true );
-
-		if ( $length < 1 || 64 < $length ) {
-			$length = 64;
-		}
-
-		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2, true );
-
-		if ( $decimals < 1 ) {
-			$decimals = 0;
-		}
-		elseif ( 30 < $decimals ) {
-			$decimals = 30;
-		}
-
-		if ( $length < $decimals ) {
-			$decimals = $length;
-		}
-
-		if ( 0 < $decimals ) {
-			$format = '%01.' . $decimals . 'F';
-		}
-		else {
-			$format = '%d';
-		}
-
-		return $format;
 
 	}
 
@@ -276,14 +201,14 @@ class PodsField_Currency extends PodsField {
 
 		$currency = 'usd';
 
-		if ( isset( self::$currencies[ pods_v( self::$type . '_format_sign', $options, -1 ) ] ) ) {
-			$currency = pods_v( self::$type . '_format_sign', $options );
+		if ( isset( static::$currencies[ pods_v( static::$type . '_format_sign', $options, -1 ) ] ) ) {
+			$currency = pods_v( static::$type . '_format_sign', $options );
 		}
 
-		$currency_sign = self::$currencies[ $currency ]['sign'];
-		$currency_label = self::$currencies[ $currency ]['label'];
+		$currency_sign = static::$currencies[ $currency ]['sign'];
+		$currency_label = static::$currencies[ $currency ]['label'];
 
-		$placement = pods_v( self::$type . '_format_placement', $options, 'before', true );
+		$placement = pods_v( static::$type . '_format_placement', $options, 'before', true );
 
 		// Currency placement policy
 		// Single sign currencies: 100$, £100
@@ -309,57 +234,6 @@ class PodsField_Currency extends PodsField {
 	}
 
 	/**
-	 * Customize output of the form field
-	 *
-	 * @param string $name
-	 * @param mixed $value
-	 * @param array $options
-	 * @param array $pod
-	 * @param int $id
-	 *
-	 * @since 2.0
-	 */
-	public function input( $name, $value = null, $options = null, $pod = null, $id = null ) {
-
-		$options = (array) $options;
-		$form_field_type = PodsForm::$field_type;
-
-		if ( is_array( $value ) ) {
-			$value = implode( '', $value );
-		}
-
-		if ( 'slider' == pods_v( self::$type . '_format_type', $options, 'number' ) ) {
-			$field_type = 'slider';
-		}
-		else {
-			$field_type = 'currency';
-		}
-
-		if ( isset( $options[ 'name' ] ) && false === PodsForm::permission( self::$type, $options[ 'name' ], $options, null, $pod, $id ) ) {
-			if ( pods_v( 'read_only', $options, false ) ) {
-				$options[ 'readonly' ] = true;
-
-				$field_type = 'text';
-
-				$value = $this->format( $value, $name, $options, $pod, $id );
-			}
-			else {
-				return;
-			}
-		}
-		elseif ( !pods_has_permissions( $options ) && pods_v( 'read_only', $options, false ) ) {
-			$options[ 'readonly' ] = true;
-
-			$field_type = 'text';
-
-			$value = $this->format( $value, $name, $options, $pod, $id );
-		}
-
-		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
-
-	}
-
-	/**
 	 * Build regex necessary for JS validation
 	 *
 	 * @param mixed $value
@@ -373,44 +247,17 @@ class PodsField_Currency extends PodsField {
 	 */
 	public function regex( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
-		global $wp_locale;
-
-		if ( '9.999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		elseif ( '9,999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9\'999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '\'';
-			$dot = '.';
-		}
-		elseif ( '9 999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ' ';
-			$dot = ',';
-		}
-		elseif ( '9999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot = '.';
-		}
-		elseif ( '9999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot = ',';
-		}
-		else {
-			$thousands = $wp_locale->number_format[ 'thousands_sep' ];
-			$dot = $wp_locale->number_format[ 'decimal_point' ];
-		}
+		$format_args = $this->get_number_format_args( $options );
+		$thousands   = $format_args['thousands'];
+		$dot         = $format_args['dot'];
 
 		$currency = 'usd';
 
-		if ( isset( self::$currencies[ pods_v( self::$type . '_format_sign', $options, -1 ) ] ) ) {
-			$currency = pods_v( self::$type . '_format_sign', $options );
+		if ( isset( static::$currencies[ pods_v( static::$type . '_format_sign', $options, -1 ) ] ) ) {
+			$currency = pods_v( static::$type . '_format_sign', $options );
 		}
 
-		$currency_sign = self::$currencies[ $currency ]['sign'];
+		$currency_sign = static::$currencies[ $currency ]['sign'];
 
 		return '\-*\\' . $currency_sign . '*[0-9\\' . implode( '\\', array_filter( array( $dot, $thousands ) ) ) . ']+';
 
@@ -432,45 +279,18 @@ class PodsField_Currency extends PodsField {
 	 */
 	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
 
-		global $wp_locale;
-
-		if ( '9.999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		elseif ( '9,999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9\'999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '\'';
-			$dot = '.';
-		}
-		elseif ( '9 999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ' ';
-			$dot = ',';
-		}
-		elseif ( '9999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		else {
-			$thousands = $wp_locale->number_format[ 'thousands_sep' ];
-			$dot = $wp_locale->number_format[ 'decimal_point' ];
-		}
+		$format_args = $this->get_number_format_args( $options );
+		$thousands   = $format_args['thousands'];
+		$dot         = $format_args['dot'];
 
 		$currency = 'usd';
 
-		if ( isset( self::$currencies[ pods_v( self::$type . '_format_sign', $options, -1 ) ] ) ) {
-			$currency = pods_v( self::$type . '_format_sign', $options );
+		if ( isset( static::$currencies[ pods_v( static::$type . '_format_sign', $options, -1 ) ] ) ) {
+			$currency = pods_v( static::$type . '_format_sign', $options );
 		}
 
-		$currency_sign = self::$currencies[ $currency ]['sign'];
-		$currency_entity = self::$currencies[ $currency ]['entity'];
+		$currency_sign = static::$currencies[ $currency ]['sign'];
+		$currency_entity = static::$currencies[ $currency ]['entity'];
 
 		// Remove currency and thousands symbols
 		$check = str_replace(
@@ -517,45 +337,18 @@ class PodsField_Currency extends PodsField {
 	 */
 	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
-		global $wp_locale;
-
-		if ( '9.999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		elseif ( '9,999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9\'999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '\'';
-			$dot = '.';
-		}
-		elseif ( '9 999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ' ';
-			$dot = ',';
-		}
-		elseif ( '9999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		else {
-			$thousands = $wp_locale->number_format[ 'thousands_sep' ];
-			$dot = $wp_locale->number_format[ 'decimal_point' ];
-		}
+		$format_args = $this->get_number_format_args( $options );
+		$thousands   = $format_args['thousands'];
+		$dot         = $format_args['dot'];
 
 		$currency = 'usd';
 
-		if ( isset( self::$currencies[ pods_v( self::$type . '_format_sign', $options, -1 ) ] ) ) {
-			$currency = pods_v( self::$type . '_format_sign', $options );
+		if ( isset( static::$currencies[ pods_v( static::$type . '_format_sign', $options, -1 ) ] ) ) {
+			$currency = pods_v( static::$type . '_format_sign', $options );
 		}
 
-		$currency_sign = self::$currencies[ $currency ]['sign'];
-		$currency_entity = self::$currencies[ $currency ]['entity'];
+		$currency_sign = static::$currencies[ $currency ]['sign'];
+		$currency_entity = static::$currencies[ $currency ]['entity'];
 
 		// Convert decimal type for numeric type
 		$value = str_replace(
@@ -576,13 +369,13 @@ class PodsField_Currency extends PodsField {
 
 		$value = preg_replace( '/[^0-9\.\-]/', '', $value );
 
-		$length = (int) pods_v( self::$type . '_max_length', $options, 12, true );
+		$length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
 
 		if ( $length < 1 || 64 < $length ) {
 			$length = 64;
 		}
 
-		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2, true );
+		$decimals = (int) pods_v( static::$type . '_decimals', $options, 2, true );
 
 		if ( $decimals < 1 ) {
 			$decimals = 0;
@@ -602,25 +395,6 @@ class PodsField_Currency extends PodsField {
 	}
 
 	/**
-	 * Customize the Pods UI manage table column output
-	 *
-	 * @param int $id
-	 * @param mixed $value
-	 * @param string $name
-	 * @param array $options
-	 * @param array $fields
-	 * @param array $pod
-	 *
-	 * @return mixed|null|string
-	 * @since 2.0
-	 */
-	public function ui( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
-
-		return $this->display( $value, $name, $options, $pod, $id );
-
-	}
-
-	/**
 	 * Reformat a number to the way the value of the field is displayed
 	 *
 	 * @param mixed $value
@@ -634,62 +408,17 @@ class PodsField_Currency extends PodsField {
 	 */
 	public function format( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
-		global $wp_locale;
-
 		if ( null === $value ) {
 			// Don't enforce a default value here
 			return null;
 		}
 
-		if ( '9.999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot = ',';
-		}
-		elseif ( '9,999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot = '.';
-		}
-		elseif ( '9\'999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '\'';
-			$dot = '.';
-		}
-		elseif ( '9 999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = ' ';
-			$dot = ',';
-		}
-		elseif ( '9999.99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot = '.';
-		}
-		elseif ( '9999,99' == pods_v( self::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot = ',';
-		}
-		else {
-			$thousands = $wp_locale->number_format[ 'thousands_sep' ];
-			$dot = $wp_locale->number_format[ 'decimal_point' ];
-		}
+		$format_args = $this->get_number_format_args( $options );
+		$thousands   = $format_args['thousands'];
+		$dot         = $format_args['dot'];
+		$decimals    = $format_args['decimals'];
 
-		$length = (int) pods_v( self::$type . '_max_length', $options, 12, true );
-
-		if ( $length < 1 || 64 < $length ) {
-			$length = 64;
-		}
-
-		$decimals = (int) pods_v( self::$type . '_decimals', $options, 2 );
-
-		if ( $decimals < 1 ) {
-			$decimals = 0;
-		}
-		elseif ( 30 < $decimals ) {
-			$decimals = 30;
-		}
-
-		if ( $length < $decimals ) {
-			$decimals = $length;
-		}
-
-		if ( 'i18n' == pods_v( self::$type . '_format', $options ) ) {
+		if ( 'i18n' == pods_v( static::$type . '_format', $options ) ) {
 			$value = number_format_i18n( (float) $value, $decimals );
 		}
 		else {
@@ -697,7 +426,7 @@ class PodsField_Currency extends PodsField {
 		}
 
 		// Additional output handling for decimals
-		$decimal_handling = pods_v( self::$type . '_decimal_handling', $options, 'none' ) ;
+		$decimal_handling = pods_v( static::$type . '_decimal_handling', $options, 'none' ) ;
 		if ( 'none' !== $decimal_handling ) {
 			$value_parts = explode( $dot, $value );
 			if ( 'remove' === $decimal_handling ) {
@@ -721,8 +450,8 @@ class PodsField_Currency extends PodsField {
 	public static function data_currencies() {
 
 		// If it's already done, do not redo the filter
-		if ( ! empty( self::$currencies ) ) {
-			return self::$currencies;
+		if ( ! empty( static::$currencies ) ) {
+			return static::$currencies;
 		}
 
 		$default_currencies = array(
@@ -928,15 +657,15 @@ class PodsField_Currency extends PodsField {
 		 * }
 		 * @return array
 		 */
-		self::$currencies = apply_filters( 'pods_form_ui_field_currency_currencies', $default_currencies );
+		static::$currencies = apply_filters( 'pods_form_ui_field_currency_currencies', $default_currencies );
 
 		// Sort the currencies
-		ksort( self::$currencies );
+		ksort( static::$currencies );
 
 		// Backwards compatibility
-		foreach ( self::$currencies as $key => $value ) {
+		foreach ( static::$currencies as $key => $value ) {
 			if ( is_string( $value ) ) {
-				self::$currencies[ $key ] = array(
+				static::$currencies[ $key ] = array(
 					'label'  => strtoupper( $key ),
 					'name'   => strtoupper( $key ),
 					'sign'   => $value,
@@ -958,10 +687,10 @@ class PodsField_Currency extends PodsField {
 				}
 			} else {
 				// Invalid
-				unset( self::$currencies[ $key ] );
+				unset( static::$currencies[ $key ] );
 			}
 		}
 
-		return self::$currencies;
+		return static::$currencies;
 	}
 }

--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -340,6 +340,7 @@ class PodsField_Currency extends PodsField_Number {
 		$format_args = $this->get_number_format_args( $options );
 		$thousands   = $format_args['thousands'];
 		$dot         = $format_args['dot'];
+		$decimals    = $format_args['decimals'];
 
 		$currency = 'usd';
 
@@ -368,25 +369,6 @@ class PodsField_Currency extends PodsField_Number {
 		$value = trim( $value );
 
 		$value = preg_replace( '/[^0-9\.\-]/', '', $value );
-
-		$length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
-
-		if ( $length < 1 || 64 < $length ) {
-			$length = 64;
-		}
-
-		$decimals = (int) pods_v( static::$type . '_decimals', $options, 2, true );
-
-		if ( $decimals < 1 ) {
-			$decimals = 0;
-		}
-		elseif ( 30 < $decimals ) {
-			$decimals = 30;
-		}
-
-		if ( $length < $decimals ) {
-			$decimals = $length;
-		}
 
 		$value = number_format( (float) $value, $decimals, '.', '' );
 

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -162,31 +162,6 @@ class PodsField_Number extends PodsField {
 	}
 
 	/**
-	 * Change the value of the field
-	 *
-	 * @param mixed|null  $value
-	 * @param string|null $name
-	 * @param array|null  $options
-	 * @param array|null  $pod
-	 * @param int|null    $id
-	 *
-	 * @return mixed|null|string
-	 *
-	 * @since 2.7
-	 */
-	public function value( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
-
-		if ( pods_v( static::$type . '_allow_empty', $options, 1 ) &&
-		     in_array( rtrim( $value, '0' ), array( '0.', '0,' ) )
-		) {
-			$value = '';
-		}
-
-		return $value;
-
-	}
-
-	/**
 	 * Define the current field's preparation for sprintf
 	 *
 	 * @param array $options

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -54,7 +54,7 @@ class PodsField_Number extends PodsField {
      */
     public function options () {
         $options = array(
-            self::$type . '_repeatable' => array(
+            static::$type . '_repeatable' => array(
                 'label' => __( 'Repeatable Field', 'pods' ),
                 'default' => 0,
                 'type' => 'boolean',
@@ -63,7 +63,7 @@ class PodsField_Number extends PodsField {
                 'dependency' => true,
                 'developer_mode' => true
             ),
-            self::$type . '_format_type' => array(
+            static::$type . '_format_type' => array(
                 'label' => __( 'Input Type', 'pods' ),
                 'default' => 'number',
                 'type' => 'pick',
@@ -73,7 +73,7 @@ class PodsField_Number extends PodsField {
                 ),
                 'dependency' => true
             ),
-            self::$type . '_format' => array(
+            static::$type . '_format' => array(
                 'label' => __( 'Format', 'pods' ),
                 'default' => apply_filters( 'pods_form_ui_field_number_format_default', 'i18n' ),
                 'type' => 'pick',
@@ -86,44 +86,44 @@ class PodsField_Number extends PodsField {
                     '9999,99' => '1234,00'
                 )
             ),
-            self::$type . '_decimals' => array(
+            static::$type . '_decimals' => array(
                 'label' => __( 'Decimals', 'pods' ),
                 'default' => 0,
                 'type' => 'number',
 	            'dependency' => true
             ),
-            self::$type . '_format_soft' => array(
+            static::$type . '_format_soft' => array(
 	            'label'      => __( 'Soft format?', 'pods' ),
 	            'help'       => __( 'Remove trailing decimals (0)', 'pods' ),
 	            'default'    => 0,
 	            'type'       => 'boolean',
-	            'excludes-on' => array( self::$type . '_decimals' => 0 ),
+	            'excludes-on' => array( static::$type . '_decimals' => 0 ),
             ),
-            self::$type . '_step' => array(
+            static::$type . '_step' => array(
                 'label' => __( 'Slider Increment (Step)', 'pods' ),
-                'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+                'depends-on' => array( static::$type . '_format_type' => 'slider' ),
                 'default' => 1,
                 'type' => 'text'
             ),
-            self::$type . '_min' => array(
+            static::$type . '_min' => array(
                 'label' => __( 'Minimum Number', 'pods' ),
-                'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+                'depends-on' => array( static::$type . '_format_type' => 'slider' ),
                 'default' => 0,
                 'type' => 'text'
             ),
-            self::$type . '_max' => array(
+            static::$type . '_max' => array(
                 'label' => __( 'Maximum Number', 'pods' ),
-                'depends-on' => array( self::$type . '_format_type' => 'slider' ),
+                'depends-on' => array( static::$type . '_format_type' => 'slider' ),
                 'default' => 100,
                 'type' => 'text'
             ),
-            self::$type . '_max_length' => array(
+            static::$type . '_max_length' => array(
                 'label' => __( 'Maximum Length', 'pods' ),
                 'default' => 12,
                 'type' => 'number',
                 'help' => __( 'Set to -1 for no limit', 'pods' )
             )/*,
-            self::$type . '_size' => array(
+            static::$type . '_size' => array(
                 'label' => __( 'Field Size', 'pods' ),
                 'default' => 'medium',
                 'type' => 'pick',
@@ -137,68 +137,107 @@ class PodsField_Number extends PodsField {
         return $options;
     }
 
-    /**
-     * Define the current field's schema for DB table storage
-     *
-     * @param array $options
-     *
-     * @return array
-     * @since 2.0
-     */
-    public function schema ( $options = null ) {
-        $length = (int) pods_var( self::$type . '_max_length', $options, 12, null, true );
+	/**
+	 * Define the current field's schema for DB table storage
+	 *
+	 * @param array $options
+	 *
+	 * @return string
+	 * @since 2.0
+	 */
+	public function schema( $options = null ) {
 
-        if ( $length < 1 || 64 < $length )
-            $length = 64;
+		$length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
 
-        $decimals = (int) pods_var( self::$type . '_decimals', $options, 0, null, true );
+		if ( $length < 1 || 64 < $length ) {
+			$length = 64;
+		}
 
-        if ( $decimals < 1 )
-            $decimals = 0;
-        elseif ( 30 < $decimals )
-            $decimals = 30;
+		$decimals = (int) pods_v( static::$type . '_decimals', $options, 2, true );
 
-        if ( $length < $decimals )
-            $decimals = $length;
+		if ( $decimals < 1 ) {
+			$decimals = 0;
+		}
+		elseif ( 30 < $decimals ) {
+			$decimals = 30;
+		}
 
-        $schema = 'DECIMAL(' . $length . ',' . $decimals . ')';
+		if ( $length < $decimals ) {
+			$decimals = $length;
+		}
 
-        return $schema;
-    }
+		$schema = 'DECIMAL(' . $length . ',' . $decimals . ')';
 
-    /**
-     * Define the current field's preparation for sprintf
-     *
-     * @param array $options
-     *
-     * @return array
-     * @since 2.0
-     */
-    public function prepare ( $options = null ) {
-        $format = self::$prepare;
+		return $schema;
 
-        $length = (int) pods_var( self::$type . '_max_length', $options, 12, null, true );
+	}
 
-        if ( $length < 1 || 64 < $length )
-            $length = 64;
+	/**
+	 * Change the value of the field
+	 *
+	 * @param mixed|null  $value
+	 * @param string|null $name
+	 * @param array|null  $options
+	 * @param array|null  $pod
+	 * @param int|null    $id
+	 *
+	 * @return mixed|null|string
+	 *
+	 * @since 2.7
+	 */
+	public function value( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
-        $decimals = (int) pods_var( self::$type . '_decimals', $options, 0, null, true );
+		if ( pods_v( static::$type . '_allow_empty', $options, 1 ) &&
+		     in_array( rtrim( $value, '0' ), array( '0.', '0,' ) )
+		) {
+			$value = '';
+		}
 
-        if ( $decimals < 1 )
-            $decimals = 0;
-        elseif ( 30 < $decimals )
-            $decimals = 30;
+		return $value;
 
-        if ( $length < $decimals )
-            $decimals = $length;
+	}
 
-        if ( 0 < $decimals )
-            $format = '%01.' . $decimals . 'f';
-        else
-            $format = '%d';
+	/**
+	 * Define the current field's preparation for sprintf
+	 *
+	 * @param array $options
+	 *
+	 * @return string
+	 * @since 2.0
+	 */
+	public function prepare( $options = null ) {
 
-        return $format;
-    }
+		$format = static::$prepare;
+
+		$length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
+
+		if ( $length < 1 || 64 < $length ) {
+			$length = 64;
+		}
+
+		$decimals = (int) pods_v( static::$type . '_decimals', $options, 2, true );
+
+		if ( $decimals < 1 ) {
+			$decimals = 0;
+		}
+		elseif ( 30 < $decimals ) {
+			$decimals = 30;
+		}
+
+		if ( $length < $decimals ) {
+			$decimals = $length;
+		}
+
+		if ( 0 < $decimals ) {
+			$format = '%01.' . $decimals . 'F';
+		}
+		else {
+			$format = '%d';
+		}
+
+		return $format;
+
+	}
 
     /**
      * Change the way the value of the field is displayed with Pods::get
@@ -218,50 +257,56 @@ class PodsField_Number extends PodsField {
         return $value;
     }
 
-    /**
-     * Customize output of the form field
-     *
-     * @param string $name
-     * @param mixed $value
-     * @param array $options
-     * @param array $pod
-     * @param int $id
-     *
-     * @since 2.0
-     */
-    public function input ( $name, $value = null, $options = null, $pod = null, $id = null ) {
-        $options = (array) $options;
-        $form_field_type = PodsForm::$field_type;
+	/**
+	 * Customize output of the form field
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 * @param array $options
+	 * @param array $pod
+	 * @param int $id
+	 *
+	 * @since 2.0
+	 */
+	public function input( $name, $value = null, $options = null, $pod = null, $id = null ) {
 
-        if ( is_array( $value ) )
-            $value = implode( '', $value );
+		$options = (array) $options;
+		$form_field_type = PodsForm::$field_type;
 
-        if ( 'slider' == pods_var( self::$type . '_format_type', $options, 'number' ) )
-            $field_type = 'slider';
-        else
-            $field_type = 'number';
+		if ( is_array( $value ) ) {
+			$value = implode( '', $value );
+		}
 
-        if ( isset( $options[ 'name' ] ) && false === PodsForm::permission( self::$type, $options[ 'name' ], $options, null, $pod, $id ) ) {
-            if ( pods_var( 'read_only', $options, false ) )  {
-                $options[ 'readonly' ] = true;
+		if ( 'slider' == pods_v( static::$type . '_format_type', $options, 'number' ) ) {
+			$field_type = 'slider';
+		}
+		else {
+			$field_type = static::$type;
+		}
 
-                $field_type = 'text';
+		if ( isset( $options[ 'name' ] ) && false === PodsForm::permission( static::$type, $options[ 'name' ], $options, null, $pod, $id ) ) {
+			if ( pods_v( 'read_only', $options, false ) ) {
+				$options[ 'readonly' ] = true;
 
-                $value = $this->format( $value, $name, $options, $pod, $id );
-            }
-            else
-                return;
-        }
-        elseif ( !pods_has_permissions( $options ) && pods_var( 'read_only', $options, false ) ) {
-            $options[ 'readonly' ] = true;
+				$field_type = 'text';
 
-            $field_type = 'text';
+				$value = $this->format( $value, $name, $options, $pod, $id );
+			}
+			else {
+				return;
+			}
+		}
+		elseif ( !pods_has_permissions( $options ) && pods_v( 'read_only', $options, false ) ) {
+			$options[ 'readonly' ] = true;
 
-            $value = $this->format( $value, $name, $options, $pod, $id );
-        }
+			$field_type = 'text';
 
-        pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
-    }
+			$value = $this->format( $value, $name, $options, $pod, $id );
+		}
+
+		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
+
+	}
 
     /**
      * Build regex necessary for JS validation
@@ -276,32 +321,10 @@ class PodsField_Number extends PodsField {
      * @since 2.0
      */
     public function regex ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
-        global $wp_locale;
 
-        if ( '9.999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        elseif ( '9,999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9 999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ' ';
-            $dot = ',';
-        }
-        elseif ( '9999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '';
-            $dot = '.';
-        }
-        elseif ( '9999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '';
-            $dot = ',';
-        }
-        else {
-            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
-            $dot = $wp_locale->number_format[ 'decimal_point' ];
-        }
+	    $format_args = $this->get_number_format_args( $options );
+	    $thousands   = $format_args['thousands'];
+	    $dot         = $format_args['dot'];
 
         return '\-*[0-9\\' . implode( '\\', array_filter( array( $dot, $thousands ) ) ) . ']+';
     }
@@ -321,35 +344,13 @@ class PodsField_Number extends PodsField {
      * @since 2.0
      */
     public function validate ( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
-        global $wp_locale;
 
-        if ( '9.999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        elseif ( '9,999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9 999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ' ';
-            $dot = ',';
-        }
-        elseif ( '9999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        else {
-            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
-            $dot = $wp_locale->number_format[ 'decimal_point' ];
-        }
+	    $format_args = $this->get_number_format_args( $options );
+	    $thousands   = $format_args['thousands'];
+	    $dot         = $format_args['dot'];
 
 	    $check = str_replace(
-	    	array( $thousands, $dot, html_entity_decode($thousands) ),
+	    	array( $thousands, $dot, html_entity_decode( $thousands ) ),
 		    array( '', '.', '' ),
 		    $value
 	    );
@@ -380,44 +381,22 @@ class PodsField_Number extends PodsField {
      * @since 2.0
      */
     public function pre_save ( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
-        global $wp_locale;
 
-        if ( '9.999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        elseif ( '9,999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9 999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ' ';
-            $dot = ',';
-        }
-        elseif ( '9999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        else {
-            $thousands = html_entity_decode( $wp_locale->number_format['thousands_sep'] );
-            $dot = $wp_locale->number_format[ 'decimal_point' ];
-        }
+	    $format_args = $this->get_number_format_args( $options );
+	    $thousands   = $format_args['thousands'];
+	    $dot         = $format_args['dot'];
 
         $value = str_replace( array( $thousands, $dot ), array( '', '.' ), $value );
-	$value = trim( $value );
+        $value = trim( $value );
 
         $value = preg_replace( '/[^0-9\.\-]/', '', $value );
 
-        $length = (int) pods_var( self::$type . '_max_length', $options, 12, null, true );
+        $length = (int) pods_var( static::$type . '_max_length', $options, 12, null, true );
 
         if ( $length < 1 || 64 < $length )
             $length = 64;
 
-        $decimals = (int) pods_var( self::$type . '_decimals', $options, 0, null, true );
+        $decimals = (int) pods_var( static::$type . '_decimals', $options, 0, null, true );
 
         if ( $decimals < 1 )
             $decimals = 0;
@@ -462,60 +441,26 @@ class PodsField_Number extends PodsField {
      * @since 2.0
      */
     public function format ( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
-        global $wp_locale;
 
-	if ( null === $value ) {
-		// Don't enforce a default value here
-		return null;
-	}
+	    if ( null === $value ) {
+		    // Don't enforce a default value here.
+		    return null;
+	    }
 
-        if ( '9.999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '.';
-            $dot = ',';
-        }
-        elseif ( '9,999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ',';
-            $dot = '.';
-        }
-        elseif ( '9 999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = ' ';
-            $dot = ',';
-        }
-        elseif ( '9999.99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '';
-            $dot = '.';
-        }
-        elseif ( '9999,99' == pods_var( self::$type . '_format', $options ) ) {
-            $thousands = '';
-            $dot = ',';
-        }
-        else {
-            $thousands = $wp_locale->number_format[ 'thousands_sep' ];
-            $dot = $wp_locale->number_format[ 'decimal_point' ];
-        }
+	    $format_args = $this->get_number_format_args( $options );
+	    $thousands   = $format_args['thousands'];
+	    $dot         = $format_args['dot'];
+	    $decimals    = $format_args['decimals'];
 
-        $length = (int) pods_var( self::$type . '_max_length', $options, 12, null, true );
-
-        if ( $length < 1 || 64 < $length )
-            $length = 64;
-
-        $decimals = (int) pods_var( self::$type . '_decimals', $options, 0, null, true );
-
-        if ( $decimals < 1 )
-            $decimals = 0;
-        elseif ( 30 < $decimals )
-            $decimals = 30;
-
-        if ( $length < $decimals )
-            $decimals = $length;
-
-        if ( 'i18n' == pods_var( self::$type . '_format', $options ) )
-            $value = number_format_i18n( (float) $value, $decimals );
-        else
-            $value = number_format( (float) $value, $decimals, $dot, $thousands );
+	    if ( 'i18n' == pods_v( static::$type . '_format', $options ) ) {
+		    $value = number_format_i18n( (float) $value, $decimals );
+	    }
+	    else {
+		    $value = number_format( (float) $value, $decimals, $dot, $thousands );
+	    }
 
         // Optionally remove trailing decimal zero's.
-        if ( pods_v( self::$type . '_format_soft', $options, 0 ) ) {
+        if ( pods_v( static::$type . '_format_soft', $options, 0 ) ) {
         	$parts = explode( $dot, $value );
         	if ( isset( $parts[1] ) ) {
         		$parts[1] = rtrim( $parts[1], '0' );
@@ -525,5 +470,73 @@ class PodsField_Number extends PodsField {
         }
 
         return $value;
+    }
+
+	/**
+	 * Get the formatting arguments for numbers.
+	 * @since 2.7
+	 * @param array $options Field options.
+	 * @return array {
+	 *     @type string $thousands
+	 *     @type string $dot
+	 *     @type int    $decimals
+	 * }
+	 */
+    public function get_number_format_args( $options ) {
+	    global $wp_locale;
+
+	    if ( '9.999,99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = '.';
+		    $dot = ',';
+	    }
+	    elseif ( '9,999.99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = ',';
+		    $dot = '.';
+	    }
+	    elseif ( '9\'999.99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = '\'';
+		    $dot = '.';
+	    }
+	    elseif ( '9 999,99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = ' ';
+		    $dot = ',';
+	    }
+	    elseif ( '9999.99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = '';
+		    $dot = '.';
+	    }
+	    elseif ( '9999,99' == pods_v( static::$type . '_format', $options ) ) {
+		    $thousands = '';
+		    $dot = ',';
+	    }
+	    else {
+		    $thousands = $wp_locale->number_format[ 'thousands_sep' ];
+		    $dot = $wp_locale->number_format[ 'decimal_point' ];
+	    }
+
+	    $length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
+
+	    if ( $length < 1 || 64 < $length ) {
+		    $length = 64;
+	    }
+
+	    $decimals = (int) pods_v( static::$type . '_decimals', $options, 2 );
+
+	    if ( $decimals < 1 ) {
+		    $decimals = 0;
+	    }
+	    elseif ( 30 < $decimals ) {
+		    $decimals = 30;
+	    }
+
+	    if ( $length < $decimals ) {
+		    $decimals = $length;
+	    }
+
+	    return array(
+	    	'thousands' => $thousands,
+	        'dot'       => $dot,
+	        'decimals'  => $decimals,
+	    );
     }
 }

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -358,10 +358,11 @@ class PodsField_Number extends PodsField {
 
         $check = preg_replace( '/[0-9\.\-\s]/', '', $check );
 
-        $label = pods_var( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
+        $label = pods_v( 'label', $options, ucwords( str_replace( '_', ' ', $name ) ) );
 
-        if ( 0 < strlen( $check ) )
-            return sprintf( __( '%s is not numeric', 'pods' ), $label );
+        if ( 0 < strlen( $check ) ) {
+	        return sprintf( __( '%s is not numeric', 'pods' ), $label );
+        }
 
         return true;
     }
@@ -385,26 +386,12 @@ class PodsField_Number extends PodsField {
 	    $format_args = $this->get_number_format_args( $options );
 	    $thousands   = $format_args['thousands'];
 	    $dot         = $format_args['dot'];
+	    $decimals    = $format_args['decimals'];
 
         $value = str_replace( array( $thousands, $dot ), array( '', '.' ), $value );
         $value = trim( $value );
 
         $value = preg_replace( '/[^0-9\.\-]/', '', $value );
-
-        $length = (int) pods_var( static::$type . '_max_length', $options, 12, null, true );
-
-        if ( $length < 1 || 64 < $length )
-            $length = 64;
-
-        $decimals = (int) pods_var( static::$type . '_decimals', $options, 0, null, true );
-
-        if ( $decimals < 1 )
-            $decimals = 0;
-        elseif ( 30 < $decimals )
-            $decimals = 30;
-
-        if ( $length < $decimals )
-            $decimals = $length;
 
         $value = number_format( (float) $value, $decimals, '.', '' );
 
@@ -514,6 +501,24 @@ class PodsField_Number extends PodsField {
 		    $dot = $wp_locale->number_format[ 'decimal_point' ];
 	    }
 
+	    $decimals = $this->get_max_decimals( $options );
+
+	    return array(
+	    	'thousands' => $thousands,
+	        'dot'       => $dot,
+	        'decimals'  => $decimals,
+	    );
+    }
+
+    /**
+     * Get the max allowed decimals.
+     *
+     * @since 2.7
+     * @param array $options
+     * @return int
+     */
+    public function get_max_decimals( $options ) {
+
 	    $length = (int) pods_v( static::$type . '_max_length', $options, 12, true );
 
 	    if ( $length < 1 || 64 < $length ) {
@@ -533,10 +538,6 @@ class PodsField_Number extends PodsField {
 		    $decimals = $length;
 	    }
 
-	    return array(
-	    	'thousands' => $thousands,
-	        'dot'       => $dot,
-	        'decimals'  => $decimals,
-	    );
+	    return $decimals;
     }
 }


### PR DESCRIPTION
Related: #4207 

Similar to what we've done with the date/time fields.

- [x] Late static binding
- [x] Currency field extends Number field (remove duplicate code)
- [x] Put thousands/dot formatting logic in separate method and re-use it
- [x] `value()` method to prevent returning values that should be empty
- [x] Also refactors old `pods_var()` calls in the number field
- [ ] Test and review
- [ ] Convert file indentation to Tabs once PR is ready @JoryHogeveen