### PR TITLE
travis-ci: remove hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
     include:
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0
-    - php: hhvm
-      env: WP_VERSION=latest WP_MULTISITE=0
     - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=0
     - php: 5.3
@@ -36,7 +34,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
+    - phpenv config-rm xdebug.ini
     - composer self-update
     - composer install --no-interaction --prefer-source
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
https://make.wordpress.org/core/2017/05/25/hhvm-no-longer-part-of-wordpress-cores-testing-infrastructure/ 