### PR TITLE
Fix: multi-file fields save causes array to string conversion notice.

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -8627,7 +8627,7 @@ class PodsAPI {
     }
 
 	/**
-	 * Remove multidimensional array values that are equal to false.
+	 * Filter an array of arrays without causing PHP notices/warnings.
 	 *
 	 * @param array $values
 	 *
@@ -8638,10 +8638,21 @@ class PodsAPI {
 	private function array_filter_walker( $values = array() ) {
 
 		foreach ( $values as $k => $v ){
-			if ( is_array( $v ) || is_object( $v ) ){
-				$this->array_filter_walker( $v );
-			} elseif ( false === (bool) $v ){
-				unset( $values[ $k ] );
+			if ( is_object( $v ) ) {
+				// Skip objects
+				continue;
+			} elseif ( is_array( $v ) ){
+				if ( empty( $v ) ) {
+					// Filter values with empty arrays
+					unset( $values[ $k ] );
+				}
+			} else {
+				$check = (bool) $v;
+
+				if ( ! $v ) {
+					// Filter empty values
+					unset( $values[ $k ] );
+				}
 			}
 		}
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -8636,6 +8636,7 @@ class PodsAPI {
 	 * @since 2.6.10
 	 */
 	private function array_filter_walker( $values = array() ) {
+		$values = (array) $values;
 
 		foreach ( $values as $k => $v ){
 			if ( is_object( $v ) ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -8636,6 +8636,7 @@ class PodsAPI {
 	 * @since 2.6.10
 	 */
 	private function array_filter_walker( $values = array() ) {
+
 		$values = (array) $values;
 
 		foreach ( $values as $k => $v ){

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3751,7 +3751,13 @@ class PodsAPI {
                     }
 
                     $value_ids = array_unique( array_filter( $value_ids ) );
-                    $values    = array_unique( array_filter( $values ) );
+
+                    //Filter unique values not equal to false in case of a multidimensional array
+                    $filtered_values = $this->array_filter_walker($values);
+                    $serialized_values = array_map('serialize', $filtered_values);
+                    $unique_serialized_values = array_unique($serialized_values);
+
+	                $values = array_map('unserialize', $unique_serialized_values);
 
                     // Limit values
                     if ( 0 < $related_limit && !empty( $value_ids ) ) {
@@ -8619,4 +8625,26 @@ class PodsAPI {
         else
             pods_deprecated( "PodsAPI::{$name}", '2.0' );
     }
+
+	/**
+	 * Remove multidimensional array values that are equal to false
+	 *
+	 * @param array $values
+	 *
+	 * @return array
+	 *
+	 * @since 2.6.9
+	 */
+	private function array_filter_walker( $values = array() ) {
+		foreach ($values as $k => $v){
+			if (is_array($v) || is_object($v)){
+				$this->array_filter_walker($v);
+			} else {
+				if (false === (bool)$v){
+					unset($values[$k]);
+				}
+			}
+		}
+		return $values;
+	}
 }

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3752,12 +3752,12 @@ class PodsAPI {
 
                     $value_ids = array_unique( array_filter( $value_ids ) );
 
-                    //Filter unique values not equal to false in case of a multidimensional array
-                    $filtered_values = $this->array_filter_walker($values);
-                    $serialized_values = array_map('serialize', $filtered_values);
-                    $unique_serialized_values = array_unique($serialized_values);
+                    // Filter unique values not equal to false in case of a multidimensional array
+                    $filtered_values = $this->array_filter_walker( $values );
+                    $serialized_values = array_map( 'serialize', $filtered_values );
+                    $unique_serialized_values = array_unique( $serialized_values );
 
-	                $values = array_map('unserialize', $unique_serialized_values);
+	            $values = array_map( 'unserialize', $unique_serialized_values );
 
                     // Limit values
                     if ( 0 < $related_limit && !empty( $value_ids ) ) {
@@ -8627,24 +8627,26 @@ class PodsAPI {
     }
 
 	/**
-	 * Remove multidimensional array values that are equal to false
+	 * Remove multidimensional array values that are equal to false.
 	 *
 	 * @param array $values
 	 *
 	 * @return array
 	 *
-	 * @since 2.6.9
+	 * @since 2.6.10
 	 */
 	private function array_filter_walker( $values = array() ) {
-		foreach ($values as $k => $v){
-			if (is_array($v) || is_object($v)){
-				$this->array_filter_walker($v);
-			} else {
-				if (false === (bool)$v){
-					unset($values[$k]);
-				}
+
+		foreach ( $values as $k => $v ){
+			if ( is_array( $v ) || is_object( $v ) ){
+				$this->array_filter_walker( $v );
+			} elseif ( false === (bool) $v ){
+				unset( $values[ $k ] );
 			}
 		}
+
 		return $values;
+
 	}
+
 }

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -8649,8 +8649,6 @@ class PodsAPI {
 					unset( $values[ $k ] );
 				}
 			} else {
-				$check = (bool) $v;
-
 				if ( ! $v ) {
 					// Filter empty values
 					unset( $values[ $k ] );


### PR DESCRIPTION
#4313 
I added a function `array_filter_walker` and a few extra steps to ensure backwards compatibility.  This may be unnecessary but since the multidimensional array is generated by the name properties in the fields HTML it seemed prudent not to affect that for the sake of making this a quick fix.  Everything should perform as expected now, regardless of the array structure. 