### PR TITLE
Don't strip field traversal if the specified field does not contain a period

### DIFF
--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -454,7 +454,7 @@ function frontier_backtrack_template( $code, $aliases ) {
 			$content = $used[ 5 ][ $key ];
 			$atts = shortcode_parse_atts( $used[ 3 ][ $key ] );
 			if ( !empty( $atts ) ) {
-				if ( !empty( $atts[ 'field' ] ) ) {
+				if ( !empty( $atts[ 'field' ] ) && false !== strpos( $atts[ 'field' ], '.' ) ) {
 					$content = str_replace( $atts[ 'field' ] . '.', '', $content );
 				}
 				preg_match_all( '/' . $regex . '/s', $content, $subused );


### PR DESCRIPTION
Needs further tests built to make sure this doesn't break anything else.

Related to #4403

Currently the code appears to expect:
```
[if rel_field.permalink]
{@permalink}
[/if]
```
When it appears that the desired behavior is:
```
[if rel_field]
{@rel_field.permalink}
[/if]
```
This should allow both behaviors to work, in the first case the context is "switched" inside the if to the object related via rel_field.  In the second case the context remains with the original object but allows it to be referenced via dot traversal.

Need to build tests for the other frontier related shortcodes to ensure more isn't broken by this