### PR TITLE
Allow where_default to pass through SQL queries

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1294,6 +1294,9 @@ class Pods implements Iterator {
 									'expires' => 180  // @todo This could potentially cause issues if someone changes the data within this time and persistent storage is used
 								);
 
+								if ( !empty( $table[ 'where_default'] ) ) {
+									$sql[ 'where_default' ] = $table[ 'where_default' ];
+								}
 								// Output types
 								if ( in_array( $params->output, array( 'ids', 'objects', 'pods' ), true ) )
 									$sql[ 'select' ] = '`t`.`' . $table[ 'field_id' ] . '` AS `pod_item_id`';

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1294,9 +1294,10 @@ class Pods implements Iterator {
 									'expires' => 180  // @todo This could potentially cause issues if someone changes the data within this time and persistent storage is used
 								);
 
-								if ( !empty( $table[ 'where_default'] ) ) {
-									$sql[ 'where_default' ] = $table[ 'where_default' ];
+								if ( ! empty( $table['where_default'] ) ) {
+									$sql['where_default'] = $table['where_default'];
 								}
+
 								// Output types
 								if ( in_array( $params->output, array( 'ids', 'objects', 'pods' ), true ) )
 									$sql[ 'select' ] = '`t`.`' . $table[ 'field_id' ] . '` AS `pod_item_id`';

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -7759,8 +7759,8 @@ class PodsAPI {
             $post_status = array( 'publish' );
 
             // Pick field post_status option
-            if ( ! empty( $field['pick_post_status'] ) ) {
-                $post_status = (array) $field['pick_post_status'];
+            if ( ! empty( $field['options']['pick_post_status'] ) ) {
+                $post_status = (array) $field['options']['pick_post_status'];
             }
 
 		    /**

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -7761,6 +7761,8 @@ class PodsAPI {
             // Pick field post_status option
             if ( ! empty( $field['options']['pick_post_status'] ) ) {
                 $post_status = (array) $field['options']['pick_post_status'];
+            } elseif ( ! empty( $field['pick_post_status'] ) ) {
+                $post_status = (array) $field['pick_post_status'];
             }
 
 		    /**

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -755,6 +755,7 @@ class PodsData {
             'table' => null,
             'join' => null,
             'where' => null,
+            'where_default' => null,
             'groupby' => null,
             'having' => null,
             'orderby' => null,
@@ -867,14 +868,14 @@ class PodsData {
 
 		$params->where_defaulted = false;
 
-		if ( empty( $params->where_default ) ) {
+		if ( ! isset( $params->where_default ) || array() !== $params->where_default ) {
 			$params->where_default = $this->where_default;
 		}
 
 		if ( false === $params->strict ) {
 			// Set default where
-            if ( !empty( $this->where_default ) && empty( $params->where ) ) {
-				$params->where = array_values( (array) $this->where_default );
+            if ( !empty( $params->where_default ) && empty( $params->where ) ) {
+				$params->where = array_values( (array) $params->where_default );
 
 				$params->where_defaulted = true;
 			}

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -866,6 +866,7 @@ class PodsData {
             $params->join = $this->join;
 
 		$params->where_defaulted = false;
+
 		if ( empty( $params->where_default ) ) {
 			$params->where_default = $this->where_default;
 		}

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -866,7 +866,9 @@ class PodsData {
             $params->join = $this->join;
 
 		$params->where_defaulted = false;
-		$params->where_default = $this->where_default;
+		if ( empty( $params->where_default ) ) {
+			$params->where_default = $this->where_default;
+		}
 
 		if ( false === $params->strict ) {
 			// Set default where

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -1992,7 +1992,7 @@ class PodsField_Pick extends PodsField {
 					}
 				}
 
-				$options['table_info'] = pods_api()->get_table_info( pods_v( self::$type . '_object', $options ), $pick_val, null, null, $options );
+				$options['table_info'] = pods_api()->get_table_info( pods_v( self::$type . '_object', $options ), $pick_val, null, null, $object_params );
 
 				$search_data = pods_data();
 				$search_data->table( $options['table_info'] );


### PR DESCRIPTION
What's happening is that the 'where_default' is always getting used because the query is a post_type but does not include the post_status in the where, so PodsData->query_fields() was using the
'where_default' param which wasn't getting passed through properly.

Related to #4437 