### PR TITLE
Allow magic tags engine to be replace via WordPress filter

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3619,15 +3619,14 @@ class Pods implements Iterator {
 		 * Filters the Pods magic tags content before the default function.
 		 * Allows complete replacement of the Pods magic tag engine.
 		 *
-		 * @param bool|mixed Value to return instead of
-		 *                   Default false to skip it.
+		 * @param null   $pre  Default is null which processes magic tags normally. Return any other value to override.
 		 * @param string $code The content to evaluate
-		 * @param object|Pods The Pods Object
+		 * @param Pods   $pods The Pods Object
 		 *
 		 * @since 2.7
 		 */
-		$pre = apply_filters( "pods_pre_do_magic_tags", false, $code, $this );
-		if ( false !== $pre ) {
+		$pre = apply_filters( "pods_pre_do_magic_tags", null, $code, $this );
+		if ( null !== $pre ) {
 			return $pre;
 		}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3625,7 +3625,7 @@ class Pods implements Iterator {
 		 *
 		 * @since 2.7
 		 */
-		$pre = apply_filters( "pods_pre_do_magic_tags", null, $code, $this );
+		$pre = apply_filters( 'pods_pre_do_magic_tags', null, $code, $this );
 		if ( null !== $pre ) {
 			return $pre;
 		}

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3614,6 +3614,23 @@ class Pods implements Iterator {
 	 * @since 2.0
 	 */
 	public function do_magic_tags ( $code ) {
+
+		/**
+		 * Filters the Pods magic tags content before the default function.
+		 * Allows complete replacement of the Pods magic tag engine.
+		 *
+		 * @param bool|mixed Value to return instead of
+		 *                   Default false to skip it.
+		 * @param string $code The content to evaluate
+		 * @param object|Pods The Pods Object
+		 *
+		 * @since 2.7
+		 */
+		$pre = apply_filters( "pods_pre_do_magic_tags", false, $code, $this );
+		if ( false !== $pre ) {
+			return $pre;
+		}
+
 		return preg_replace_callback( '/({@(.*?)})/m', array( $this, 'process_magic_tags' ), $code );
 	}
 


### PR DESCRIPTION
Creates new WordPress filter 'pods_pre_do_magic_tags'.  By default returns false which continues on with normal execution, if something other than false is returned that value is returned.

Resolves #4447 

Thought I opened a PR on this but I guess I just created the branch