### PR TITLE
Allow handling of arbitrary data that aren't Pods

### DIFF
--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -339,6 +339,7 @@ function frontier_do_subtemplate( $atts, $content ) {
  * @param array $data
  *
  * @return string
+ * @since 2.7
  */
 function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -26,8 +26,6 @@ function frontier_get_shortcodes() {
 	return $shortcodes;
 }
 
-
-
 /**
  * @param $content
  *
@@ -343,8 +341,10 @@ function frontier_do_subtemplate( $atts, $content ) {
  * @return string
  */
 function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
+
 	return preg_replace_callback( '/({@(.*?)})/m',
 		function( $tag ) use ( $pod, $data ) {
+
 			// This is essentially Pods->process_magic_tags() but with the Pods specific code ripped out
 			if ( is_array( $tag ) ) {
 				if ( !isset( $tag[ 2 ] ) && strlen( trim( $tag[ 2 ] ) ) < 1 )
@@ -356,8 +356,9 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 			$tag = trim( $tag, ' {@}' );
 			$tag = explode( ',', $tag );
 
-			if ( empty( $tag ) || !isset( $tag[ 0 ] ) || strlen( trim( $tag[ 0 ] ) ) < 1 )
+			if ( empty( $tag ) || !isset( $tag[ 0 ] ) || strlen( trim( $tag[ 0 ] ) ) < 1 ) {
 				return '';
+			}
 
 			foreach ( $tag as $k => $v ) {
 				$tag[ $k ] = trim( $v );
@@ -376,29 +377,32 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 						$value = $pod->helper( $helper_name, $value, $field_name );
 					}
 				}
-
 			} else {
 				$value = '';
 			}
 
-			if ( isset( $tag[ 2 ] ) && !empty( $tag[ 2 ] ) )
+			if ( isset( $tag[ 2 ] ) && !empty( $tag[ 2 ] ) ) {
 				$before = $tag[ 2 ];
+			}
 
-			if ( isset( $tag[ 3 ] ) && !empty( $tag[ 3 ] ) )
+			if ( isset( $tag[ 3 ] ) && !empty( $tag[ 3 ] ) ) {
 				$after = $tag[ 3 ];
+			}
 
 			$value = apply_filters( 'pods_do_magic_tags', $value, $field_name, $helper_name, $before, $after );
 
-			if ( is_array( $value ) )
+			if ( is_array( $value ) ) {
 				$value = pods_serial_comma( $value, array( 'field' => $field_name, 'fields' => $this->fields ) );
+			}
 
-			if ( null !== $value && false !== $value )
+			if ( null !== $value && false !== $value ) {
 				return $before . $value . $after;
+			}
 
 			return '';
-
 		}
 		, $template );
+
 	return '';
 }
 

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -374,7 +374,7 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknow
 
 			$helper_name = $before = $after = '';
 
-			if ( isset( $data[ $field_name ] ) ) {
+			if ( is_array( $data) && isset( $data[ $field_name ] ) ) {
 				$value = $data[ $field_name ];
 				if ( isset( $tag[ 1 ] ) && !empty( $tag[ 1 ] ) ) {
 					$helper_name = $tag[ 1 ];

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -374,7 +374,7 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknow
 
 			$helper_name = $before = $after = '';
 
-			if ( is_array( $data) && isset( $data[ $field_name ] ) ) {
+			if ( isset( $data[ $field_name ] ) ) {
 				$value = $data[ $field_name ];
 				if ( isset( $tag[ 1 ] ) && !empty( $tag[ 1 ] ) ) {
 					$helper_name = $tag[ 1 ];

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -401,9 +401,8 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 
 			return '';
 		}
-		, $template );
-
-	return '';
+		, $template
+	);
 }
 
 /**

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -256,8 +256,9 @@ function frontier_do_subtemplate( $atts, $content ) {
 	$pod = pods( $atts[ 'pod' ], $atts[ 'id' ] );
 	$field_name = $atts[ 'field' ];
 
-	$entries = (array) $pod->field( $field_name );
+	$entries = $pod->field( $field_name );
 	if ( ! empty( $entries ) ) {
+		$entries = (array) $entries;
 
 		$field = $pod->fields[ $field_name ];
 		// Object types that could be Pods

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -348,8 +348,9 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 
 			// This is essentially Pods->process_magic_tags() but with the Pods specific code ripped out
 			if ( is_array( $tag ) ) {
-				if ( !isset( $tag[ 2 ] ) && strlen( trim( $tag[ 2 ] ) ) < 1 )
+				if ( !isset( $tag[ 2 ] ) && strlen( trim( $tag[ 2 ] ) ) < 1 ) {
 					return '';
+				}
 
 				$tag = $tag[ 2 ];
 			}

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -258,7 +258,7 @@ function frontier_do_subtemplate( $atts, $content ) {
 	$pod = pods( $atts[ 'pod' ], $atts[ 'id' ] );
 	$field_name = $atts[ 'field' ];
 
-	$entries = $pod->field( $field_name );
+	$entries = (array) $pod->field( $field_name );
 	if ( ! empty( $entries ) ) {
 
 		$field = $pod->fields[ $field_name ];

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -311,6 +311,7 @@ function frontier_do_subtemplate( $atts, $content ) {
 				$content = str_replace( '{@_img', '{@image_attachment.' . $entry[ 'ID' ], $content );
 				$content = str_replace( '{@_src', '{@image_attachment_url.' . $entry[ 'ID' ], $content );
 				$content = str_replace( '{@' . $field_name . '}', '{@image_attachment.' . $entry[ 'ID' ] . '}', $content );
+				$content = frontier_pseudo_magic_tags( $content, $entry, $pod, true );
 
 				$out .= pods_do_shortcode( $pod->do_magic_tags( $content ), frontier_get_shortcodes() );
 			}
@@ -338,14 +339,15 @@ function frontier_do_subtemplate( $atts, $content ) {
  * @param Pod $pod
  * @param string $template
  * @param array $data
+ * @param boolean $skip_unknown If true then values not in $data will not be touched
  *
  * @return string
  * @since 2.7
  */
-function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
+function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknown = false ) {
 
 	return preg_replace_callback( '/({@(.*?)})/m',
-		function( $tag ) use ( $pod, $data ) {
+		function( $tag ) use ( $pod, $data, $skip_unknown ) {
 
 			// This is essentially Pods->process_magic_tags() but with the Pods specific code ripped out
 			if ( is_array( $tag ) ) {
@@ -353,6 +355,7 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 					return '';
 				}
 
+				$original_tag = $tag[0];
 				$tag = $tag[ 2 ];
 			}
 
@@ -381,6 +384,9 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 					}
 				}
 			} else {
+				if ( $skip_unknown ) {
+					return $original_tag;
+				}
 				$value = '';
 			}
 

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -320,8 +320,10 @@ function frontier_do_subtemplate( $atts, $content ) {
 			// Relationship to something other than a Pod (ie: user)
 			foreach ( $entries as $key => $entry ) {
 				$template = frontier_decode_template( $content, $atts );
-				$content = str_replace( '{_index}', $key, $template );
-
+				$template = str_replace( '{_index}', $key, $template );
+				if ( !is_array( $entry ) ) {
+					$entry = array( '_key' => $key, '_value' => $entry );
+				}
 				$out .= pods_do_shortcode( frontier_pseudo_magic_tags( $template, $entry, $pod ), frontier_get_shortcodes() );
 			}
 		}
@@ -375,6 +377,8 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null ) {
 					}
 				}
 
+			} else {
+				$value = '';
 			}
 
 			if ( isset( $tag[ 2 ] ) && !empty( $tag[ 2 ] ) )


### PR DESCRIPTION
Relationships to things like Pods don't really have data to traverse into with each.  So here it creates a pseudo magic tag handler that uses data from the array instead of from a Pod.

This is really closer to how all tags should be handled anyways and lines up closer to how Twig handles things.

Related to #4484 