### PR TITLE
Inline `wp_print_scripts` causes load order problems with script dependencies

### DIFF
--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -1,5 +1,6 @@
 <?php
 wp_enqueue_style( 'pods-form' );
+wp_enqueue_script( 'pods' );
 
 // unset fields
 foreach ( $fields as $k => $field ) {

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -1,10 +1,6 @@
 <?php
 wp_enqueue_style( 'pods-form' );
 
-if ( wp_script_is( 'pods', 'registered' ) && !wp_script_is( 'pods', 'done' ) ) {
-    wp_print_scripts( 'pods' );
-}
-
 // unset fields
 foreach ( $fields as $k => $field ) {
 


### PR DESCRIPTION
Fixes #4514

The dependency tree for the `pods` script has grown via its dependency on `pods-dfv` resulting in a script load-order bug.