### PR TITLE
Make form submission not direct and then die

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -8518,7 +8518,7 @@ class PodsAPI {
 			if ( 0 < $id && ! empty( $thank_you ) ) {
 				$thank_you = str_replace( 'X_ID_X', $id, $thank_you );
 
-				pods_redirect( $thank_you );
+				pods_redirect( $thank_you, 302, false );
 			}
 		}
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -1164,20 +1164,26 @@ function pods_function_or_file ( $function_or_file, $function_name = null, $file
  *
  * @param string $location The path to redirect to
  * @param int $status Status code to use
+ * @param boolean $die If true, PHP code exection will stop
  *
  * @return void
  *
  * @since 2.0
  */
-function pods_redirect ( $location, $status = 302 ) {
+function pods_redirect ( $location, $status = 302, $die = true ) {
     if ( !headers_sent() ) {
         wp_redirect( $location, $status );
-        die();
+        if ( $die ) {
+            die();
+        }
     }
     else {
-        die( '<script type="text/javascript">'
+        echo '<script type="text/javascript">'
             . 'document.location = "' . str_replace( '&amp;', '&', esc_js( $location ) ) . '";'
-            . '</script>' );
+            . '</script>';
+        if ( $die ) {
+            die();
+        }
     }
 }
 


### PR DESCRIPTION
Related to #4540.  This will allow the JS redirect to be displayed as well as let the footer be printed which will keep the original issue from happening.