### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = tab
-indent_size = 4
-tab_width = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 # spaces_around_operators = true
@@ -21,6 +18,6 @@ trim_trailing_whitespace = true
 [*.{txt,md}]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,json}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+# spaces_around_operators = true
+# spaces_around_brackets = both
+
+[*.{txt,md}]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /ui/js/pods-dfv/pods-dfv.min.js.map export-ignore
 /ui/styles/src export-ignore
 .travis.yml export-ignore
+.editorconfig export-ignore
 composer.json export-ignore
 rollup.config.js export-ignore
 CONTRIBUTING.md export-ignore


### PR DESCRIPTION
Related: #4569 #4216 
Fixes: #4571 

`spaces_around_operators` and `spaces_around_brackets` not available yet.

Comment from @pglewis 
Maybe remove the tab size options. No problem if the user has their own preferences. **Only issue it _could_ cause is when dev's are using precision alignment with spaces.**