### PR TITLE
Fixed: Relationships to Advanced Content Types in [each] template tags.

### DIFF
--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -262,6 +262,9 @@ function frontier_do_subtemplate( $atts, $content ) {
 				$target_id = null;
 				if ( isset( $entry[ 'ID' ] ) ) {
 					$target_id = $entry[ 'ID' ];
+				} elseif ( isset( $entry[ 'id' ] ) ) {
+					// Advanced Content Types have lowercase 'id'
+					$target_id = $entry[ 'id' ];
 				} elseif ( isset( $entry[ 'term_id' ] ) ) {
 					$target_id = $entry[ 'term_id' ];
 				}


### PR DESCRIPTION
ACTs have a lowercase 'id' but while parsing the [each] template tags only the uppercase 'ID' was checked.