### PR TITLE
`ajaxurl` was being locally scoped; remove superfluous document ready wrappers

### DIFF
--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -185,13 +185,11 @@ if ( !$fields_only ) {
 			if ( 'undefined' !== typeof jQuery( document ).Pods ) {
 
 				if ( 'undefined' === typeof ajaxurl ) {
-					var ajaxurl = '<?php echo pods_slash( admin_url( 'admin-ajax.php' ) ); ?>';
+					window.ajaxurl = '<?php echo pods_slash( admin_url( 'admin-ajax.php' ) ); ?>';
 				}
 
-				jQuery( function ( $ ) {
-					$( document ).Pods( 'validate' );
-					$( document ).Pods( 'submit' );
-				} );
+				$( document ).Pods( 'validate' );
+				$( document ).Pods( 'submit' );
 			}
 		} );
 	}


### PR DESCRIPTION
Fixes #4618 
Fixes #4621