### PR TITLE
Set minimum MySQL version to 5.1, at least it's better than 5.0

### DIFF
--- a/init.php
+++ b/init.php
@@ -55,8 +55,9 @@ if ( defined( 'PODS_VERSION' ) || defined( 'PODS_DIR' ) ) {
 
 	// This should match minimum WP requirements or usage (90%+)
 	// Found at: https://wordpress.org/about/stats/
+	// Using 5.1 for now, many RedHat servers aren't EOL yet and they backport security releases
 	if ( ! defined( 'PODS_MYSQL_VERSION_MINIMUM' ) ) {
-		define( 'PODS_MYSQL_VERSION_MINIMUM', '5.5' );
+		define( 'PODS_MYSQL_VERSION_MINIMUM', '5.1' );
 	}
 
 	define( 'PODS_SLUG', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Related:
https://wordpress.org/support/topic/pods-breakage-due-to-new-php-mysql-requirements/#post-9762357