### PR TITLE
check for the localized string 'help' before inserting help tooltip

### DIFF
--- a/ui/fields/_label.php
+++ b/ui/fields/_label.php
@@ -5,7 +5,7 @@
     if ( 1 == pods_var( 'required', $options, pods_var( 'options', $options, $options ) ) )
         echo ' <abbr title="required" class="required">*</abbr>';
 
-    if ( 0 == pods_var( 'grouped', $options, 0, null, true ) && !empty( $help ) && 'help' != $help )
+    if ( 0 == pods_var( 'grouped', $options, 0, null, true ) && !empty( $help ) && __( 'help', 'pods' ) != $help )
         pods_help( $help );
     ?>
 </label>


### PR DESCRIPTION
Fixes #4614 issue.