### PR TITLE
Fix for #4745 Title not shown in metabox if only one group is defined

### DIFF
--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -537,7 +537,7 @@ if ( 0 < $pod->id() ) {
                             <h3 class="hndle">
                                 <span>
                                     <?php
-                                        if ( ! $more && 1 == count( $groups ) && $group[ 'label' ] == __( 'More Fields', 'pods' ) ) {
+                                        if ( ! $more && 1 == count( $groups ) && $group[ 'label' ] === __( 'More Fields', 'pods' ) ) {
                                             $title = __( 'Fields', 'pods' );
                                         }
                                         else {

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -537,7 +537,7 @@ if ( 0 < $pod->id() ) {
                             <h3 class="hndle">
                                 <span>
                                     <?php
-                                        if ( ! $more && 1 == count( $groups ) ) {
+                                        if ( ! $more && 1 == count( $groups ) && $group[ 'label' ] == __( 'More Fields', 'pods' ) ) {
                                             $title = __( 'Fields', 'pods' );
                                         }
                                         else {


### PR DESCRIPTION
Fixes #4745 issue
Change 'More Fields' with 'Fields' in group (metabox) title only if no different title has been provided (e.g. with pods_group_add).