### PR TITLE
Avoid printing null message in PodsUI

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1461,16 +1461,18 @@ class PodsUI {
 	 */
 	public function message( $msg, $error = false ) {
 
-		$msg = $this->do_hook( ( $error ) ? 'error' : 'message', $msg );
-		
-		if ( null === $msg ) {
-			return;
-		}
-		
 		$class = 'updated';
+		$hook  = 'message';
 		
 		if ( $error ) {
 			$class = 'error';
+			$hook  = 'error';
+		}
+		
+		$msg = $this->do_hook( $hook, $msg );
+		
+		if ( empty( $msg ) ) {
+			return;
 		}
 		?> 
 		<div id="message" class="<?php echo esc_attr( $class ); ?> fade">

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1462,10 +1462,11 @@ class PodsUI {
 	public function message( $msg, $error = false ) {
 
 		$msg = $this->do_hook( ( $error ) ? 'error' : 'message', $msg );
-		?>
+		if($msg !== null) {
+		?> 
 		<div id="message" class="<?php echo esc_attr( ( $error ) ? 'error' : 'updated' ); ?> fade">
 			<p><?php echo $msg; ?></p></div>
-		<?php
+		<?php }
 	}
 
 	/**

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1462,11 +1462,21 @@ class PodsUI {
 	public function message( $msg, $error = false ) {
 
 		$msg = $this->do_hook( ( $error ) ? 'error' : 'message', $msg );
-		if($msg !== null) {
+		
+		if ( null === $msg ) {
+			return;
+		}
+		
+		$class = 'updated';
+		
+		if ( $error ) {
+			$class = 'error';
+		}
 		?> 
-		<div id="message" class="<?php echo esc_attr( ( $error ) ? 'error' : 'updated' ); ?> fade">
-			<p><?php echo $msg; ?></p></div>
-		<?php }
+		<div id="message" class="<?php echo esc_attr( $class ); ?> fade">
+			<p><?php echo $msg; ?></p>
+		</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
The `pods_ui_message` filter hook in `pods_ui` allows to change the message being printed in the admin notice box. In case the returned message is `null` the box shouldn't be printed at all. 

