### PR TITLE
mockery 1.0 requires php >=5.6.0; downgrade to 0.9 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
   "require-dev": {
     "wp-cli/wp-cli": "1.*",
     "phpunit/phpunit": "4.*",
-    "mockery/mockery": "1.0.*",
+    "mockery/mockery": "0.9.*",
     "squizlabs/php_codesniffer": "2.9.1 - 3.2.3",
     "DealerDirect/phpcodesniffer-composer-installer":"0.4.*",
     "wp-coding-standards/wpcs": "0.14.*",


### PR DESCRIPTION
Fixes #4817