### PR TITLE
Update phpcs.xml.dist with prefix and textdomain

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,18 @@
 	<config name="testVersion" value="5.3-"/>
 	<rule ref="PHPCompatibility"/>
 
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="pods"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="pods"/>
+		</properties>
+	</rule>
+
 	<rule ref="Squiz.Commenting">
 		<!-- Excluding the need for a full stop at the end of a comment (common, harmless error) -->
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>


### PR DESCRIPTION
Add prefix and textdomain to enable further checks.

See:
- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace
- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#internationalization-setting-your-text-domain