### PR TITLE
Fix copy/paste mistake for `search` param in Pods shortcode

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -749,7 +749,7 @@ function pods_shortcode( $tags, $content = null ) {
 	$tags = apply_filters( 'pods_shortcode', $tags );
 
 	$tags['pagination']  = filter_var( $tags['pagination'], FILTER_VALIDATE_BOOLEAN );
-	$tags['search']      = filter_var( $tags['pagination'], FILTER_VALIDATE_BOOLEAN );
+	$tags['search']      = filter_var( $tags['search'], FILTER_VALIDATE_BOOLEAN );
 	$tags['use_current'] = filter_var( $tags['use_current'], FILTER_VALIDATE_BOOLEAN );
 
 	if ( empty( $content ) ) {


### PR DESCRIPTION
Fixes #4909