### PR TITLE
Handle saving related values if passed as an array of information

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -4005,6 +4005,33 @@ class PodsAPI {
 								}
 							} elseif ( $is_file_field && isset( $v['id'] ) ) {
 								$v = (int) $v['id'];
+							} elseif ( 'pods' === $data_mode && ! isset( $v[0] ) ) {
+								// Save related field values.
+								$v_id = false;
+
+								if ( isset( $v[ $search_data->field_id ] ) ) {
+									$v_id = $v[ $search_data->field_id ];
+
+									unset( $v[ $search_data->field_id ] );
+								}
+
+								if ( ! empty( $v_id ) ) {
+									$search_data->save( $v, null, $v_id );
+								} else {
+									$row_has_values = array_filter( $v );
+
+									if ( ! $row_has_values ) {
+										continue;
+									}
+
+									$v_id = $search_data->add( $v );
+								}
+
+								if ( empty( $v_id ) ) {
+									continue;
+								}
+
+								$v = $v_id;
 							} else {
 								continue;
 							}


### PR DESCRIPTION
Examples below use a "book" pick field, multiple select, related to a "book" custom post type created or extended by Pods).

---

## Example 1

```
$pod = pods( 'author', 1234 );

$data = array(
    'books' => array(
        array(
            'post_title' => 'Book 1',
            'post_content' => 'Some content',
            'some_custom_field' => 'Value here',
        ),
    ),
);

$pod->save( $data );
```

Expectation would be that the above code would save a new value for the related book field.

---

## Example 2

```
$pod = pods( 'author', 1234 );

$data = array(
    'books' => array(
        array(
            'ID' => 1234,
            'post_title' => 'Book 1',
            'post_content' => 'Some new content',
            'some_custom_field' => 'New value here',
        ),
    ),
);

$pod->save( $data );
```

Expectation would be that the above code would update the data for the the related book field.