### PR TITLE
'00:00:00' is midnight and a perfectly valid time value

### DIFF
--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -40,7 +40,7 @@ class PodsField_Time extends PodsField_DateTime {
 	 * @var string
 	 * @since 2.7
 	 */
-	public static $empty_value = '00:00:00';
+	public static $empty_value = '';
 
 	/**
 	 * {@inheritdoc}
@@ -159,6 +159,50 @@ class PodsField_Time extends PodsField_DateTime {
 
 		return $schema;
 	}
+
+	/**
+	 * Convert value to the correct format for display.
+	 *
+	 * @param string $value   Field value.
+	 * @param array  $options Field options.
+	 * @param bool   $js      Return formatted from jQuery UI format? (only for custom formats).
+	 *
+	 * @return string
+	 * @since 2.7
+	 */
+	public function format_value_display( $value, $options, $js = false ) {
+
+		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
+			$js = false;
+		}
+		$format = $this->format_datetime( $options, $js );
+		if ( $js ) {
+			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
+		}
+
+		if ( ! empty( $value ) ) {
+			// Try default storage format.
+			$date = $this->createFromFormat( static::$storage_format, (string) $value );
+
+			// Try field format.
+			$date_local = $this->createFromFormat( $format, (string) $value );
+
+			if ( $date instanceof DateTime ) {
+				$value = $date->format( $format );
+			} elseif ( $date_local instanceof DateTime ) {
+				$value = $date_local->format( $format );
+			} else {
+				$value = date_i18n( $format, strtotime( (string) $value ) );
+			}
+		} elseif ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
+			$value = date_i18n( $format );
+		} else {
+			$value = '';
+		}
+
+		return $value;
+	}
+
 
 	/**
 	 * {@inheritdoc}


### PR DESCRIPTION
Change `empty_value` to the empty string and override `format_value_display` in the time field to allow midnight as a valid time and allow a proper empty value to be set (where allowed).

Fixes #4937, #3488

This is hopefully just a final patch to fix a couple issues with the time field before converting date/time/datetime to DFV.  