### PR TITLE
Code Editor for Pods Template double-escapes HTML when Visual Editor is OFF in WordPress

### DIFF
--- a/components/Templates/includes/element-view_template.php
+++ b/components/Templates/includes/element-view_template.php
@@ -6,7 +6,12 @@
 <div class="pods-compat-container">
 	<textarea id="content" name="content">
 		<?php if ( isset( $content ) ) {
-			echo esc_textarea( $content );
+			// WordPress will already call esc_textarea() if richedit is off, don't escape twice (see #3462)
+			if ( ! user_can_richedit() ) {
+				echo $content;
+			} else {
+				echo esc_textarea( $content );
+			}
 		} ?>
 	</textarea>
 </div>

--- a/components/Templates/includes/element-view_template.php
+++ b/components/Templates/includes/element-view_template.php
@@ -12,7 +12,7 @@
 		if ( isset( $content ) ) {
 			// WordPress will already call esc_textarea() if richedit is off, don't escape twice (see #3462)
 			if ( ! user_can_richedit() ) {
-				// phpcs:ignore
+				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $content;
 			} else {
 				echo esc_textarea( $content );

--- a/components/Templates/includes/element-view_template.php
+++ b/components/Templates/includes/element-view_template.php
@@ -1,17 +1,22 @@
 <?php
 /**
  * Frontier Template code editor metabox
+ *
+ * @package Pods_templates
  */
+
 ?>
 <div class="pods-compat-container">
 	<textarea id="content" name="content">
-		<?php if ( isset( $content ) ) {
+		<?php
+		if ( isset( $content ) ) {
 			// WordPress will already call esc_textarea() if richedit is off, don't escape twice (see #3462)
 			if ( ! user_can_richedit() ) {
-				echo $content;
+				echo $content; // phpcs:ignore
 			} else {
 				echo esc_textarea( $content );
 			}
-		} ?>
+		}
+		?>
 	</textarea>
 </div>

--- a/components/Templates/includes/element-view_template.php
+++ b/components/Templates/includes/element-view_template.php
@@ -12,7 +12,8 @@
 		if ( isset( $content ) ) {
 			// WordPress will already call esc_textarea() if richedit is off, don't escape twice (see #3462)
 			if ( ! user_can_richedit() ) {
-				echo $content; // phpcs:ignore
+				// phpcs:ignore
+				echo $content;
 			} else {
 				echo esc_textarea( $content );
 			}


### PR DESCRIPTION
Wordpress will already call `esc_textarea()` if rich edit is off, so don't double-escape when the visual editor is disabled.

Fixes #3462