### PR TITLE
Extend PR #4975

### DIFF
--- a/bin/phpcs-audit.sh
+++ b/bin/phpcs-audit.sh
@@ -24,5 +24,5 @@ echo Running PHPCS reports
 for type in ${types[@]}
 do
   echo Running PHPCS report: ${type}
-  ./vendor/bin/phpcs -v -s -p -d memory_limit="256M" --extensions="php" --report="${type}" --report-file="report-${type}${file_affix}.txt" ${file_path}
+  ./vendor/bin/phpcs -v -s -p -d memory_limit="256M" --report="${type}" --report-file="report-${type}${file_affix}.txt" ${file_path}
 done;

--- a/bin/phpcs-audit.sh
+++ b/bin/phpcs-audit.sh
@@ -24,5 +24,5 @@ echo Running PHPCS reports
 for type in ${types[@]}
 do
   echo Running PHPCS report: ${type}
-  ./vendor/bin/phpcs -v -s -p -d memory_limit="256M" --report="${type}" --report-file="report-${type}${file_affix}.txt" ${file_path}
+  ./vendor/bin/phpcs -v --report="${type}" --report-file="report-${type}${file_affix}.txt" ${file_path}
 done;

--- a/bin/phpcs-autofix.sh
+++ b/bin/phpcs-autofix.sh
@@ -11,7 +11,5 @@
 default_path="."
 file_path=${1:-$default_path}
 
-ignore="\.idea,\.saas-cache,node_modules,vendor,bin,tests"
-
 echo Running PHPCS autofix
-./vendor/bin/phpcbf -v -d memory_limit="256M" --extensions="php" --ignore="${ignore}" ${file_path}
+./vendor/bin/phpcbf -v -d memory_limit="256M" ${file_path}

--- a/bin/phpcs-autofix.sh
+++ b/bin/phpcs-autofix.sh
@@ -12,4 +12,4 @@ default_path="."
 file_path=${1:-$default_path}
 
 echo Running PHPCS autofix
-./vendor/bin/phpcbf -v -d memory_limit="256M" ${file_path}
+./vendor/bin/phpcbf -v ${file_path}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,8 @@
 	<arg value="s"/> <!-- Show sniff -->
 	<arg name="extensions" value="php"/><!-- Only check .php files -->
 
+	<ini name="memory_limit" value="256M"/>
+
 	<config name="minimum_supported_wp_version" value="4.5"/>
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,8 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/components/Markdown.php</exclude-pattern>
 
-	<arg name="extensions" value="php"/>
+	<arg value="s"/> <!-- Show sniff -->
+	<arg name="extensions" value="php"/><!-- Only check .php files -->
 
 	<config name="minimum_supported_wp_version" value="4.5"/>
 	<rule ref="WordPress-Core"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,7 @@
 <ruleset name="Pods">
 	<description>Pods-customized WordPress Coding Standards</description>
 
+	<file>.</file>
 	<exclude-pattern>*/.idea/*</exclude-pattern>
 	<exclude-pattern>*/.sass-cache/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,8 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/components/Markdown.php</exclude-pattern>
 
+	<arg name="extensions" value="php"/>
+
 	<config name="minimum_supported_wp_version" value="4.5"/>
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
Extends #4975 with a few more changes to centralise PHPCS args into `phpcs.xml.dist`.

See https://github.com/pods-framework/pods/pull/4975#discussion_r192555632.