### PR TITLE
Handle cases where $related_obj didn't result in a valid pod, fall back to table select

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1518,7 +1518,7 @@ class Pods implements Iterator {
 
 								$item_data = array();
 
-								if ( ! $related_obj ) {
+								if ( ! $related_obj || ! $related_obj->valid() ) {
 									if ( ! is_object( $this->alt_data ) ) {
 										$this->alt_data = pods_data( null, 0, true, true );
 									}


### PR DESCRIPTION
Fixes #4979 

Changelog:

`Fixed issue where relationship fields related to the _pods_pod or _pods_field post type would not return the correct value`