### PR TITLE
PHPCS: Fix some I18n violations

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1722,7 +1722,7 @@ class PodsAPI {
 			}
 
 			if ( $old_name !== $params->name && false !== $this->pod_exists( array( 'name' => $params->name ) ) ) {
-				return pods_error( sprintf( __( 'Pod %s already exists, you cannot rename %s to that', 'pods' ), $params->name, $old_name ), $this );
+				return pods_error( sprintf( __( 'Pod %1$s already exists, you cannot rename %2$s to that', 'pods' ), $params->name, $old_name ), $this );
 			}
 
 			if ( $old_name !== $params->name && in_array( $pod['type'], array(
@@ -1919,13 +1919,13 @@ class PodsAPI {
 				$check = get_post_type_object( $params->name );
 
 				if ( ! empty( $check ) ) {
-					return pods_error( sprintf( __( 'Post Type %s already exists, you cannot rename %s to that', 'pods' ), $params->name, $old_name ), $this );
+					return pods_error( sprintf( __( 'Post Type %1$s already exists, you cannot rename %2$s to that', 'pods' ), $params->name, $old_name ), $this );
 				}
 			} elseif ( 'taxonomy' === $pod['type'] ) {
 				$check = get_taxonomy( $params->name );
 
 				if ( ! empty( $check ) ) {
-					return pods_error( sprintf( __( 'Taxonomy %s already exists, you cannot rename %s to that', 'pods' ), $params->name, $old_name ), $this );
+					return pods_error( sprintf( __( 'Taxonomy %1$s already exists, you cannot rename %2$s to that', 'pods' ), $params->name, $old_name ), $this );
 				}
 			}
 		}
@@ -2492,7 +2492,7 @@ class PodsAPI {
 			}
 
 			if ( $old_name !== $field['name'] && false !== $this->field_exists( $params ) ) {
-				return pods_error( sprintf( __( 'Field %s already exists, you cannot rename %s to that', 'pods' ), $field['name'], $old_name ), $this );
+				return pods_error( sprintf( __( 'Field %1$s already exists, you cannot rename %2$s to that', 'pods' ), $field['name'], $old_name ), $this );
 			}
 
 			if ( ( $id_required || ! empty( $params->id ) ) && ( empty( $old_id ) || $old_id != $params->id ) ) {

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -3426,8 +3426,8 @@ class PodsAdmin {
 		if ( ! function_exists( 'register_rest_field' ) ) {
 			$options['rest-api'] = array(
 				'no_dependencies' => array(
-					'label' => __( sprintf( 'Pods REST API support requires WordPress 4.3.1 or later and the %s or later.', '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">WordPress REST API 2.0-beta9</a>' ), 'pods' ),
-					'help'  => __( sprintf( 'See %s for more information.', '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/</a>' ), 'pods' ),
+					'label' => sprintf( __( 'Pods REST API support requires WordPress 4.3.1 or later and the %s or later.', 'pods' ), '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">WordPress REST API 2.0-beta9</a>' ),
+					'help'  => sprintf( __( 'See %s for more information.', 'pods' ), '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/</a>' ),
 					'type'  => 'html',
 				),
 			);
@@ -3469,7 +3469,7 @@ class PodsAdmin {
 			$options['rest-api'] = array(
 				'not_restable' => array(
 					'label' => __( 'Pods REST API support covers post type, taxonomy and user Pods.', 'pods' ),
-					'help'  => __( sprintf( 'See %s for more information.', '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/"</a>' ), 'pods' ),
+					'help'  => sprintf( __( 'See %s for more information.', 'pods' ), '<a href="https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/" target="_blank">https://pods.io/docs/build/extending-core-wordpress-rest-api-routes-with-pods/"</a>' ),
 					'type'  => 'html',
 				),
 			);

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -948,11 +948,6 @@ class PodsInit {
 			// Max length for taxonomies are 32 characters
 			$taxonomy = substr( $taxonomy, 0, 32 );
 
-			// i18n compatibility for plugins that override it
-			if ( is_array( $options['rewrite'] ) && isset( $options['rewrite']['slug'] ) && ! empty( $options['rewrite']['slug'] ) ) {
-				$options['rewrite']['slug'] = _x( $options['rewrite']['slug'], 'URL taxonomy slug', 'pods' );
-			}
-
 			/**
 			 * Allow filtering of taxonomy options per taxonomy.
 			 *
@@ -997,11 +992,6 @@ class PodsInit {
 
 			// Max length for post types are 20 characters
 			$post_type = substr( $post_type, 0, 20 );
-
-			// i18n compatibility for plugins that override it
-			if ( is_array( $options['rewrite'] ) && isset( $options['rewrite']['slug'] ) && ! empty( $options['rewrite']['slug'] ) ) {
-				$options['rewrite']['slug'] = _x( $options['rewrite']['slug'], 'URL slug', 'pods' );
-			}
 
 			/**
 			 * Allow filtering of post type options per post type.

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1213,7 +1213,7 @@ class PodsInit {
 				$messages[ $post_type['name'] ][6] = sprintf( __( '%s published.', 'pods' ), $labels['singular_name'] );
 				$messages[ $post_type['name'] ][8] = sprintf( __( '%s submitted.', 'pods' ), $labels['singular_name'] );
 				$messages[ $post_type['name'] ][9] = sprintf(
-					__( '%s scheduled for: <strong>%1$s</strong>.', 'pods' ), $labels['singular_name'],
+					__( '%1$s scheduled for: <strong>%2$s</strong>.', 'pods' ), $labels['singular_name'],
 					// translators: Publish box date format, see http://php.net/date
 					date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) )
 				);

--- a/components/Helpers.php
+++ b/components/Helpers.php
@@ -124,7 +124,7 @@ class Pods_Helpers extends PodsComponent {
 			7  => sprintf( __( '%s saved.', 'pods' ), $labels->singular_name ),
 			8  => sprintf( __( '%1$s submitted. <a target="_blank" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 			9  => sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview %4$s</a>', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $labels->singular_name
 			),
@@ -136,7 +136,7 @@ class Pods_Helpers extends PodsComponent {
 			$messages[ $post_type->name ][6] = sprintf( __( '%s published.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][8] = sprintf( __( '%s submitted.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][9] = sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>.', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>.', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) )
 			);

--- a/components/I18n/I18n-polylang.php
+++ b/components/I18n/I18n-polylang.php
@@ -5,8 +5,7 @@
  */
 class Pods_I18n_Polylang {
 
-	public $languages  = array();
-	public $textdomain = 'polylang';
+	public $languages = array();
 
 	/**
 	 * Pods_I18n_Polylang constructor.
@@ -54,7 +53,7 @@ class Pods_I18n_Polylang {
 	public function pods_component_i18n_admin_ui_fields( $fields, $data ) {
 
 		$fields['manage']['polylang'] = array(
-			'label' => __( 'Polylang', $this->textdomain ),
+			'label' => __( 'Polylang', 'pods' ),
 			'type'  => 'boolean',
 			/*
 			'options' => array(

--- a/components/I18n/I18n-wpml.php
+++ b/components/I18n/I18n-wpml.php
@@ -5,8 +5,7 @@
  */
 class Pods_I18n_WPML {
 
-	public $languages  = array();
-	public $textdomain = 'sitepress-multilingual-cms';
+	public $languages = array();
 
 	/**
 	 * Pods_I18n_WPML constructor.
@@ -60,7 +59,7 @@ class Pods_I18n_WPML {
 	public function pods_component_i18n_admin_ui_fields( $fields, $data ) {
 
 		$fields['manage']['wpml'] = array(
-			'label' => __( 'WPML', $this->textdomain ),
+			'label' => __( 'WPML', 'pods' ),
 			'type'  => 'boolean',
 			/*
 			'options' => array(

--- a/components/Pages.php
+++ b/components/Pages.php
@@ -212,7 +212,7 @@ class Pods_Pages extends PodsComponent {
 			7  => sprintf( __( '%s saved.', 'pods' ), $labels->singular_name ),
 			8  => sprintf( __( '%1$s submitted. <a target="_blank" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 			9  => sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview %4$s</a>', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $labels->singular_name
 			),
@@ -224,7 +224,7 @@ class Pods_Pages extends PodsComponent {
 			$messages[ $post_type->name ][6] = sprintf( __( '%s published.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][8] = sprintf( __( '%s submitted.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][9] = sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>.', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>.', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) )
 			);

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -182,7 +182,7 @@ class Pods_Templates extends PodsComponent {
 			7  => sprintf( __( '%s saved.', 'pods' ), $labels->singular_name ),
 			8  => sprintf( __( '%1$s submitted. <a target="_blank" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 			9  => sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>. <a target="_blank" href="%3$s">Preview %4$s</a>', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $labels->singular_name
 			),
@@ -194,7 +194,7 @@ class Pods_Templates extends PodsComponent {
 			$messages[ $post_type->name ][6] = sprintf( __( '%s published.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][8] = sprintf( __( '%s submitted.', 'pods' ), $labels->singular_name );
 			$messages[ $post_type->name ][9] = sprintf(
-				__( '%s scheduled for: <strong>%1$s</strong>.', 'pods' ), $labels->singular_name,
+				__( '%1$s scheduled for: <strong>%2$s</strong>.', 'pods' ), $labels->singular_name,
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) )
 			);

--- a/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Settings.php
+++ b/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Settings.php
@@ -359,7 +359,7 @@ class Pods_Templates_Auto_Template_Settings {
 			if ( is_array( $archive_test ) ) {
 				foreach ( $archive_test as $label => $test ) {
 					if ( $test === 'fail' ) {
-						echo sprintf( '<div id="message" class="error"><p>%s</p></div>', sprintf( __( 'The Pods post type %1$s has an archive template set to be displayed using Pods auto template, but the Pod does not have an archive. You can enable post type archives in the "Advanced Options" tab.', 'pfat' ), $label ) );
+						echo sprintf( '<div id="message" class="error"><p>%s</p></div>', sprintf( __( 'The Pods post type %1$s has an archive template set to be displayed using Pods auto template, but the Pod does not have an archive. You can enable post type archives in the "Advanced Options" tab.', 'pods' ), $label ) );
 					}
 				}
 			}

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -242,7 +242,7 @@ if ( isset( $_GET[ 'do' ] ) ) {
     elseif ( 'duplicate' ==$do )
         $action = __( 'duplicated', 'pods' );
 
-    $message = sprintf( __( '<strong>Success!</strong> %s %s successfully.', 'pods' ), $obj->item, $action );
+    $message = sprintf( __( '<strong>Success!</strong> %1$s %2$s successfully.', 'pods' ), $obj->item, $action );
 
     echo $obj->message( $message );
 }


### PR DESCRIPTION
## Description
Addresses some I18n code standards violations.

- WordPress.WP.I18n.MixedOrderedPlaceholdersText
- WordPress.WP.I18n.UnorderedPlaceholdersText
- WordPress.WP.I18n.TextDomainMismatch
- WordPress.WP.I18n.NonSingularStringLiteralDomain
- WordPress.WP.I18n.NonSingularStringLiteralText

Makes it easier for translators to re-order placeholders in their locale, adds several string to the `pods` textdomain.

See #4982.

## Types of changes
Code standards improvements. See the individual commits for more info.

## ChangeLog
Improvement: Addresses some internationalization code standard violations #4982 (@GaryJones)
