### PR TITLE
PHPCS: Add colors and basepath args

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,8 @@
 	<arg value="s"/> <!-- Show sniff codes in all reports -->
 	<arg value="p"/> <!-- Show progress of the run -->
 	<arg name="extensions" value="php"/><!-- Only check .php files -->
+	<arg name="basepath" value="."/><!-- Strip the file paths down to the relevant bit -->
+	<arg name="colors"/><!-- Show colors in output -->
 
 	<ini name="memory_limit" value="256M"/>
 


### PR DESCRIPTION
## Description
Adds two args to `phpcs.xml.dist` to make the PHPCS output easier to read.

Fixes #4985.

## Screenshots (jpeg or gifs if applicable):
See #4985.

## ChangeLog
Improvement: Make PHPCS output easier to read #4985 (@GaryJones)