### PR TITLE
Labels: Check for localized 'help' before adding tooltip

### DIFF
--- a/ui/fields/_label.php
+++ b/ui/fields/_label.php
@@ -6,7 +6,7 @@
 		echo ' <abbr title="required" class="required">*</abbr>';
 	}
 
-	if ( 0 == pods_var( 'grouped', $options, 0, null, true ) && ! empty( $help ) && 'help' !== $help ) {
+	if ( 0 == pods_var( 'grouped', $options, 0, null, true ) && ! empty( $help ) && __( 'help', 'pods' ) !== $help ) {
 		pods_help( $help );
 	}
 	?>


### PR DESCRIPTION
## Description
Fixes #4614.

See #4684 (props @davidatwhiletrue for original PR). This PR just addresses the merge conflict. I checked out @davidatwhiletrue's branch, cherry-picked his commit, and then fixed the merge conflict and committed, so that @davidatwhiletrue's contribution is retained.

## How Has This Been Tested?
Manually checking for the presence of the tooltip icon, before and after applying patch.

## Screenshots (jpeg or gifs if applicable):

Before: Label just says "Help" in Spanish:

![](https://user-images.githubusercontent.com/88371/40949086-2c94052e-6864-11e8-85fd-096abbf019c2.png)

After: No tooltip icons present for redundant help text:

![](https://user-images.githubusercontent.com/88371/40949087-2caf7106-6864-11e8-811b-0d42d946be2c.png)



## Types of changes
Bug fix / UI improvement (non-breaking change which fixes an issue)

## ChangeLog
Improvement: Check for localized 'help' before adding tooltip #4612 (@davidatwhieltrue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.
