### PR TITLE
CLI: Fix missing negation on valid & exists checks

### DIFF
--- a/classes/cli/Pods_CLI_Command.php
+++ b/classes/cli/Pods_CLI_Command.php
@@ -31,7 +31,7 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $pod_name, null, false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 
@@ -91,11 +91,11 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $pod_name, $item, false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 
-		if ( null !== $item && $pod->exists() ) {
+		if ( null !== $item && ! $pod->exists() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%1$s" item "%2$s" does not exist.', 'pods' ), $assoc_args['pod'], $assoc_args['item'] ) );
 		}
 
@@ -142,11 +142,11 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $assoc_args['pod'], $assoc_args['item'], false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 
-		if ( $pod->exists() ) {
+		if ( ! $pod->exists() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%1$s" item "%2$s" does not exist.', 'pods' ), $assoc_args['pod'], $assoc_args['item'] ) );
 		}
 
@@ -189,11 +189,11 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $assoc_args['pod'], $assoc_args['item'], false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 
-		if ( $pod->exists() ) {
+		if ( ! $pod->exists() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%1$s" item "%2$s" does not exist.', 'pods' ), $assoc_args['pod'], $assoc_args['item'] ) );
 		}
 
@@ -255,11 +255,11 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $pod_name, $item, false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 
-		if ( null !== $item && $pod->exists() ) {
+		if ( null !== $item && ! $pod->exists() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%1$s" item "%2$s" does not exist.', 'pods' ), $assoc_args['pod'], $assoc_args['item'] ) );
 		}
 
@@ -332,7 +332,7 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 		$pod = pods( $pod_name, null, false );
 
-		if ( $pod->valid() ) {
+		if ( ! $pod->valid() ) {
 			WP_CLI::error( sprintf( __( 'Pod "%s" does not exist.', 'pods' ), $assoc_args['pod'] ) );
 		}
 


### PR DESCRIPTION
## Description
WP-CLI errors should only be thrown if Pods / Pods Items are NOT valid or do NOT exist.

Original code committed in https://github.com/pods-framework/pods/commit/c1d39bc09b452bfb197ed66a590e130a63f7acc9.

Fixes #4989.

## How Has This Been Tested?
Running command-line calls locally.

## Screenshots (jpeg or gifs if applicable):

Before and after the code fix:

![Screenshot of WP-CLI calls](https://user-images.githubusercontent.com/88371/40950589-4e9f7f8e-686b-11e8-92fc-35f85d9579d3.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## ChangeLog
Fix: CLI: Fix missing negation on valid & exists checks #4989 (@GaryJones)

## Checklist:
- [x] My code is manually tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
