### PR TITLE
Refactor PodsField_Pick::can_ajax()

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -2409,7 +2409,7 @@ class PodsField_Pick extends PodsField {
 	/**
 	 * Check if a field supports AJAX mode
 	 *
-	 * @param string $type
+	 * @param string $type    Field type.
 	 * @param array  $options Field options.
 	 *
 	 * @return bool

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -2392,6 +2392,21 @@ class PodsField_Pick extends PodsField {
 	}
 
 	/**
+	 * Check if a field type is a tableless text field type.
+	 *
+	 * @since 2.7.4
+	 *
+	 * @param string $type    Field type.
+	 * @param array  $options Field options.
+	 * @return bool True if the field type is a tableless text field type, false otherwise.
+	 */
+	public function is_simple_tableless( $type, array $options ) {
+		$field_object = pods_v( $type . '_object', $options );
+
+		return in_array( $field_object, PodsForm::simple_tableless_objects(), true );
+	}
+
+	/**
 	 * Check if a field supports AJAX mode
 	 *
 	 * @param string $type
@@ -2401,17 +2416,9 @@ class PodsField_Pick extends PodsField {
 	 * @since 2.7.4
 	 */
 	public function can_ajax( $type, $options ) {
-
-		$field_object = pods_v( $type . '_object', $options );
-		$is_simple_tableless = in_array( $field_object, PodsForm::simple_tableless_objects(), true );
-
-		$value = false;
-		if ( $this->is_autocomplete( $options ) && ! $is_simple_tableless ) {
-			$value = true;
-		}
-
-		return $value;
+		return $this->is_autocomplete( $options ) && ! $this->is_simple_tableless( $type, $options );
 	}
+
 
 	/**
 	 * Handle autocomplete AJAX.

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -2374,7 +2374,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @since 2.7
 	 */
-	public function is_autocomplete( $options ) {
+	private function is_autocomplete( $options ) {
 
 		$autocomplete = false;
 
@@ -2400,7 +2400,7 @@ class PodsField_Pick extends PodsField {
 	 * @param array  $options Field options.
 	 * @return bool True if the field type is a tableless text field type, false otherwise.
 	 */
-	public function is_simple_tableless( $type, array $options ) {
+	private function is_simple_tableless( $type, array $options ) {
 		$field_object = pods_v( $type . '_object', $options );
 
 		return in_array( $field_object, PodsForm::simple_tableless_objects(), true );
@@ -2415,7 +2415,7 @@ class PodsField_Pick extends PodsField {
 	 * @return bool
 	 * @since 2.7.4
 	 */
-	public function can_ajax( $type, $options ) {
+	private function can_ajax( $type, $options ) {
 		return $this->is_autocomplete( $options ) && ! $this->is_simple_tableless( $type, $options );
 	}
 


### PR DESCRIPTION
## Description

Introduce `PodsField_Pick::is_simple_tableless()` method to simplify the `can_ajax()` method to a single line.

Fixes #4993.

## How Has This Been Tested?
Manual inspection.

## Types of changes
Code refactoring.


## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.
