### PR TITLE
PHPCS: Contents of `@since` and `@deprecated` tags

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -257,7 +257,7 @@ class Pods implements Iterator {
 	 *
 	 * @var string
 	 *
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public $datatype;
 
@@ -266,7 +266,7 @@ class Pods implements Iterator {
 	 *
 	 * @var int
 	 *
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public $datatype_id;
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -391,7 +391,7 @@ class Pods implements Iterator {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function valid() {
 
@@ -502,7 +502,7 @@ class Pods implements Iterator {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function exists() {
 
@@ -521,7 +521,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array|bool An array of all rows returned from a find() call, or false if no items returned
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/data/
 	 */
 	public function data() {
@@ -587,7 +587,7 @@ class Pods implements Iterator {
 	 *
 	 * @return bool|mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function fields( $field = null, $option = null ) {
 
@@ -647,7 +647,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array|false
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function row() {
 
@@ -670,7 +670,7 @@ class Pods implements Iterator {
 	 *
 	 * @return string|null|false The output from the field, null if the field doesn't exist, false if no value returned
 	 *                           for tableless fields
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/display/
 	 */
 	public function display( $name, $single = null ) {
@@ -730,7 +730,7 @@ class Pods implements Iterator {
 	 *
 	 * @return string|null|false The output from the field, null if the field doesn't exist, false if no value returned
 	 *                           for tableless fields
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/display/
 	 */
 	public function raw( $name, $single = null ) {
@@ -771,7 +771,7 @@ class Pods implements Iterator {
 	 *
 	 * @return mixed|null Value returned depends on the field type, null if the field doesn't exist, false if no value
 	 *                    returned for tableless fields.
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/field/
 	 */
 	public function field( $name, $single = null, $raw = false ) {
@@ -2145,7 +2145,7 @@ class Pods implements Iterator {
 	 * Return the item ID
 	 *
 	 * @return int
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function id() {
 
@@ -2164,7 +2164,7 @@ class Pods implements Iterator {
 	 * @param array|object|null $params_override Override the find() parameters.
 	 *
 	 * @return int
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function prev_id( $id = null, $params_override = null ) {
 
@@ -2253,7 +2253,7 @@ class Pods implements Iterator {
 	 * @param array|object|null $params_override Override the find() parameters.
 	 *
 	 * @return int
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function next_id( $id = null, $params_override = null ) {
 
@@ -2321,7 +2321,7 @@ class Pods implements Iterator {
 	 * @param array|object|null $params_override Override the find() parameters.
 	 *
 	 * @return int
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function first_id( $params_override = null ) {
 
@@ -2366,7 +2366,7 @@ class Pods implements Iterator {
 	 * @param array|object|null $params_override Override the find() parameters.
 	 *
 	 * @return int
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function last_id( $params_override = null ) {
 
@@ -2436,7 +2436,7 @@ class Pods implements Iterator {
 	 * Return the item name
 	 *
 	 * @return string
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function index() {
 
@@ -2452,7 +2452,7 @@ class Pods implements Iterator {
 	 * @param string       $sql    (deprecated) For advanced use, a custom SQL query to run.
 	 *
 	 * @return \Pods The pod object
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/find/
 	 */
 	public function find( $params = null, $limit = 15, $where = null, $sql = null ) {
@@ -2698,7 +2698,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array An array of fields from the row
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/fetch/
 	 */
 	public function fetch( $id = null, $explicit_set = true ) {
@@ -2731,7 +2731,7 @@ class Pods implements Iterator {
 	 *
 	 * @return \Pods The pod object
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/reset/
 	 */
 	public function reset( $row = null ) {
@@ -2759,7 +2759,7 @@ class Pods implements Iterator {
 	 * @see   PodsData::total
 	 *
 	 * @return int Number of rows returned by find(), based on the 'limit' parameter set
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/total/
 	 */
 	public function total() {
@@ -2781,7 +2781,7 @@ class Pods implements Iterator {
 	 * @see   PodsData::total_found
 	 *
 	 * @return int Number of rows returned by find(), regardless of the 'limit' parameter
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/total-found/
 	 */
 	public function total_found() {
@@ -2855,7 +2855,7 @@ class Pods implements Iterator {
 	 * @param int|string $nth The $nth to match on the PodsData::row_number.
 	 *
 	 * @return bool Whether $nth matches
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function nth( $nth = null ) {
 
@@ -2870,7 +2870,7 @@ class Pods implements Iterator {
 	 * @see   PodsData::position
 	 *
 	 * @return int Current row number (+1)
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function position() {
 
@@ -2892,7 +2892,7 @@ class Pods implements Iterator {
 	 *
 	 * @return int The item ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/add/
 	 */
 	public function add( $data = null, $value = null ) {
@@ -2928,7 +2928,7 @@ class Pods implements Iterator {
 	 *
 	 * @return int The item ID
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function add_to( $field, $value, $id = null ) {
 
@@ -3185,7 +3185,7 @@ class Pods implements Iterator {
 	 *
 	 * @return int The item ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/save/
 	 */
 	public function save( $data = null, $value = null, $id = null, $params = null ) {
@@ -3262,7 +3262,7 @@ class Pods implements Iterator {
 	 *
 	 * @return bool Whether the item was successfully deleted
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/delete/
 	 */
 	public function delete( $id = null ) {
@@ -3317,7 +3317,7 @@ class Pods implements Iterator {
 	 *
 	 * @return int|bool ID of the new pod item
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/duplicate/
 	 */
 	public function duplicate( $id = null ) {
@@ -3351,7 +3351,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array IDs of imported items
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function import( $import_data, $numeric_mode = false, $format = null ) {
 
@@ -3369,7 +3369,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array|bool Data array of the exported pod item
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/export/
 	 */
 	public function export( $fields = null, $id = null, $format = null ) {
@@ -3422,7 +3422,7 @@ class Pods implements Iterator {
 	 *
 	 * @return array Data arrays of all exported pod items
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function export_data( $params = null ) {
 
@@ -3449,7 +3449,7 @@ class Pods implements Iterator {
 	 * @param array|object $params Associative array of parameters.
 	 *
 	 * @return string Pagination HTML
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/pagination/
 	 */
 	public function pagination( $params = null ) {
@@ -3528,7 +3528,7 @@ class Pods implements Iterator {
 	 *
 	 * @return string Filters HTML
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/filters/
 	 */
 	public function filters( $params = null ) {
@@ -3654,7 +3654,7 @@ class Pods implements Iterator {
 	 * @param string       $name   Field name.
 	 *
 	 * @return mixed Anything returned by the helper
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function helper( $helper, $value = null, $name = null ) {
 
@@ -3697,7 +3697,7 @@ class Pods implements Iterator {
 			 * @param array $disallowed List of callbacks not allowed.
 			 * @param array $params     Parameters used by Pods::helper() method.
 			 *
-			 * @since 2.7
+			 * @since 2.7.0
 			 */
 			$disallowed = apply_filters( 'pods_helper_disallowed_callbacks', $disallowed, $params );
 
@@ -3707,7 +3707,7 @@ class Pods implements Iterator {
 			 * @param array $allowed List of callbacks explicitly allowed.
 			 * @param array $params  Parameters used by Pods::helper() method.
 			 *
-			 * @since 2.7
+			 * @since 2.7.0
 			 */
 			$allowed = apply_filters( 'pods_helper_allowed_callbacks', $allowed, $params );
 
@@ -3747,7 +3747,7 @@ class Pods implements Iterator {
 	 *
 	 * @return mixed Template output
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/template/
 	 */
 	public function template( $template_name, $code = null, $deprecated = false ) {
@@ -3877,7 +3877,7 @@ class Pods implements Iterator {
 	 * @param string $thank_you (optional) Thank you URL to send to upon success.
 	 *
 	 * @return bool|mixed
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @link  https://pods.io/docs/form/
 	 */
 	public function form( $params = null, $label = null, $thank_you = null ) {
@@ -4003,7 +4003,7 @@ class Pods implements Iterator {
 				 *
 				 * @param string $message Success message.
 				 *
-				 * @since 2.7
+				 * @since 2.7.0
 				 */
 				$message = apply_filters( 'pods_pod_form_success_message', $message );
 
@@ -4106,7 +4106,7 @@ class Pods implements Iterator {
 	 *
 	 * @return string Code with Magic Tags evaluated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function do_magic_tags( $code ) {
 
@@ -4118,7 +4118,7 @@ class Pods implements Iterator {
 		 * @param string $code The content to evaluate.
 		 * @param Pods   $pods The Pods Object.
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$pre = apply_filters( 'pods_pre_do_magic_tags', null, $code, $this );
 		if ( null !== $pre ) {
@@ -4470,7 +4470,7 @@ class Pods implements Iterator {
 	 *
 	 * @return mixed Value filtered
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private function do_hook( $name ) {
 
@@ -4493,7 +4493,7 @@ class Pods implements Iterator {
 	 *
 	 * @return mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __get( $name ) {
 
@@ -4535,7 +4535,7 @@ class Pods implements Iterator {
 	 *
 	 * @return mixed|null
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __call( $name, $args ) {
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -42,7 +42,7 @@ class PodsAPI {
 
 	/**
 	 * @var
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public $format = null;
 
@@ -3240,7 +3240,7 @@ class PodsAPI {
 			$error_mode = $params->error_mode;
 		}
 
-		// @deprecated 2.0
+		// @deprecated 2.0.0
 		if ( isset( $params->datatype ) ) {
 			pods_deprecated( '$params->pod instead of $params->datatype', '2.0' );
 
@@ -3267,7 +3267,7 @@ class PodsAPI {
 			}
 		}
 
-		// @deprecated 2.0
+		// @deprecated 2.0.0
 		if ( isset( $params->tbl_row_id ) ) {
 			pods_deprecated( '$params->id instead of $params->tbl_row_id', '2.0' );
 
@@ -3276,7 +3276,7 @@ class PodsAPI {
 			unset( $params->tbl_row_id );
 		}
 
-		// @deprecated 2.0
+		// @deprecated 2.0.0
 		if ( isset( $params->columns ) ) {
 			pods_deprecated( '$params->data instead of $params->columns', '2.0' );
 
@@ -3513,9 +3513,9 @@ class PodsAPI {
 			}
 		}
 
-		$columns            =& $fields; // @deprecated 2.0
-		$active_columns     =& $fields_active; // @deprecated 2.0
-		$params->tbl_row_id =& $params->id; // @deprecated 2.0
+		$columns            =& $fields; // @deprecated 2.0.0
+		$active_columns     =& $fields_active; // @deprecated 2.0.0
+		$params->tbl_row_id =& $params->id; // @deprecated 2.0.0
 
 		$pre_save_helpers = $post_save_helpers = array();
 
@@ -4177,7 +4177,9 @@ class PodsAPI {
 	}
 
 	/**
-	 *Handle tracking changed fields or get them
+	 * Handle tracking changed fields or get them.
+	 *
+	 * @since 2.7.0
 	 *
 	 * @param string $pod
 	 * @param int    $id
@@ -4258,7 +4260,7 @@ class PodsAPI {
 	 *
 	 * @return array Array of fields and values that have changed
 	 *
-	 * @deprecated Use PodsAPI::handle_changed_fields
+	 * @deprecated 2.7.0 Use PodsAPI::handle_changed_fields
 	 */
 	public function get_changed_fields( $pieces ) {
 
@@ -4923,7 +4925,7 @@ class PodsAPI {
 
 		$params = (object) pods_sanitize( $params );
 
-		// @deprecated 2.0
+		// @deprecated 2.0.0
 		if ( isset( $params->datatype ) ) {
 			pods_deprecated( __( '$params->pod instead of $params->datatype', 'pods' ), '2.0' );
 
@@ -5435,7 +5437,7 @@ class PodsAPI {
 
 		$params = (object) pods_sanitize( $params );
 
-		// @deprecated 2.0
+		// @deprecated 2.0.0
 		if ( isset( $params->datatype_id ) || isset( $params->datatype ) || isset( $params->tbl_row_id ) ) {
 			if ( isset( $params->tbl_row_id ) ) {
 				pods_deprecated( __( '$params->id instead of $params->tbl_row_id', 'pods' ), '2.0' );
@@ -7510,7 +7512,7 @@ class PodsAPI {
 	 * @uses  PodsForm::field_loader
 	 *
 	 * @since 2.0.0
-	 * @deprecated
+	 * @deprecated 2.3.0
 	 */
 	public function get_field_types() {
 
@@ -8655,7 +8657,7 @@ class PodsAPI {
 	 * @return array|bool
 	 *
 	 * @since      1.9.0
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function export_package( $params ) {
 
@@ -8674,7 +8676,7 @@ class PodsAPI {
 	 * @return bool
 	 *
 	 * @since      1.9.8
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function replace_package( $data = false ) {
 
@@ -8690,7 +8692,7 @@ class PodsAPI {
 	 * @return bool
 	 *
 	 * @since      1.9.0
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function import_package( $data = false, $replace = false ) {
 
@@ -8710,7 +8712,7 @@ class PodsAPI {
 	 * @return array|bool
 	 *
 	 * @since      1.9.0
-	 * @deprecated 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function validate_package( $data = false, $output = false ) {
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -53,20 +53,20 @@ class PodsAPI {
 
 	/**
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 */
 	private $fields_cache = array();
 
 	/**
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 *
 	 */
 	private static $table_info_cache = array();
 
 	/**
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 *
 	 */
 	private static $related_item_cache = array();
@@ -143,7 +143,7 @@ class PodsAPI {
 	 *
 	 * @return bool|mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_wp_object( $object_type, $data, $meta = array(), $strict = false, $sanitized = false, $fields = array() ) {
 
@@ -183,7 +183,7 @@ class PodsAPI {
 	 *
 	 * @return bool|mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function delete_wp_object( $object_type, $id, $force_delete = true ) {
 
@@ -222,7 +222,7 @@ class PodsAPI {
 	 *
 	 * @return mixed|void
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_post( $post_data, $post_meta = null, $strict = false, $sanitized = false, $fields = array() ) {
 
@@ -283,7 +283,7 @@ class PodsAPI {
 	 *
 	 * @return int Id of the post with the meta
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_post_meta( $id, $post_meta = null, $strict = false, $fields = array() ) {
 
@@ -372,7 +372,7 @@ class PodsAPI {
 	 *
 	 * @return int Returns user id on success
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_user( $user_data, $user_meta = null, $strict = false, $sanitized = false, $fields = array() ) {
 
@@ -440,7 +440,7 @@ class PodsAPI {
 	 *
 	 * @return int User ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 */
 	public function save_user_meta( $id, $user_meta = null, $strict = false, $fields = array() ) {
@@ -522,7 +522,7 @@ class PodsAPI {
 	 *
 	 * @return int Comment ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_comment( $comment_data, $comment_meta = null, $strict = false, $sanitized = false, $fields = array() ) {
 
@@ -584,7 +584,7 @@ class PodsAPI {
 	 *
 	 * @return int Comment ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_comment_meta( $id, $comment_meta = null, $strict = false, $fields = array() ) {
 
@@ -665,7 +665,7 @@ class PodsAPI {
 	 *
 	 * @return int Term ID
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_term( $term_data, $term_meta, $strict = false, $sanitized = false, $fields = array() ) {
 
@@ -740,7 +740,7 @@ class PodsAPI {
 	 *
 	 * @return int Id of the term with the meta
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_term_meta( $id, $term_meta = null, $strict = false, $fields = array() ) {
 
@@ -831,7 +831,7 @@ class PodsAPI {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function save_setting( $setting, $option_data, $sanitized = false ) {
 
@@ -873,7 +873,7 @@ class PodsAPI {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function rename_wp_object_type( $object_type, $old_name, $new_name ) {
 
@@ -920,7 +920,7 @@ class PodsAPI {
 	 *
 	 * @return array Array of fields
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function get_wp_object_fields( $object = 'post_type', $pod = null, $refresh = false ) {
 
@@ -1466,7 +1466,7 @@ class PodsAPI {
 	 * @param array $params An associative array of parameters
 	 *
 	 * @return bool|int Pod ID
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function add_pod( $params ) {
 
@@ -3011,7 +3011,7 @@ class PodsAPI {
 	 *                                will sanitize them if false.
 	 *
 	 * @return int The Object ID
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_object( $params, $sanitized = false ) {
 
@@ -4154,7 +4154,7 @@ class PodsAPI {
 	 * @param array        $data   An associative array of pod ids and field names + values (arrays of field data)
 	 *
 	 * @return int The item ID
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function save_pod_items( $params, $data ) {
 
@@ -4421,7 +4421,7 @@ class PodsAPI {
 	 * @param bool  $strict (optional) Makes sure a pod exists, if it doesn't throws an error
 	 *
 	 * @return int New Pod ID
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function duplicate_pod( $params, $strict = false ) {
 
@@ -4736,7 +4736,7 @@ class PodsAPI {
 	 *
 	 * @return array Data array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	private function export_pod_item_level( $pod, $params ) {
 
@@ -5325,7 +5325,7 @@ class PodsAPI {
 	 * @uses  wp_delete_post
 	 *
 	 * @return bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function delete_object( $params ) {
 
@@ -5581,7 +5581,7 @@ class PodsAPI {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function delete_object_from_relationships( $id, $object, $name = null ) {
 
@@ -5690,7 +5690,7 @@ class PodsAPI {
 	 *
 	 * @return void
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function delete_relationships( $related_id, $id, $related_pod, $related_field ) {
 
@@ -6220,7 +6220,7 @@ class PodsAPI {
 	 *
 	 * @uses  PodsAPI::load_pod
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_pods( $params = null ) {
 
@@ -7010,7 +7010,7 @@ class PodsAPI {
 	 * @param bool         $strict
 	 *
 	 * @return array|bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_object( $params, $strict = false ) {
 
@@ -7081,7 +7081,7 @@ class PodsAPI {
 	 * @param array|object $params An associative array of parameters
 	 *
 	 * @return array
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_objects( $params ) {
 
@@ -7228,7 +7228,7 @@ class PodsAPI {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_templates( $params = null ) {
 
@@ -7286,7 +7286,7 @@ class PodsAPI {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_pages( $params = null ) {
 
@@ -7340,7 +7340,7 @@ class PodsAPI {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_helpers( $params = null ) {
 
@@ -7366,7 +7366,7 @@ class PodsAPI {
 	 *
 	 * @uses  pods()
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load_pod_item( $params ) {
 
@@ -7473,7 +7473,7 @@ class PodsAPI {
 	 *
 	 * @return string The field type
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function detect_pod_field_from_sql_data_type( $sql_field ) {
 
@@ -7509,7 +7509,7 @@ class PodsAPI {
 	 *
 	 * @uses  PodsForm::field_loader
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @deprecated
 	 */
 	public function get_field_types() {
@@ -7525,7 +7525,7 @@ class PodsAPI {
 	 *
 	 * @return array|bool|mixed|null
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private function get_field_definition( $type, $options = null ) {
 
@@ -7550,7 +7550,7 @@ class PodsAPI {
 	 *
 	 * @uses  PodsForm::validate
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function handle_field_validation( &$value, $field, $object_fields, $fields, $pod, $params ) {
 
@@ -7646,7 +7646,7 @@ class PodsAPI {
 	 *
 	 * @return int[]
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @uses  pods_query()
 	 */
@@ -7854,7 +7854,7 @@ class PodsAPI {
 	 *
 	 * @return array|bool
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 *
 	 * @uses  pods_query()
 	 */
@@ -8018,7 +8018,7 @@ class PodsAPI {
 	 *
 	 * @return array
 	 *
-	 * @since 2.5
+	 * @since 2.5.0
 	 */
 	public function get_table_info_load( $object_type, $object, $name = null, $pod = null ) {
 
@@ -8142,7 +8142,7 @@ class PodsAPI {
 	 *
 	 * @return array|bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function get_table_info( $object_type, $object, $name = null, $pod = null, $field = null ) {
 
@@ -8976,7 +8976,7 @@ class PodsAPI {
 	 *
 	 * @return void
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function cache_flush_pods( $pod = null ) {
 
@@ -9027,7 +9027,7 @@ class PodsAPI {
 	 *
 	 * @return mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function process_form( $params, $obj = null, $fields = null, $thank_you = null ) {
 
@@ -9116,7 +9116,7 @@ class PodsAPI {
 	/**
 	 * Handle filters / actions for the class
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private function do_hook() {
 
@@ -9132,7 +9132,7 @@ class PodsAPI {
 	/**
 	 * Handle variables that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __get( $name ) {
 
@@ -9159,7 +9159,7 @@ class PodsAPI {
 	/**
 	 * Handle methods that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __call( $name, $args ) {
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -32,7 +32,7 @@ class PodsAdmin {
 	 * @return \PodsAdmin
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 
@@ -64,7 +64,7 @@ class PodsAdmin {
 	/**
 	 * Init the admin area
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_init() {
 
@@ -107,7 +107,7 @@ class PodsAdmin {
 	/**
 	 * Attach requirements to admin header
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_head() {
 
@@ -181,7 +181,7 @@ class PodsAdmin {
 	/**
 	 * Build the admin menus
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_menu() {
 
@@ -2308,7 +2308,7 @@ class PodsAdmin {
 			/**
 			 * Modify Additional Field Options tab
 			 *
-			 * @since 2.7
+			 * @since 2.7.0
 			 *
 			 * @param array       $options Additional field type options,
 			 * @param string      $type    Field type,
@@ -3282,7 +3282,7 @@ class PodsAdmin {
 	 *
 	 * @return array
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function configuration( $pod = null, $full_field_info = false ) {
 

--- a/classes/PodsArray.php
+++ b/classes/PodsArray.php
@@ -19,7 +19,7 @@ class PodsArray implements ArrayAccess {
 	 * @return \PodsArray
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $container ) {
 
@@ -35,7 +35,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $value  Value to be set.
 	 *
 	 * @return mixed
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function offsetSet( $offset, $value ) {
 
@@ -54,7 +54,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $offset Used to get value of Array or Variable on Object.
 	 *
 	 * @return mixed|null
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function offsetGet( $offset ) {
 
@@ -75,7 +75,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $offset Used to get value of Array or Variable on Object.
 	 *
 	 * @return bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function offsetExists( $offset ) {
 
@@ -91,7 +91,7 @@ class PodsArray implements ArrayAccess {
 	 *
 	 * @param mixed $offset Used to unset index of Array or Variable on Object.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function offsetUnset( $offset ) {
 
@@ -112,7 +112,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed|null  $extra   Used in advanced types of variables.
 	 *
 	 * @return array|bool|int|mixed|null|number|object
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function validate( $offset, $default = null, $type = null, $extra = null ) {
 
@@ -189,7 +189,7 @@ class PodsArray implements ArrayAccess {
 	 *
 	 * @return array Array version of the object
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function dump() {
 
@@ -207,7 +207,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $value  Property value.
 	 *
 	 * @return mixed
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __set( $offset, $value ) {
 
@@ -220,7 +220,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $offset Property name.
 	 *
 	 * @return mixed|null
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __get( $offset ) {
 
@@ -233,7 +233,7 @@ class PodsArray implements ArrayAccess {
 	 * @param mixed $offset Property name.
 	 *
 	 * @return bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __isset( $offset ) {
 
@@ -245,7 +245,7 @@ class PodsArray implements ArrayAccess {
 	 *
 	 * @param mixed $offset Property name.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __unset( $offset ) {
 

--- a/classes/PodsComponent.php
+++ b/classes/PodsComponent.php
@@ -10,7 +10,7 @@ class PodsComponent {
 	/**
 	 * Setup initial component class.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 
@@ -33,7 +33,7 @@ class PodsComponent {
 	 *
 	 * @return array $options
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * public function options () {
 	 * $options = array(
 	 * 'option_name' => array(
@@ -82,7 +82,7 @@ class PodsComponent {
 	 *
 	 * @param array $options Component options.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function handler( $options ) {
 		// run code based on $options set
@@ -93,7 +93,7 @@ class PodsComponent {
 	 *
 	 * @param array $options Component options.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * public function admin ( $options ) {
 	 * // run code based on $options set
 	 * }

--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -18,7 +18,7 @@ class PodsComponents {
 	 * @var string
 	 *
 	 * @private
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private $components_dir = null;
 
@@ -27,7 +27,7 @@ class PodsComponents {
 	 *
 	 * @var array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public $components = array();
 
@@ -36,7 +36,7 @@ class PodsComponents {
 	 *
 	 * @var array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public $settings = array();
 
@@ -59,7 +59,7 @@ class PodsComponents {
 	/**
 	 * Setup actions and get options
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 
@@ -96,7 +96,7 @@ class PodsComponents {
 	 *
 	 * @param string $parent The parent slug.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @uses  add_submenu_page
 	 */
@@ -245,7 +245,7 @@ class PodsComponents {
 	/**
 	 * Load activated components and init component
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function load() {
 
@@ -325,7 +325,7 @@ class PodsComponents {
 	/**
 	 * Get list of components available
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function get_components() {
 
@@ -516,7 +516,7 @@ class PodsComponents {
 	 * @param string $component Component name.
 	 * @param array  $options   Component options.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function options( $component, $options ) {
 
@@ -534,7 +534,7 @@ class PodsComponents {
 	/**
 	 * Call component specific admin functions
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_handler() {
 
@@ -581,7 +581,7 @@ class PodsComponents {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function is_component_active( $component ) {
 
@@ -602,7 +602,7 @@ class PodsComponents {
 	 *
 	 * @return boolean Whether the component was activated.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function activate_component( $component ) {
 
@@ -634,7 +634,7 @@ class PodsComponents {
 	 *
 	 * @param string $component The component name to deactivate.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function deactivate_component( $component ) {
 
@@ -656,7 +656,7 @@ class PodsComponents {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function toggle( $component, $toggle_mode = false ) {
 
@@ -721,7 +721,7 @@ class PodsComponents {
 	/**
 	 * Handle admin ajax
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_ajax() {
 

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -267,7 +267,7 @@ class PodsData {
 	 * @return \PodsData
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $pod = null, $id = 0, $strict = true ) {
 
@@ -447,7 +447,7 @@ class PodsData {
 	 *
 	 * @uses  wpdb::insert
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function insert( $table, $data, $format = null ) {
 
@@ -503,7 +503,7 @@ class PodsData {
 	 *
 	 * @uses  wpdb::prepare
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function insert_on_duplicate( $table, $data, $formats = array() ) {
 
@@ -547,7 +547,7 @@ class PodsData {
 	 * @param array  $where_format (optional) An array of formats to be mapped to each of the values in $where.
 	 *
 	 * @return bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function update( $table, $data, $where, $format = null, $where_format = null ) {
 
@@ -624,7 +624,7 @@ class PodsData {
 	 * @uses  PodsData::query
 	 * @uses  PodsData::prepare
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function delete( $table, $where, $where_format = null ) {
 
@@ -672,7 +672,7 @@ class PodsData {
 	 * @param array $params
 	 *
 	 * @return array|bool|mixed
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function select( $params ) {
 
@@ -809,7 +809,7 @@ class PodsData {
 	 * @param array $params
 	 *
 	 * @return bool|mixed|string
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function build( $params ) {
 
@@ -1661,7 +1661,7 @@ class PodsData {
 	 * Fetch the total row count returned
 	 *
 	 * @return int Number of rows returned by select()
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function total() {
 
@@ -1672,7 +1672,7 @@ class PodsData {
 	 * Fetch the total row count total
 	 *
 	 * @return int Number of rows found by select()
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function total_found() {
 
@@ -1702,7 +1702,7 @@ class PodsData {
 	 * @param int|string $nth The $nth to match on the PodsData::row_number.
 	 *
 	 * @return bool Whether $nth matches
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function nth( $nth ) {
 
@@ -1750,7 +1750,7 @@ class PodsData {
 	 * Fetch the current position in the loop (starting at 1)
 	 *
 	 * @return int Current row number (+1)
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function position() {
 
@@ -1768,7 +1768,7 @@ class PodsData {
 	 *
 	 * @uses  PodsData::query
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function table_create( $table, $fields, $if_not_exists = false ) {
 
@@ -1806,7 +1806,7 @@ class PodsData {
 	 *
 	 * @uses  PodsData::query
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function table_alter( $table, $changes ) {
 
@@ -1829,7 +1829,7 @@ class PodsData {
 	 *
 	 * @uses  PodsData::query
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function table_truncate( $table ) {
 
@@ -1854,7 +1854,7 @@ class PodsData {
 	 *
 	 * @uses  PodsData::query
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function table_drop( $table ) {
 
@@ -1880,7 +1880,7 @@ class PodsData {
 	 *
 	 * @uses  PodsData::update
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function reorder( $table, $weight_field, $id_field, $ids ) {
 
@@ -1919,7 +1919,7 @@ class PodsData {
 	 *
 	 * @return mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function fetch( $row = null, $explicit_set = true ) {
 
@@ -2218,7 +2218,7 @@ class PodsData {
 	 *
 	 * @return mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function reset( $row = null ) {
 
@@ -2251,7 +2251,7 @@ class PodsData {
 	 *
 	 * @return array|bool|mixed|null|void Result of the query
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function query( $sql, $error = 'Database Error', $results_error = null, $no_results_error = null ) {
 
@@ -2355,7 +2355,7 @@ class PodsData {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function get_tables( $wp_core = true, $pods_tables = true ) {
 
@@ -2400,7 +2400,7 @@ class PodsData {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function get_table_columns( $table ) {
 
@@ -2434,7 +2434,7 @@ class PodsData {
 	 *
 	 * @return array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function get_column_data( $column_name, $table ) {
 
@@ -2459,7 +2459,7 @@ class PodsData {
 	 *
 	 * @return bool|null|string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function prepare( $sql, $data ) {
 
@@ -2482,7 +2482,7 @@ class PodsData {
 	 * @return string|null Query string for WHERE/HAVING
 	 *
 	 * @static
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function query_fields( $fields, $pod = null, &$params = null ) {
 
@@ -2603,7 +2603,7 @@ class PodsData {
 	 *
 	 * @see   PodsData::query_fields
 	 * @static
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function query_field( $field, $q, $pod = null, &$params = null ) {
 
@@ -2966,7 +2966,7 @@ class PodsData {
 	 *
 	 * @param object $params (optional) Parameters from build().
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function traverse_build( $fields = null, $params = null ) {
 
@@ -3002,7 +3002,7 @@ class PodsData {
 	 *
 	 * @return array Array of table joins
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function traverse_recurse( $traverse_recurse ) {
 
@@ -3475,7 +3475,7 @@ class PodsData {
 	/**
 	 * Handle filters / actions for the class
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private static function do_hook() {
 
@@ -3509,7 +3509,7 @@ class PodsData {
 		 * @param string   $sql       SQL Query string.
 		 * @param PodsData $pods_data PodsData object.
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$sql = apply_filters( 'pods_data_get_sql', $sql, $this );
 

--- a/classes/PodsField.php
+++ b/classes/PodsField.php
@@ -11,7 +11,7 @@ class PodsField {
 	 * Whether this field is running under 1.x deprecated forms
 	 *
 	 * @var bool
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $deprecated = false;
 
@@ -19,7 +19,7 @@ class PodsField {
 	 * Field Type Identifier
 	 *
 	 * @var string
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $type = 'text';
 
@@ -27,7 +27,7 @@ class PodsField {
 	 * Field Type Label
 	 *
 	 * @var string
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $label = 'Unknown';
 
@@ -35,7 +35,7 @@ class PodsField {
 	 * Field Type Preparation
 	 *
 	 * @var string
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $prepare = '%s';
 
@@ -43,7 +43,7 @@ class PodsField {
 	 * Pod Types supported on (true for all, false for none, or give array of specific types supported)
 	 *
 	 * @var array|bool
-	 * @since 2.1
+	 * @since 2.1.0
 	 */
 	public static $pod_types = true;
 
@@ -51,14 +51,14 @@ class PodsField {
 	 * API caching for fields that need it during validate/save
 	 *
 	 * @var \PodsAPI
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	private static $api;
 
 	/**
 	 * Initial setup of class object.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 
@@ -79,7 +79,7 @@ class PodsField {
 	/**
 	 * Add admin_init actions.
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function admin_init() {
 
@@ -91,7 +91,7 @@ class PodsField {
 	 *
 	 * @return array $options
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @see   PodsField::ui_options
 	 */
 	public function options() {
@@ -145,7 +145,7 @@ class PodsField {
 	 *
 	 * @return array $options
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @see   PodsField::options
 	 */
 	public function ui_options() {
@@ -161,7 +161,7 @@ class PodsField {
 	 *
 	 * @return string|false
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function schema( $options = null ) {
 
@@ -178,7 +178,7 @@ class PodsField {
 	 *
 	 * @return string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function prepare( $options = null ) {
 
@@ -195,7 +195,7 @@ class PodsField {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function is_empty( $value ) {
 
@@ -221,7 +221,7 @@ class PodsField {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function values_are_empty( $values, $strict = true ) {
 
@@ -260,7 +260,7 @@ class PodsField {
 	 *
 	 * @return mixed|null|string
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function value( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
@@ -279,7 +279,7 @@ class PodsField {
 	 *
 	 * @return mixed|null|string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
@@ -297,7 +297,7 @@ class PodsField {
 	 * @param int|string|null $id      Current item ID.
 	 *
 	 * @return string|null
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function format( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
@@ -314,7 +314,7 @@ class PodsField {
 	 * @param array|null      $pod     Pod information.
 	 * @param int|string|null $id      Current item ID.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function input( $name, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -416,7 +416,7 @@ class PodsField {
 		/**
 		 * Filter Pods DFV field data to further customize functionality.
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 *
 		 * @param array  $data       DFV field data
 		 * @param object $args       {
@@ -559,7 +559,7 @@ class PodsField {
 	 *
 	 * @return array Array of possible field data.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function data( $name, $value = null, $options = null, $pod = null, $id = null, $in_form = true ) {
 
@@ -578,7 +578,7 @@ class PodsField {
 	 *
 	 * @return string|false
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function regex( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
@@ -599,7 +599,7 @@ class PodsField {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
 
@@ -620,7 +620,7 @@ class PodsField {
 	 *
 	 * @return mixed
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
@@ -641,7 +641,7 @@ class PodsField {
 	 *
 	 * @return bool|null Whether the value was saved, returning null means no save needed to occur
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
@@ -660,7 +660,7 @@ class PodsField {
 	 * @param array|null      $pod     Pod information.
 	 * @param array|null      $params  Additional parameters.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function post_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
@@ -675,7 +675,7 @@ class PodsField {
 	 * @param array|null      $options Field options.
 	 * @param array|null      $pod     Pod information.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function pre_delete( $id = null, $name = null, $options = null, $pod = null ) {
 
@@ -690,7 +690,7 @@ class PodsField {
 	 * @param array|null      $options Field options.
 	 * @param array|null      $pod     Pod information.
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function delete( $id = null, $name = null, $options = null, $pod = null ) {
 
@@ -705,7 +705,7 @@ class PodsField {
 	 * @param array|null      $options Field options.
 	 * @param array|null      $pod     Pod information.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function post_delete( $id = null, $name = null, $options = null, $pod = null ) {
 
@@ -724,7 +724,7 @@ class PodsField {
 	 *
 	 * @return string Value to be shown in the UI
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function ui( $id, $value, $name = null, $options = null, $fields = null, $pod = null ) {
 

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -62,7 +62,7 @@ class PodsForm {
 	 * @return \PodsForm
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	private function __construct() {
 
@@ -72,7 +72,7 @@ class PodsForm {
 	/**
 	 * Prevent clones
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	private function __clone() {
 		// Hulk smash
@@ -81,7 +81,7 @@ class PodsForm {
 	/**
 	 * Output a field's label
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 
 	/**
@@ -94,7 +94,7 @@ class PodsForm {
 	 *
 	 * @return string Label HTML
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function label( $name, $label, $help = '', $options = null ) {
 
@@ -141,7 +141,7 @@ class PodsForm {
 	 *
 	 * @return string Comment HTML
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function comment( $name, $message = null, $options = null ) {
 
@@ -183,7 +183,7 @@ class PodsForm {
 	 *
 	 * @return string Field HTML
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function field( $name, $value, $type = 'text', $options = null, $pod = null, $id = null ) {
 
@@ -295,7 +295,7 @@ class PodsForm {
 	 *
 	 * Used for field names and other places where only [a-z0-9_] is accepted
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $name
 	 * @param null $value
@@ -359,7 +359,7 @@ class PodsForm {
 	 *                                       string such as 'tabindex="1"', though the array format is typically
 	 *                                       cleaner.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 * @return string
 	 */
 	public static function submit_button( $text = null, $type = 'primary large', $name = 'submit', $wrap = true, $other_attributes = null ) {
@@ -441,7 +441,7 @@ class PodsForm {
 	 *
 	 * @return string Row HTML
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function row( $name, $value, $type = 'text', $options = null, $pod = null, $id = null ) {
 
@@ -459,7 +459,7 @@ class PodsForm {
 	/**
 	 * Output a field's attributes
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $attributes
 	 * @param null       $name
@@ -482,7 +482,7 @@ class PodsForm {
 	/**
 	 * Output a field's data (for use with jQuery)
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $data
 	 * @param null $name
@@ -511,7 +511,7 @@ class PodsForm {
 	/**
 	 * Merge attributes and handle classes
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param        $attributes
 	 * @param null       $name
@@ -606,7 +606,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function options( $type, $options ) {
 
@@ -670,7 +670,7 @@ class PodsForm {
 	 * @param null $options
 	 *
 	 * @return array|null
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function options_setup( $type = null, $options = null ) {
 
@@ -731,7 +731,7 @@ class PodsForm {
 	 *
 	 * @return array|null
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function ui_options( $type ) {
 
@@ -781,7 +781,7 @@ class PodsForm {
 	 * @return array|null
 	 *
 	 * @static
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function fields_setup( $fields = null, $core_defaults = null, $single = false ) {
 
@@ -836,7 +836,7 @@ class PodsForm {
 	 *
 	 * @return array|null
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function field_setup( $field = null, $core_defaults = null, $type = null ) {
 
@@ -910,7 +910,7 @@ class PodsForm {
 	 *
 	 * @return array
 	 * @static
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function dependencies( $options, $prefix = '' ) {
 
@@ -992,7 +992,7 @@ class PodsForm {
 	 *
 	 * @return array|mixed|null|object
 	 * @internal param array $fields
-	 * @since    2.3
+	 * @since 2.3.0
 	 */
 	public static function value( $type, $value = null, $name = null, $options = null, $pod = null, $id = null, $traverse = null ) {
 
@@ -1042,7 +1042,7 @@ class PodsForm {
 	 *
 	 * @return array|mixed|null|void
 	 * @internal param array $fields
-	 * @since    2.0
+	 * @since 2.0.0
 	 */
 	public static function display( $type, $value = null, $name = null, $options = null, $pod = null, $id = null, $traverse = null ) {
 
@@ -1103,7 +1103,7 @@ class PodsForm {
 	 * @param $options
 	 *
 	 * @return mixed|void
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function regex( $type, $options ) {
 
@@ -1129,7 +1129,7 @@ class PodsForm {
 	 * @param $options
 	 *
 	 * @return mixed|void
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function prepare( $type, $options ) {
 
@@ -1160,7 +1160,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @return bool|mixed|void
 	 */
 	public static function validate( $type, $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
@@ -1192,7 +1192,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @return mixed
 	 */
 	public static function pre_save( $type, $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
@@ -1220,7 +1220,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 * @return null
 	 */
 	public static function save( $type, $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
@@ -1247,7 +1247,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 * @return null
 	 */
 	public static function delete( $type, $id = null, $name = null, $options = null, $pod = null ) {
@@ -1276,7 +1276,7 @@ class PodsForm {
 	 *
 	 * @static
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 * @return bool
 	 */
 	public static function permission( $type, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
@@ -1291,7 +1291,7 @@ class PodsForm {
 	/**
 	 * Parse the default the value
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param        $value
 	 * @param string $type
@@ -1336,7 +1336,7 @@ class PodsForm {
 	/**
 	 * Clean a value for use in class / id
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $input
 	 * @param bool  $noarray
@@ -1379,7 +1379,7 @@ class PodsForm {
 	/**
 	 * Run admin_init methods for each field type
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function admin_init() {
 
@@ -1415,7 +1415,7 @@ class PodsForm {
 	 * @return string
 	 * @access public
 	 * @static
-	 * @since  2.0
+	 * @since 2.0.0
 	 */
 	public static function field_loader( $field_type, $file = '' ) {
 
@@ -1487,7 +1487,7 @@ class PodsForm {
 	 *
 	 * @access   public
 	 * @static
-	 * @since    2.0
+	 * @since 2.0.0
 	 */
 	public static function field_method() {
 
@@ -1517,7 +1517,7 @@ class PodsForm {
 	 *
 	 * @return array Field Type data
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function register_field_type( $type, $file = null ) {
 
@@ -1544,7 +1544,7 @@ class PodsForm {
 	 *
 	 * @return array Registered Field Types data
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function field_types() {
 
@@ -1617,7 +1617,7 @@ class PodsForm {
 	 *
 	 * @return array Tableless field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function tableless_field_types() {
 
@@ -1643,7 +1643,7 @@ class PodsForm {
 	 *
 	 * @return array File field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function file_field_types() {
 
@@ -1663,7 +1663,7 @@ class PodsForm {
 	 *
 	 * @return array Repeatable field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function repeatable_field_types() {
 
@@ -1697,7 +1697,7 @@ class PodsForm {
 	 *
 	 * @return array Number field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function number_field_types() {
 
@@ -1717,7 +1717,7 @@ class PodsForm {
 	 *
 	 * @return array Date field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function date_field_types() {
 
@@ -1737,7 +1737,7 @@ class PodsForm {
 	 *
 	 * @return array Text field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function text_field_types() {
 
@@ -1757,7 +1757,7 @@ class PodsForm {
 	 *
 	 * @return array Text field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function block_field_types() {
 
@@ -1785,7 +1785,7 @@ class PodsForm {
 	 *
 	 * @return array Text field types
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static function simple_tableless_objects() {
 

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -228,7 +228,7 @@ class PodsForm {
 		 *
 		 * They will be entirely removed in Pods 3.0.
 		 *
-		 * @deprecated 2.7
+		 * @deprecated 2.7.0
 		 */
 		if ( 0 < strlen( pods_v( 'input_helper', $options ) ) ) {
 			$helper = pods_api()->load_helper( array( 'name' => $options['input_helper'] ) );
@@ -244,7 +244,7 @@ class PodsForm {
 		 *
 		 * It will be replaced in Pods 3.0 with better documentation.
 		 *
-		 * @deprecated 2.7
+		 * @deprecated 2.7.0
 		 */
 		if ( true === apply_filters( 'pods_form_ui_field_' . $type . '_override', false, $name, $value, $options, $pod, $id ) ) {
 			/**
@@ -252,7 +252,7 @@ class PodsForm {
 			 *
 			 * It will be replaced in Pods 3.0 with better documentation.
 			 *
-			 * @deprecated 2.7
+			 * @deprecated 2.7.0
 			 */
 			do_action( 'pods_form_ui_field_' . $type, $name, $value, $options, $pod, $id );
 		} elseif ( ! empty( $helper ) && 0 < strlen( pods_v( 'code', $helper ) ) && false === strpos( $helper['code'], '$this->' ) && ( ! defined( 'PODS_DISABLE_EVAL' ) || ! PODS_DISABLE_EVAL ) ) {
@@ -261,7 +261,7 @@ class PodsForm {
 			 *
 			 * They will be entirely removed in Pods 3.0.
 			 *
-			 * @deprecated 2.7
+			 * @deprecated 2.7.0
 			 */
 			eval( '?>' . $helper['code'] );
 		} elseif ( method_exists( get_class(), 'field_' . $type ) ) {
@@ -275,7 +275,7 @@ class PodsForm {
 			 *
 			 * It will be replaced in Pods 3.0 with better documentation.
 			 *
-			 * @deprecated 2.7
+			 * @deprecated 2.7.0
 			 */
 			do_action( 'pods_form_ui_field_' . $type, $name, $value, $options, $pod, $id );
 		}//end if

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -2,7 +2,7 @@
 
 /**
  * @package Pods
- * @since   2.7
+ * @since 2.7.0
  */
 final class PodsI18n {
 
@@ -29,7 +29,7 @@ final class PodsI18n {
 	/**
 	 * Singleton handling for a basic pods_i18n() request
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private function __construct() {
 
@@ -49,7 +49,7 @@ final class PodsI18n {
 	 *
 	 * @return \PodsI18n
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public static function get_instance() {
 
@@ -62,7 +62,7 @@ final class PodsI18n {
 	}
 
 	/**
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function enqueue_scripts() {
 
@@ -78,7 +78,7 @@ final class PodsI18n {
 	 *     * Build localizations strings from the defaults and those provided via filter
 	 *     * Provide a global JavaScript object with the assembled localization strings via `wp_localize_script`
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private static function localize_assets() {
 
@@ -87,7 +87,7 @@ final class PodsI18n {
 		 * Setting the key of your string to the original (non translated) value is mandatory
 		 * Note: Existing keys in this class will overwrite the ones of this filter!
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 * @see   default_strings()
 		 *
 		 * @param array
@@ -116,7 +116,7 @@ final class PodsI18n {
 	 * @param string $string_key
 	 * @param string $translation
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private static function register( $string_key, $translation ) {
 
@@ -140,7 +140,7 @@ final class PodsI18n {
 	 *
 	 * @return array Key/value pairs with label/translation
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private static function default_strings() {
 
@@ -205,7 +205,7 @@ final class PodsI18n {
 	/**
 	 * Get current locale information from Multilingual plugins
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 *
 	 * @param array $args    (optional) {
 	 *
@@ -455,7 +455,7 @@ final class PodsI18n {
 	/**
 	 * Add Pods templates to possible i18n enabled post-types (polylang settings).
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  array $post_types
 	 * @param  bool  $is_settings

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -104,7 +104,7 @@ class PodsMeta {
 	/**
 	 * @return \PodsMeta
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function __construct() {
 
@@ -662,7 +662,7 @@ class PodsMeta {
 	 * @param string       $priority (optional) The priority within the context where the boxes should show ('high',
 	 *                               'core', 'default' or 'low').
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @return mixed|void
 	 */

--- a/classes/PodsMigrate.php
+++ b/classes/PodsMigrate.php
@@ -65,7 +65,7 @@ class PodsMigrate {
 	 * @return \PodsMigrate
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $type = null, $delimiter = null, $data = null ) {
 

--- a/classes/PodsRESTHandlers.php
+++ b/classes/PodsRESTHandlers.php
@@ -113,7 +113,7 @@ class PodsRESTHandlers {
 				/**
 				 * What output type to use for a related field REST response.
 				 *
-				 * @since 2.7
+				 * @since 2.7.0
 				 *
 				 * @param string                 $output_type The pick response output type.
 				 * @param string                 $field_name  The name of the field

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -442,7 +442,7 @@ class PodsUI {
 	 * @return \PodsUI
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $options, $deprecated = false ) {
 
@@ -1463,18 +1463,18 @@ class PodsUI {
 
 		$class = 'updated';
 		$hook  = 'message';
-		
+
 		if ( $error ) {
 			$class = 'error';
 			$hook  = 'error';
 		}
-		
+
 		$msg = $this->do_hook( $hook, $msg );
-		
+
 		if ( empty( $msg ) ) {
 			return;
 		}
-		?> 
+		?>
 		<div id="message" class="<?php echo esc_attr( $class ); ?> fade">
 			<p><?php echo $msg; ?></p>
 		</div>

--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -28,7 +28,7 @@ class PodsView {
 	 *
 	 * @return bool|mixed|null|string|void
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function view( $view, $data = null, $expires = false, $cache_mode = 'cache' ) {
 
@@ -160,7 +160,7 @@ class PodsView {
 	 *
 	 * @return bool|mixed|null|void
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function get( $key, $cache_mode = 'cache', $group = '', $callback = null ) {
 
@@ -296,7 +296,7 @@ class PodsView {
 	 *
 	 * @return bool|mixed|null|string|void
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function set( $key, $value, $expires = 0, $cache_mode = null, $group = '' ) {
 
@@ -384,7 +384,7 @@ class PodsView {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function clear( $key = true, $cache_mode = null, $group = '' ) {
 
@@ -606,7 +606,7 @@ class PodsView {
 	 *
 	 * @return bool|int
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 * @static
 	 */
 	public static function expires( $expires, $cache_mode = 'cache' ) {

--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -30,7 +30,7 @@ class PodsField_Currency extends PodsField_Number {
 	 * Currency Formats
 	 *
 	 * @var array
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $currencies = array();
 
@@ -621,7 +621,7 @@ class PodsField_Currency extends PodsField_Number {
 	 * Get the max allowed decimals.
 	 * Overwrites the default value of Number field. 2 decimals instead of 0.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 *
 	 * @param array $options Field options.
 	 *

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -29,7 +29,7 @@ class PodsField_DateTime extends PodsField {
 	 * Storage format.
 	 *
 	 * @var string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public static $storage_format = 'Y-m-d H:i:s';
 
@@ -37,7 +37,7 @@ class PodsField_DateTime extends PodsField {
 	 * The default empty value (database)
 	 *
 	 * @var string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public static $empty_value = '0000-00-00 00:00:00';
 
@@ -385,7 +385,7 @@ class PodsField_DateTime extends PodsField {
 	 * @param bool   $js      Return formatted from jQuery UI format? (only for custom formats).
 	 *
 	 * @return string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function format_value_display( $value, $options, $js = false ) {
 
@@ -423,7 +423,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Build date and/or time format string based on options
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  array $options Field options.
 	 * @param  bool  $js      Whether to return format for jQuery UI.
@@ -446,7 +446,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Build date format string based on options
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  array $options Field options.
 	 * @param  bool  $js      Whether to return format for jQuery UI.
@@ -485,7 +485,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Build time format string based on options
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  array $options Field options.
 	 * @param  bool  $js      Whether to return format for jQuery UI.
@@ -536,7 +536,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Get the date formats.
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  bool $js Whether to return format for jQuery UI.
 	 *
@@ -576,7 +576,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Get the time formats.
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  bool $js Whether to return format for jQuery UI.
 	 *
@@ -612,7 +612,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Get the time formats.
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  bool $js Whether to return format for jQuery UI.
 	 *
@@ -742,7 +742,7 @@ class PodsField_DateTime extends PodsField {
 	 * @link   https://api.jqueryui.com/datepicker/
 	 * @link   http://trentrichardson.com/examples/timepicker/
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  string $source_format Source format string.
 	 * @param  array  $args          Format arguments.
@@ -863,7 +863,7 @@ class PodsField_DateTime extends PodsField {
 	/**
 	 * Enqueue the i18n files for jquery date/timepicker
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 */
 	public function enqueue_jquery_ui_i18n() {
 

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -791,7 +791,7 @@ class PodsField_File extends PodsField {
 	 * @return string
 	 * @since 2.0.0
 	 *
-	 * @deprecated 2.7
+	 * @deprecated 2.7.0
 	 */
 	public function markup( $attributes, $limit = 1, $editable = true, $id = null, $icon = null, $name = null, $linked = false, $link = null ) {
 

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -669,7 +669,7 @@ class PodsField_File extends PodsField {
 	 * @param string $image_size Image size.
 	 *
 	 * @return string
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function images( $id, $value, $name = null, $options = null, $pod = null, $image_size = null ) {
 
@@ -698,7 +698,7 @@ class PodsField_File extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_image_sizes( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -717,7 +717,7 @@ class PodsField_File extends PodsField {
 	/**
 	 * Create a WP Gallery from the passed values (need to be attachments)
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 *
 	 * @param  string|array $value   The value(s).
 	 * @param  array        $options The field options.
@@ -789,7 +789,7 @@ class PodsField_File extends PodsField {
 	 * @param null|string     $link       Link URL.
 	 *
 	 * @return string
-	 * @since      2.0
+	 * @since 2.0.0
 	 *
 	 * @deprecated 2.7
 	 */
@@ -872,7 +872,7 @@ class PodsField_File extends PodsField {
 	/**
 	 * Handle AJAX plupload calls.
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function admin_ajax_upload() {
 

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -178,7 +178,7 @@ class PodsField_Link extends PodsField_Website {
 	 *
 	 * @return mixed|null|string
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function display_list( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -326,7 +326,7 @@ class PodsField_Number extends PodsField {
 	/**
 	 * Get the formatting arguments for numbers.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 *
 	 * @param array $options Field options.
 	 *
@@ -375,7 +375,7 @@ class PodsField_Number extends PodsField {
 	/**
 	 * Get the max allowed decimals.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 *
 	 * @param array $options Field options.
 	 *

--- a/classes/fields/oembed.php
+++ b/classes/fields/oembed.php
@@ -29,7 +29,7 @@ class PodsField_OEmbed extends PodsField {
 	 * Available oEmbed providers
 	 *
 	 * @var array
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private $providers = array();
 
@@ -37,7 +37,7 @@ class PodsField_OEmbed extends PodsField {
 	 * Current embed width
 	 *
 	 * @var int
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private $width = 0;
 
@@ -45,7 +45,7 @@ class PodsField_OEmbed extends PodsField {
 	 * Current embed height
 	 *
 	 * @var int
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	private $height = 0;
 
@@ -287,7 +287,7 @@ class PodsField_OEmbed extends PodsField {
 	 *
 	 * @return string Potentially modified $content.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function autoembed( $content ) {
 
@@ -314,7 +314,7 @@ class PodsField_OEmbed extends PodsField {
 	 *
 	 * @return string The embed shortcode
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function autoembed_callback( $match ) {
 
@@ -336,7 +336,7 @@ class PodsField_OEmbed extends PodsField {
 	 * @type string Hostname for this provider
 	 * }
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function get_providers() {
 
@@ -388,7 +388,7 @@ class PodsField_OEmbed extends PodsField {
 	 * This function is ripped from WP since Pods has support from 3.8 and in the WP core this function is 4.0+
 	 * We've stripped the autodiscover part from this function to keep it basic
 	 *
-	 * @since  2.7
+	 * @since 2.7.0
 	 * @access public
 	 *
 	 * @see    WP_oEmbed::get_provider()
@@ -430,7 +430,7 @@ class PodsField_OEmbed extends PodsField {
 	/**
 	 * Validate a value with the enabled oEmbed providers (if required).
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 *
 	 * @param string $value   Field value.
 	 * @param array  $options Field options.
@@ -477,7 +477,7 @@ class PodsField_OEmbed extends PodsField {
 	/**
 	 * Handle update preview AJAX.
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function admin_ajax_oembed_update_preview() {
 

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -29,7 +29,7 @@ class PodsField_Pick extends PodsField {
 	 * Available Related Objects.
 	 *
 	 * @var array
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static $related_objects = array();
 
@@ -37,7 +37,7 @@ class PodsField_Pick extends PodsField {
 	 * Custom Related Objects
 	 *
 	 * @var array
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static $custom_related_objects = array();
 
@@ -45,7 +45,7 @@ class PodsField_Pick extends PodsField {
 	 * Data used during validate / save to avoid extra queries.
 	 *
 	 * @var array
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static $related_data = array();
 
@@ -53,7 +53,7 @@ class PodsField_Pick extends PodsField {
 	 * Data used during input method (mainly for autocomplete).
 	 *
 	 * @var array
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static $field_data = array();
 
@@ -61,7 +61,7 @@ class PodsField_Pick extends PodsField {
 	 * Saved array of simple relationship names.
 	 *
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 */
 	private static $names_simple = null;
 
@@ -69,7 +69,7 @@ class PodsField_Pick extends PodsField {
 	 * Saved array of relationship names
 	 *
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 */
 	private static $names_related = null;
 
@@ -77,7 +77,7 @@ class PodsField_Pick extends PodsField {
 	 * Saved array of bidirectional relationship names
 	 *
 	 * @var array
-	 * @since 2.5
+	 * @since 2.5.0
 	 */
 	private static $names_bidirectional = null;
 
@@ -329,7 +329,7 @@ class PodsField_Pick extends PodsField {
 	 * @param array  $options Object options.
 	 *
 	 * @return array|boolean Object array or false if unsuccessful
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function register_related_object( $name, $label, $options = null ) {
 
@@ -360,7 +360,7 @@ class PodsField_Pick extends PodsField {
 	 * @param boolean $force Whether to force refresh of related objects.
 	 *
 	 * @return bool True when data has been loaded
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function setup_related_objects( $force = false ) {
 
@@ -604,7 +604,7 @@ class PodsField_Pick extends PodsField {
 	 * @param boolean $force Whether to force refresh of related objects.
 	 *
 	 * @return array Field selection array
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function related_objects( $force = false ) {
 
@@ -630,7 +630,7 @@ class PodsField_Pick extends PodsField {
 	 * Return available simple object names
 	 *
 	 * @return array Simple object names
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function simple_objects() {
 
@@ -851,7 +851,7 @@ class PodsField_Pick extends PodsField {
 		 *
 		 * @param array|null $select2_overrides Override options for Select2/SelectWoo.
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$options['select2_overrides'] = apply_filters( 'pods_pick_select2_overrides', null );
 
@@ -931,7 +931,7 @@ class PodsField_Pick extends PodsField {
 		 * @param array $config
 		 * @param array $args
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$show_on_front = apply_filters( 'pods_ui_dfv_pick_modals_show_on_front', false, $config, $args );
 
@@ -942,7 +942,7 @@ class PodsField_Pick extends PodsField {
 		 * @param array $config
 		 * @param array $args
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$allow_nested_modals = apply_filters( 'pods_ui_dfv_pick_modals_allow_nested', false, $config, $args );
 
@@ -1032,7 +1032,7 @@ class PodsField_Pick extends PodsField {
 		 * @param array $config
 		 * @param array $args
 		 *
-		 * @since 2.7
+		 * @since 2.7.0
 		 */
 		$iframe = apply_filters( 'pods_ui_dfv_pick_modals_iframe', $iframe, $config, $args );
 
@@ -1540,7 +1540,7 @@ class PodsField_Pick extends PodsField {
 	 * @param array|null  $options Field options.
 	 * @param array|null  $pod     Pod options.
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function delete( $id = null, $name = null, $options = null, $pod = null ) {
 
@@ -1768,7 +1768,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return string
 	 *
-	 * @since 2.2
+	 * @since 2.2.0
 	 */
 	public function value_to_label( $name, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -2372,7 +2372,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return bool
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function is_autocomplete( $options ) {
 
@@ -2416,7 +2416,7 @@ class PodsField_Pick extends PodsField {
 	/**
 	 * Handle autocomplete AJAX.
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function admin_ajax_relationship() {
 
@@ -2550,7 +2550,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_post_stati( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -2577,7 +2577,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_roles( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -2604,7 +2604,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_capabilities( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -2708,7 +2708,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_image_sizes( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -2735,7 +2735,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_countries( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -3021,7 +3021,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_us_states( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -3094,7 +3094,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_ca_provinces( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -3129,7 +3129,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_days_of_week( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -3153,7 +3153,7 @@ class PodsField_Pick extends PodsField {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_months_of_year( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -30,7 +30,7 @@ class PodsField_Time extends PodsField_DateTime {
 	 * Storage format.
 	 *
 	 * @var string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public static $storage_format = 'H:i:s';
 
@@ -38,7 +38,7 @@ class PodsField_Time extends PodsField_DateTime {
 	 * The default empty value (database)
 	 *
 	 * @var string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public static $empty_value = '';
 
@@ -168,7 +168,7 @@ class PodsField_Time extends PodsField_DateTime {
 	 * @param bool   $js      Return formatted from jQuery UI format? (only for custom formats).
 	 *
 	 * @return string
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function format_value_display( $value, $options, $js = false ) {
 
@@ -219,7 +219,7 @@ class PodsField_Time extends PodsField_DateTime {
 	 * @param bool  $js      Return formatted from jQuery UI format? (only for custom formats).
 	 *
 	 * @return string
-	 * @since  2.7
+	 * @since 2.7.0
 	 */
 	public function format_time( $options, $js = false ) {
 

--- a/classes/fields/website.php
+++ b/classes/fields/website.php
@@ -234,7 +234,7 @@ class PodsField_Website extends PodsField {
 	 *
 	 * @return string
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function validate_url( $value, $options = null ) {
 		if ( empty( $value ) ) {
@@ -329,7 +329,7 @@ class PodsField_Website extends PodsField {
 	 *
 	 * @return string
 	 *
-	 * @since 2.7
+	 * @since 2.7.0
 	 */
 	public function validate_target( $value ) {
 		if ( ! empty( $value ) && '_blank' === $value ) {

--- a/components/Advanced-Relationships.php
+++ b/components/Advanced-Relationships.php
@@ -35,7 +35,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	/**
 	 * Add Advanced Related Objects
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function add_related_objects() {
 
@@ -103,7 +103,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_themes( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -129,7 +129,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_page_templates( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -171,7 +171,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_sidebars( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -199,7 +199,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_post_types( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 
@@ -231,7 +231,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 	 *
 	 * @return array
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public function data_taxonomies( $name = null, $value = null, $options = null, $pod = null, $id = null ) {
 

--- a/components/Helpers.php
+++ b/components/Helpers.php
@@ -29,7 +29,7 @@ class Pods_Helpers extends PodsComponent {
 	 *
 	 * @var object
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	static $obj = null;
 
@@ -38,7 +38,7 @@ class Pods_Helpers extends PodsComponent {
 	 *
 	 * @var string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private $object_type = '_pods_helper';
 
@@ -149,7 +149,7 @@ class Pods_Helpers extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -212,7 +212,7 @@ class Pods_Helpers extends PodsComponent {
 	/**
 	 * Clear cache on save
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function clear_cache( $data, $pod = null, $id = null, $groups = null, $post = null ) {
 
@@ -239,7 +239,7 @@ class Pods_Helpers extends PodsComponent {
 	/**
 	 * Change post title placeholder text
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function set_title_text( $text, $post ) {
 
@@ -249,7 +249,7 @@ class Pods_Helpers extends PodsComponent {
 	/**
 	 * Edit page form
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function edit_page_form() {
 
@@ -265,7 +265,7 @@ class Pods_Helpers extends PodsComponent {
 	/**
 	 * Add meta boxes to the page
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function add_meta_boxes() {
 
@@ -383,7 +383,7 @@ class Pods_Helpers extends PodsComponent {
 	 * @param null  $obj
 	 *
 	 * @return mixed Anything returned by the helper
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function helper( $params, $obj = null ) {
 
@@ -478,7 +478,7 @@ class Pods_Helpers extends PodsComponent {
 			 * @param array $disallowed List of callbacks not allowed.
 			 * @param array $params     Parameters used by Pods::helper() method.
 			 *
-			 * @since 2.7
+			 * @since 2.7.0
 			 */
 			$disallowed = apply_filters( 'pods_helper_disallowed_callbacks', $disallowed, get_object_vars( $params ) );
 
@@ -488,7 +488,7 @@ class Pods_Helpers extends PodsComponent {
 			 * @param array $allowed List of callbacks explicitly allowed.
 			 * @param array $params  Parameters used by Pods::helper() method.
 			 *
-			 * @since 2.7
+			 * @since 2.7.0
 			 */
 			$allowed = apply_filters( 'pods_helper_allowed_callbacks', $allowed, get_object_vars( $params ) );
 

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -161,7 +161,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Load assets for this component
 	 *
-	 * @since 0.1
+	 * @since 0.1.0
 	 */
 	public function admin_assets() {
 
@@ -210,7 +210,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Check is a field name is set for translation
 	 *
-	 * @since 0.1
+	 * @since 0.1.0
 	 *
 	 * @param string $name
 	 *
@@ -246,7 +246,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Get a translated option for a field key (if available)
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  string $current Current value
 	 * @param  string $key     The key / opion name to search for
@@ -275,7 +275,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Page title for setting pages
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsAdmin.php >> admin_menu()
 	 * @see    PodsAdmin.php >> admin_content_settings()
 	 *
@@ -292,7 +292,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Menu title for setting pages
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsAdmin.php >> admin_menu()
 	 *
 	 * @param  string $menu_label Current menu label
@@ -308,7 +308,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Returns the translated label if available
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsForm.php >> 'pods_form_ui_label_text' (filter)
 	 *
 	 * @param  string $label   The default label
@@ -326,7 +326,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Returns the translated description if available
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsForm.php >> 'pods_form_ui_comment_text' (filter)
 	 *
 	 * @param  string $message The default description
@@ -343,7 +343,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Replaces the default selected text with a translation if available
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    pick.php >> 'pods_field_pick_data' (filter)
 	 *
 	 * @param  array  $data    The default data of the field
@@ -370,7 +370,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Replaces the default values with a translation if available
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsForm.php >> 'pods_form_ui_field_' . $type . '_options' (filter)
 	 *
 	 * @param  array  $options The field options
@@ -396,7 +396,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Filter hook function to overwrite the labels and description with translations (if available)
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsInit.php >> setup_content_types()
 	 *
 	 * @param  array  $options The array of object options
@@ -479,7 +479,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Filter hook function to overwrite the labels and description with translations (if available)
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsInit.php >> admin_menu()
 	 *
 	 * @param  array  $options The array of object options
@@ -516,7 +516,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Save component settings
 	 *
-	 * @since 0.1
+	 * @since 0.1.0
 	 */
 	public function admin_save() {
 
@@ -562,7 +562,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Build admin area
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  $options
 	 * @param  $component
@@ -650,7 +650,7 @@ class Pods_Component_I18n extends PodsComponent {
 		/**
 		 * Filter the language data
 		 *
-		 * @since 0.1
+		 * @since 0.1.0
 		 *
 		 * @param array
 		 */
@@ -659,7 +659,7 @@ class Pods_Component_I18n extends PodsComponent {
 		/**
 		 * Filter the UI fields
 		 *
-		 * @since 0.1
+		 * @since 0.1.0
 		 *
 		 * @param array
 		 */
@@ -696,7 +696,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @todo   Remove if not used in final version
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  array $tabs
 	 * @param  array $pod
@@ -716,7 +716,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @todo   Remove if not used in final version
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  array $options
 	 * @param  array $pod
@@ -750,7 +750,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Add the i18n metabox.
 	 *
-	 * @since 0.1
+	 * @since 0.1.0
 	 */
 	public function admin_meta_box() {
 
@@ -775,7 +775,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @todo   Store enabled languages serialized instead of separate inputs
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 */
 	public function meta_box() {
 
@@ -821,7 +821,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Adds translation inputs to fields
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 * @see    PodsForm.php >> 'pods_form_ui_field_' . $type (filter)
 	 *
 	 * @param  string $output  The default output of the field
@@ -895,7 +895,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Check if a language is get to enabled for an object
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  string $locale The locale to validate
 	 * @param  array  $data   Object data
@@ -921,7 +921,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Create a label with the english and native name combined
 	 *
-	 * @since  0.1
+	 * @since 0.1.0
 	 *
 	 * @param  array $lang_data
 	 *

--- a/components/Migrate-CPTUI/Migrate-CPTUI.php
+++ b/components/Migrate-CPTUI/Migrate-CPTUI.php
@@ -72,7 +72,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -175,7 +175,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 	/**
 	 *
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param $post_type
 	 *
@@ -272,7 +272,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 	/**
 	 *
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param $taxonomy
 	 *
@@ -346,7 +346,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 
 	/**
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function clean() {
 

--- a/components/Migrate-Packages/Migrate-Packages.php
+++ b/components/Migrate-Packages/Migrate-Packages.php
@@ -29,7 +29,7 @@ class Pods_Migrate_Packages extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -42,7 +42,7 @@ class Pods_Migrate_Packages extends PodsComponent {
 	 * @param array  $options   Component options.
 	 * @param string $component Component name.
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin( $options, $component ) {
 

--- a/components/Pages.php
+++ b/components/Pages.php
@@ -30,7 +30,7 @@ class Pods_Pages extends PodsComponent {
 	 *
 	 * @var array
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $exists = null;
 
@@ -39,7 +39,7 @@ class Pods_Pages extends PodsComponent {
 	 *
 	 * @var string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private $object_type = '_pods_page';
 
@@ -48,7 +48,7 @@ class Pods_Pages extends PodsComponent {
 	 *
 	 * @var bool
 	 *
-	 * @since 2.1
+	 * @since 2.1.0
 	 */
 	public static $checked = false;
 
@@ -57,7 +57,7 @@ class Pods_Pages extends PodsComponent {
 	 *
 	 * @var bool
 	 *
-	 * @since 2.3
+	 * @since 2.3.0
 	 */
 	public static $content_called = false;
 
@@ -237,7 +237,7 @@ class Pods_Pages extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -315,7 +315,7 @@ class Pods_Pages extends PodsComponent {
 	/**
 	 * Clear cache on save
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $data
 	 * @param null $pod
@@ -356,7 +356,7 @@ class Pods_Pages extends PodsComponent {
 	/**
 	 * Change post title placeholder text
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param $text
 	 * @param $post
@@ -371,7 +371,7 @@ class Pods_Pages extends PodsComponent {
 	/**
 	 * Edit page form
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function edit_page_form() {
 
@@ -410,7 +410,7 @@ class Pods_Pages extends PodsComponent {
 	/**
 	 * Add meta boxes to the page
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function add_meta_boxes() {
 

--- a/components/Roles/Roles.php
+++ b/components/Roles/Roles.php
@@ -37,7 +37,7 @@ class Pods_Roles extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -51,7 +51,7 @@ class Pods_Roles extends PodsComponent {
 	 * @param $component
 	 *
 	 * @return void
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin( $options, $component ) {
 

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -39,7 +39,7 @@ class Pods_Templates extends PodsComponent {
 	 *
 	 * @var object
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $obj = null;
 
@@ -48,7 +48,7 @@ class Pods_Templates extends PodsComponent {
 	 *
 	 * @var bool
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static $deprecated = false;
 
@@ -57,7 +57,7 @@ class Pods_Templates extends PodsComponent {
 	 *
 	 * @var string
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	private $object_type = '_pods_template';
 
@@ -207,7 +207,7 @@ class Pods_Templates extends PodsComponent {
 	/**
 	 * Enqueue styles
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function admin_assets() {
 
@@ -285,7 +285,7 @@ class Pods_Templates extends PodsComponent {
 	/**
 	 * Clear cache on save
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param      $data
 	 * @param null $pod
@@ -318,7 +318,7 @@ class Pods_Templates extends PodsComponent {
 	/**
 	 * Change post title placeholder text
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param $text
 	 * @param $post
@@ -333,7 +333,7 @@ class Pods_Templates extends PodsComponent {
 	/**
 	 * Edit page form
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function edit_page_form() {
 
@@ -349,7 +349,7 @@ class Pods_Templates extends PodsComponent {
 	/**
 	 * Add meta boxes to the page
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public function add_meta_boxes() {
 
@@ -475,7 +475,7 @@ class Pods_Templates extends PodsComponent {
 	 * @param bool   $deprecated    Whether to use deprecated functionality based on old function usage
 	 *
 	 * @return mixed|string|void
-	 * @since 2.0
+	 * @since 2.0.0
 	 */
 	public static function template( $template_name, $code = null, $obj = null, $deprecated = false ) {
 

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -60,7 +60,7 @@ function frontier_do_shortcode( $content ) {
  * @param array attributed provided from parent
  *
  * @return string
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_decode_template( $code, $atts ) {
 
@@ -87,7 +87,7 @@ function frontier_decode_template( $code, $atts ) {
  * @param string $code encoded template to be decoded
  *
  * @return string
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_if_block( $atts, $code ) {
 
@@ -191,7 +191,7 @@ function frontier_if_block( $atts, $code ) {
  * @param string shortcode slug used to process
  *
  * @return null
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_template_blocks( $atts, $code, $slug ) {
 
@@ -232,7 +232,7 @@ function frontier_template_blocks( $atts, $code, $slug ) {
  * @param string encoded template to be decoded
  *
  * @return string template code
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_template_once_blocks( $atts, $code ) {
 
@@ -258,7 +258,7 @@ function frontier_template_once_blocks( $atts, $code ) {
  * @param string template to be processed
  *
  * @return null
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_do_subtemplate( $atts, $content ) {
 
@@ -374,7 +374,7 @@ function frontier_do_subtemplate( $atts, $content ) {
  * @param boolean $skip_unknown If true then values not in $data will not be touched
  *
  * @return string
- * @since 2.7
+ * @since 2.7.0
  */
 function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknown = false ) {
 
@@ -457,7 +457,7 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknow
  * @param string template to be processed
  *
  * @return null
- * @since 2.4
+ * @since 2.4.0
  */
 function frontier_prefilter_template( $code, $template, $pod ) {
 

--- a/deprecated/classes/Pods.php
+++ b/deprecated/classes/Pods.php
@@ -22,7 +22,7 @@ class Pods_Deprecated {
 	 * @param object $obj The Pods object
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $obj ) {
 
@@ -500,7 +500,7 @@ class Pods_Deprecated {
 	/**
 	 * Search and filter records
 	 *
-	 * @since      1.x
+	 * @since 1.x.x
 	 * @deprecated deprecated since version 2.0
 	 *
 	 * @param null $orderby
@@ -586,7 +586,7 @@ class Pods_Deprecated {
 	/**
 	 * Return a single record
 	 *
-	 * @since      1.x
+	 * @since 1.x.x
 	 * @deprecated deprecated since version 2.0
 	 *
 	 * @param int $id Item ID.

--- a/deprecated/classes/Pods.php
+++ b/deprecated/classes/Pods.php
@@ -60,7 +60,7 @@ class Pods_Deprecated {
 	/**
 	 * Display HTML for all datatype fields
 	 *
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param null   $id
 	 * @param null   $public_fields
@@ -367,7 +367,7 @@ class Pods_Deprecated {
 	/**
 	 * Build public input form
 	 *
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param null   $fields
 	 * @param string $label
@@ -413,7 +413,7 @@ class Pods_Deprecated {
 	/**
 	 * Build HTML for a single field
 	 *
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param array $field Field data.
 	 */
@@ -430,7 +430,7 @@ class Pods_Deprecated {
 	 * Fetch a row of results from the DB
 	 *
 	 * @since      1.2.0
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function fetchRecord() {
 
@@ -448,7 +448,7 @@ class Pods_Deprecated {
 	 * @param string $orderby (optional) The orderby string, for PICK fields
 	 *
 	 * @since      1.2.0
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 * @return array|mixed
 	 */
 	public function get_field( $name, $orderby = null ) {
@@ -482,7 +482,7 @@ class Pods_Deprecated {
 	 *
 	 * @return int The ID from the wp_pod table
 	 * @since      1.2.0
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function get_pod_id() {
 
@@ -501,7 +501,7 @@ class Pods_Deprecated {
 	 * Search and filter records
 	 *
 	 * @since 1.x.x
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param null $orderby
 	 * @param int  $rows_per_page
@@ -587,7 +587,7 @@ class Pods_Deprecated {
 	 * Return a single record
 	 *
 	 * @since 1.x.x
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param int $id Item ID.
 	 *
@@ -605,7 +605,7 @@ class Pods_Deprecated {
 	/**
 	 * Fetch the total row count
 	 *
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function getTotalRows() {
 
@@ -619,7 +619,7 @@ class Pods_Deprecated {
 	/**
 	 * (Re)set the MySQL result pointer
 	 *
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param int $row_number
 	 *
@@ -637,7 +637,7 @@ class Pods_Deprecated {
 	/**
 	 * Display the pagination controls
 	 *
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param string $label
 	 */
@@ -658,7 +658,7 @@ class Pods_Deprecated {
 	/**
 	 * Display the list filters
 	 *
-	 * @deprecated deprecated since 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param null   $filters
 	 * @param string $label
@@ -694,7 +694,7 @@ class Pods_Deprecated {
 	 * @internal   param string $helper The helper name
 	 *
 	 * @since      1.2.0
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 */
 	public function pod_helper( $helper_name, $value = null, $name = null ) {
 
@@ -715,7 +715,7 @@ class Pods_Deprecated {
 	/**
 	 * Display the page template
 	 *
-	 * @deprecated deprecated since version 2.0
+	 * @deprecated 2.0.0
 	 *
 	 * @param string      $template_name Template name.
 	 * @param null|string $code          Template code override.

--- a/deprecated/classes/PodsAPI.php
+++ b/deprecated/classes/PodsAPI.php
@@ -24,7 +24,7 @@ class PodsAPI_Deprecated {
 	 * @param object $obj The PodsAPI object
 	 *
 	 * @license http://www.gnu.org/licenses/gpl-2.0.html
-	 * @since   2.0
+	 * @since 2.0.0
 	 */
 	public function __construct( $obj ) {
 

--- a/deprecated/deprecated.php
+++ b/deprecated/deprecated.php
@@ -76,7 +76,7 @@ if ( ! function_exists( 'get_current_url' ) ) {
 /**
  * Mapping function to new function name (following normalization of function names from pod_ to pods_)
  *
- * @since      1.x
+ * @since 1.x.x
  * @deprecated deprecated since version 2.0
  *
  * @param string      $sql              SQL query.
@@ -111,7 +111,7 @@ function pod_query( $sql, $error = 'SQL failed', $results_error = null, $no_resu
 /**
  * Include and Init the Pods class
  *
- * @since      1.x
+ * @since 1.x.x
  * @deprecated deprecated since version 2.0
  * @package    Pods\Deprecated
  */
@@ -151,7 +151,7 @@ class Pod {
 	/**
 	 * Handle variables that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name Property name.
 	 *
@@ -197,7 +197,7 @@ class Pod {
 	/**
 	 * Handle variables that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name  Property name.
 	 * @param mixed  $value Property value to set.
@@ -216,7 +216,7 @@ class Pod {
 	/**
 	 * Handle methods that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name Call name.
 	 * @param array  $args Call arguments.
@@ -233,7 +233,7 @@ class Pod {
 	/**
 	 * Handle variables that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name Property name.
 	 *
@@ -256,7 +256,7 @@ class Pod {
 /**
  * Include and Init the PodsAPI class
  *
- * @since      1.x
+ * @since 1.x.x
  * @deprecated deprecated since version 2.0
  * @package    Pods\Deprecated
  */
@@ -284,7 +284,7 @@ class PodAPI {
 	/**
 	 * Handle variables that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name Property name.
 	 *
@@ -302,7 +302,7 @@ class PodAPI {
 	/**
 	 * Handle methods that have been deprecated
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
 	 *
 	 * @param string $name Call name.
 	 * @param array  $args Call arguments.
@@ -320,7 +320,7 @@ class PodAPI {
 /**
  * Include and Init the PodsUI class
  *
- * @since      2.0
+ * @since 2.0.0
  * @deprecated deprecated since version 2.0
  *
  * @param Pods $obj Pods object.
@@ -337,7 +337,7 @@ function pods_ui_manage( $obj ) {
 /**
  * Limit Access based on Field Value
  *
- * @since      1.x
+ * @since 1.x.x
  * @deprecated deprecated since version 2.0
  *
  * @param Pods   $object Pods object.

--- a/deprecated/deprecated.php
+++ b/deprecated/deprecated.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'wp_send_json' ) ) {
  * @return string
  * @since      1.9.6
  *
- * @deprecated 2.3
+ * @deprecated 2.3.0
  */
 if ( ! function_exists( 'get_current_url' ) ) {
 	/**
@@ -77,7 +77,7 @@ if ( ! function_exists( 'get_current_url' ) ) {
  * Mapping function to new function name (following normalization of function names from pod_ to pods_)
  *
  * @since 1.x.x
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  *
  * @param string      $sql              SQL query.
  * @param string      $error            Error message on failure.
@@ -112,7 +112,7 @@ function pod_query( $sql, $error = 'SQL failed', $results_error = null, $no_resu
  * Include and Init the Pods class
  *
  * @since 1.x.x
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  * @package    Pods\Deprecated
  */
 class Pod {
@@ -257,7 +257,7 @@ class Pod {
  * Include and Init the PodsAPI class
  *
  * @since 1.x.x
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  * @package    Pods\Deprecated
  */
 class PodAPI {
@@ -321,7 +321,7 @@ class PodAPI {
  * Include and Init the PodsUI class
  *
  * @since 2.0.0
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  *
  * @param Pods $obj Pods object.
  *
@@ -338,7 +338,7 @@ function pods_ui_manage( $obj ) {
  * Limit Access based on Field Value
  *
  * @since 1.x.x
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  *
  * @param Pods   $object Pods object.
  * @param array  $access Access array.
@@ -378,7 +378,7 @@ function pods_ui_access( $object, $access, $what ) {
  *
  * @return string The requested value, or null
  * @since      1.6.2
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  */
 function pods_url_variable( $key = 'last', $type = 'url' ) {
 
@@ -391,7 +391,7 @@ function pods_url_variable( $key = 'last', $type = 'url' ) {
  * Generate form key - INTERNAL USE
  *
  * @since      1.2.0
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  *
  * @param string $datatype   Pod name.
  * @param string $uri_hash   URI hash for session.
@@ -413,7 +413,7 @@ function pods_generate_key( $datatype, $uri_hash, $columns, $form_count = 1 ) {
  * Validate form key - INTERNAL USE
  *
  * @since      1.2.0
- * @deprecated deprecated since version 2.0
+ * @deprecated 2.0.0
  *
  * @param string     $token      Nonce token.
  * @param string     $datatype   Pod name.

--- a/includes/classes.php
+++ b/includes/classes.php
@@ -12,7 +12,7 @@
  * @param bool   $strict (optional) If set to true, return false instead of an object if the Pod doesn't exist
  *
  * @return bool|\Pods returns false if $strict, WP_DEBUG, PODS_STRICT or (PODS_DEPRECATED && PODS_STRICT_MODE) are true
- * @since 2.0
+ * @since 2.0.0
  * @link  https://pods.io/docs/pods/
  */
 function pods( $type = null, $id = null, $strict = null ) {
@@ -43,7 +43,7 @@ function pods( $type = null, $id = null, $strict = null ) {
  *
  * @return PodsUI
  *
- * @since 2.0
+ * @since 2.0.0
  * @link  https://pods.io/docs/pods-ui/
  */
 function pods_ui( $obj, $deprecated = false ) {
@@ -63,7 +63,7 @@ function pods_ui( $obj, $deprecated = false ) {
  *
  * @return PodsAPI
  *
- * @since 2.0
+ * @since 2.0.0
  * @link  https://pods.io/docs/pods-api/
  */
 function pods_api( $pod = null, $format = null ) {
@@ -85,7 +85,7 @@ function pods_api( $pod = null, $format = null ) {
  *
  * @return PodsData
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_data( $pod = null, $id = null, $strict = true, $unique = true ) {
 
@@ -105,7 +105,7 @@ function pods_data( $pod = null, $id = null, $strict = true, $unique = true ) {
  *
  * @return PodsForm
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_form() {
 
@@ -121,7 +121,7 @@ function pods_form() {
  *
  * @return PodsInit
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_init() {
 
@@ -137,7 +137,7 @@ function pods_init() {
  *
  * @return PodsComponents
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_components() {
 
@@ -154,7 +154,7 @@ function pods_components() {
  *
  * @return PodsAdmin
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_admin() {
 
@@ -170,7 +170,7 @@ function pods_admin() {
  *
  * @return PodsMeta
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_meta() {
 
@@ -188,7 +188,7 @@ function pods_meta() {
  *
  * @return PodsArray
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_array( $container ) {
 
@@ -198,7 +198,7 @@ function pods_array( $container ) {
 }
 
 /**
- * @since 2.7
+ * @since 2.7.0
  */
 function pods_i18n() {
 
@@ -221,7 +221,7 @@ function pods_i18n() {
  *
  * @return string|bool The view output
  *
- * @since 2.0
+ * @since 2.0.0
  * @link  https://pods.io/docs/pods-view/
  */
 function pods_view( $view, $data = null, $expires = false, $cache_mode = 'cache', $return = false ) {
@@ -248,7 +248,7 @@ function pods_view( $view, $data = null, $expires = false, $cache_mode = 'cache'
  *
  * @return PodsMigrate
  *
- * @since 2.2
+ * @since 2.2.0
  */
 function pods_migrate( $type = null, $delimiter = null, $data = null ) {
 
@@ -266,7 +266,7 @@ function pods_migrate( $type = null, $delimiter = null, $data = null ) {
  *
  * @return PodsUpgrade
  *
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_upgrade( $version = '' ) {
 

--- a/includes/data.php
+++ b/includes/data.php
@@ -996,7 +996,7 @@ function pods_v_set( $value, $var, $type = 'get' ) {
  * @return mixed The variable (if exists), or default value
  * @since      1.10.6
  *
- * @deprecated 2.4 Use pods_v() or pods_v_sanitized() instead.
+ * @deprecated 2.4.0 Use pods_v() or pods_v_sanitized() instead.
  * @see        pods_v_sanitized
  */
 function pods_var( $var = 'last', $type = 'get', $default = null, $allowed = null, $strict = false, $casting = false, $context = 'display' ) {
@@ -1035,7 +1035,7 @@ function pods_var( $var = 'last', $type = 'get', $default = null, $allowed = nul
  * @return mixed The variable (if exists), or default value
  * @since 2.0.0
  *
- * @deprecated 2.4 Use pods_v() instead.
+ * @deprecated 2.4.0 Use pods_v() instead.
  * @see        pods_v
  */
 function pods_var_raw( $var = 'last', $type = 'get', $default = null, $allowed = null, $strict = false, $casting = false ) {
@@ -1059,7 +1059,7 @@ function pods_var_raw( $var = 'last', $type = 'get', $default = null, $allowed =
  * @return mixed $value (if set), $type (if $type is array or object), or $url (if $type is 'url')
  * @since      1.10.6
  *
- * @deprecated 2.4 Use pods_v_set() instead.
+ * @deprecated 2.4.0 Use pods_v_set() instead.
  * @see        pods_v_set
  */
 function pods_var_set( $value, $var = 'last', $type = 'url' ) {
@@ -1168,7 +1168,7 @@ function pods_query_arg( $array = null, $allowed = null, $excluded = null, $url 
  *
  * @since 2.0.0
  *
- * @deprecated 2.4 Use pods_query_arg() instead.
+ * @deprecated 2.4.0 Use pods_query_arg() instead.
  * @see        pods_query_arg
  */
 function pods_var_update( $array = null, $allowed = null, $excluded = null, $url = null ) {

--- a/includes/data.php
+++ b/includes/data.php
@@ -1033,7 +1033,7 @@ function pods_var( $var = 'last', $type = 'get', $default = null, $allowed = nul
  * @param bool   $casting (optional) Whether to cast the value returned like provided in $default
  *
  * @return mixed The variable (if exists), or default value
- * @since      2.0
+ * @since 2.0.0
  *
  * @deprecated 2.4 Use pods_v() instead.
  * @see        pods_v
@@ -1166,7 +1166,7 @@ function pods_query_arg( $array = null, $allowed = null, $excluded = null, $url 
  *
  * @return mixed
  *
- * @since      2.0
+ * @since 2.0.0
  *
  * @deprecated 2.4 Use pods_query_arg() instead.
  * @see        pods_query_arg
@@ -1185,7 +1185,7 @@ function pods_var_update( $array = null, $allowed = null, $excluded = null, $url
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_cast( $value, $cast_from = null ) {
 
@@ -1361,7 +1361,7 @@ function pods_js_name( $orig, $lower = true ) {
  * @param bool   $allow_negative (optional)
  *
  * @return integer
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_absint( $maybeint, $strict = true, $allow_negative = false ) {
 
@@ -1616,7 +1616,7 @@ function pods_evaluate_tag( $tag, $sanitize = false ) {
  *
  * @return string
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_serial_comma( $value, $field = null, $fields = null, $and = null, $field_index = null ) {
 
@@ -1804,7 +1804,7 @@ function pods_var_user( $anon = false, $user = true, $capability = null ) {
  * @param array        $args Array of parent, children, and id keys to use
  *
  * @return array|object
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_hierarchical_list( $list, $args = array() ) {
 
@@ -1837,7 +1837,7 @@ function pods_hierarchical_list( $list, $args = array() ) {
  * @param array        $args   Array of parent, children, and id keys to use
  *
  * @return array|object
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_hierarchical_list_recurse( $parent, $list, &$args ) {
 
@@ -1942,7 +1942,7 @@ function pods_hierarchical_list_recurse( $parent, $list, &$args ) {
  * @return array|object
  * @internal param string $children_key Key to recurse children into
  *
- * @since    2.3
+ * @since 2.3.0
  */
 function pods_hierarchical_select( $list, $args = array() ) {
 
@@ -1984,7 +1984,7 @@ function pods_hierarchical_select( $list, $args = array() ) {
  * @internal param string $children_key Key to recurse children into
  *
  * @see      pods_hierarchical_select
- * @since    2.3
+ * @since 2.3.0
  */
 function pods_hierarchical_select_recurse( $items, $args, $depth = 0 ) {
 
@@ -2041,7 +2041,7 @@ function pods_hierarchical_select_recurse( $items, $args, $depth = 0 ) {
  *
  * @see   wp_list_filter
  * @return array
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_list_filter( $list, $args = array(), $operator = 'AND' ) {
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -13,7 +13,7 @@
  * @param string $no_results_error (optional) Throw an error if no records are found
  *
  * @return array|bool|mixed|null|void
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_query( $sql, $error = 'Database Error', $results_error = null, $no_results_error = null ) {
 
@@ -56,7 +56,7 @@ function pods_query( $sql, $error = 'Database Error', $results_error = null, $no
  * @param object $obj   (optional) Object to reference for filter / action
  *
  * @return mixed
- * @since 2.0
+ * @since 2.0.0
  * @todo  Need to figure out how to handle $scope = 'pods' for the Pods class
  */
 function pods_do_hook( $scope, $name, $args = null, $obj = null ) {
@@ -111,7 +111,7 @@ $GLOBALS['pods_errors'] = array();
  *
  * @return mixed
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_error( $error, $obj = null ) {
 
@@ -247,7 +247,7 @@ $pods_debug = 0;
  *
  * @return void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_debug( $debug = '_null', $die = false, $prefix = '_null' ) {
 
@@ -334,7 +334,7 @@ function pods_is_admin( $cap = null ) {
  *
  * @return bool Whether Developer Mode is enabled
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_developer() {
 
@@ -350,7 +350,7 @@ function pods_developer() {
  *
  * @return bool Whether Tableless Mode is enabled
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_tableless() {
 
@@ -442,7 +442,7 @@ function pods_api_cache() {
  * @param string $version     The version of WordPress that deprecated the function
  * @param string $replacement Optional. The function that should have been called
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_deprecated( $function, $version, $replacement = null ) {
 
@@ -472,7 +472,7 @@ function pods_deprecated( $function, $version, $replacement = null ) {
  *
  * @return void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_help( $text, $url = null ) {
 
@@ -564,7 +564,7 @@ function pods_helper( $helper_name, $value = null, $name = null ) {
  * Get the full URL of the current page
  *
  * @return string Full URL of the current page
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_current_url() {
 
@@ -585,7 +585,7 @@ function pods_current_url() {
  * @param object $object The Pod Object currently checking (optional)
  *
  * @return bool
- * @since 2.0
+ * @since 2.0.0
  */
 function is_pod( $object = null ) {
 
@@ -1009,7 +1009,7 @@ function pods_shortcode( $tags, $content = null ) {
  * @param string $content Not currently used
  *
  * @return string
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_shortcode_form( $tags, $content = null ) {
 
@@ -1245,7 +1245,7 @@ function pods_function_or_file( $function_or_file, $function_name = null, $file_
  *
  * @return void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_redirect( $location, $status = 302, $die = true ) {
 
@@ -1430,7 +1430,7 @@ function pods_by_title( $title, $output = OBJECT, $type = 'page', $status = null
  *
  * @return mixed Field value
  *
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_field( $pod, $id = false, $name = null, $single = false ) {
 
@@ -1463,7 +1463,7 @@ function pods_field( $pod, $id = false, $name = null, $single = false ) {
  *
  * @return mixed Field value
  *
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_field_display( $pod, $id = false, $name = null, $single = false ) {
 
@@ -1496,7 +1496,7 @@ function pods_field_display( $pod, $id = false, $name = null, $single = false ) 
  *
  * @return mixed Field value
  *
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_field_raw( $pod, $id = false, $name = null, $single = false ) {
 
@@ -1526,7 +1526,7 @@ function pods_field_raw( $pod, $id = false, $name = null, $single = false ) {
  *
  * @return bool|mixed|null|string|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_view_set( $key, $value, $expires = 0, $cache_mode = 'cache', $group = '' ) {
 
@@ -1547,7 +1547,7 @@ function pods_view_set( $key, $value, $expires = 0, $cache_mode = 'cache', $grou
  *
  * @return bool|mixed|null|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_view_get( $key, $cache_mode = 'cache', $group = '', $callback = null ) {
 
@@ -1567,7 +1567,7 @@ function pods_view_get( $key, $cache_mode = 'cache', $group = '', $callback = nu
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_view_clear( $key = true, $cache_mode = 'cache', $group = '' ) {
 
@@ -1588,7 +1588,7 @@ function pods_view_clear( $key = true, $cache_mode = 'cache', $group = '' ) {
  *
  * @return bool|mixed|null|string|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_cache_set( $key, $value, $group = '', $expires = 0 ) {
 
@@ -1606,7 +1606,7 @@ function pods_cache_set( $key, $value, $group = '', $expires = 0 ) {
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_cache_get( $key, $group = '', $callback = null ) {
 
@@ -1623,7 +1623,7 @@ function pods_cache_get( $key, $group = '', $callback = null ) {
  *
  * @return bool|mixed|null|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_cache_clear( $key = true, $group = '' ) {
 
@@ -1641,7 +1641,7 @@ function pods_cache_clear( $key = true, $group = '' ) {
  *
  * @return bool|mixed|null|string|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_transient_set( $key, $value, $expires = 0 ) {
 
@@ -1658,7 +1658,7 @@ function pods_transient_set( $key, $value, $expires = 0 ) {
  *
  * @return bool|mixed|null|void
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_transient_get( $key, $callback = null ) {
 
@@ -1674,7 +1674,7 @@ function pods_transient_get( $key, $callback = null ) {
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_transient_clear( $key = true ) {
 
@@ -1822,7 +1822,7 @@ function pods_template_part( $template, $data = null, $return = false ) {
  * @param array  $object (optional) Pod array, including any 'fields' arrays
  *
  * @return array|boolean Pod data or false if unsuccessful
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_register_type( $type, $name, $object = null ) {
 
@@ -1847,7 +1847,7 @@ function pods_register_type( $type, $name, $object = null ) {
  * @param array        $object (optional) Pod array, including any 'fields' arrays
  *
  * @return array|boolean Field data or false if unsuccessful
- * @since 2.1
+ * @since 2.1.0
  */
 function pods_register_field( $pod, $name, $field = null ) {
 
@@ -1871,7 +1871,7 @@ function pods_register_field( $pod, $name, $field = null ) {
  * @param string $file The new field type class file location
  *
  * @return array Field type array
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_register_field_type( $type, $file = null ) {
 
@@ -1886,7 +1886,7 @@ function pods_register_field_type( $type, $file = null ) {
  * @param array  $options Object options
  *
  * @return array|boolean Object array or false if unsuccessful
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_register_related_object( $name, $label, $options = null ) {
 
@@ -1900,7 +1900,7 @@ function pods_register_related_object( $name, $label, $options = null ) {
  *
  * @return void
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_require_component( $component ) {
 
@@ -1924,7 +1924,7 @@ function pods_require_component( $component ) {
  *
  * @return void
  *
- * @since 2.0
+ * @since 2.0.0
  * @link  https://pods.io/docs/pods-group-add/
  */
 function pods_group_add( $pod, $label, $fields, $context = 'normal', $priority = 'default', $type = null ) {
@@ -1946,7 +1946,7 @@ function pods_group_add( $pod, $label, $fields, $context = 'normal', $priority =
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_is_plugin_active( $plugin ) {
 
@@ -1982,7 +1982,7 @@ function pods_is_plugin_active( $plugin ) {
  *
  * @return bool
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_no_conflict_check( $object_type = 'post' ) {
 
@@ -2011,7 +2011,7 @@ function pods_no_conflict_check( $object_type = 'post' ) {
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_no_conflict_on( $object_type = 'post', $object = null ) {
 
@@ -2208,7 +2208,7 @@ function pods_no_conflict_on( $object_type = 'post', $object = null ) {
  *
  * @return bool
  *
- * @since 2.0
+ * @since 2.0.0
  */
 function pods_no_conflict_off( $object_type = 'post' ) {
 
@@ -2295,7 +2295,7 @@ function pods_session_start() {
  *
  * @return bool
  *
- * @since 2.7
+ * @since 2.7.0
  */
 function pods_is_modal_window() {
 
@@ -2315,7 +2315,7 @@ function pods_is_modal_window() {
  *
  * @return bool Whether the pod object is valid and exists
  *
- * @since 2.7
+ * @since 2.7.0
  */
 function pod_is_valid( $pod ) {
 
@@ -2335,7 +2335,7 @@ function pod_is_valid( $pod ) {
  *
  * @return bool Whether the pod object has items
  *
- * @since 2.7
+ * @since 2.7.0
  */
 function pod_has_items( $pod ) {
 

--- a/includes/media.php
+++ b/includes/media.php
@@ -196,7 +196,7 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
  *
  * @return int Attachment ID
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_attachment_import( $url, $post_parent = null, $featured = false ) {
 
@@ -269,7 +269,7 @@ function pods_attachment_import( $url, $post_parent = null, $featured = false ) 
  *
  * @return boolean Image generation result
  *
- * @since 2.3
+ * @since 2.3.0
  */
 function pods_image_resize( $attachment_id, $size ) {
 
@@ -342,7 +342,7 @@ function pods_image_resize( $attachment_id, $size ) {
  *
  * @uses  wp_audio_shortcode()
  *
- * @since 2.5
+ * @since 2.5.0
  *
  * @param string|array $url  Can be a URL of the source file, or a Pods audio field.
  * @param bool|array   $args Optional. Additional arguments to pass to wp_audio_shortcode
@@ -375,7 +375,7 @@ function pods_audio( $url, $args = false ) {
  *
  * @uses  wp_video_shortcode()
  *
- * @since 2.5
+ * @since 2.5.0
  *
  * @param string|array $url  Can be a URL of the source file, or a Pods video field.
  * @param bool|array   $args Optional. Additional arguments to pass to wp_video_shortcode()

--- a/tests/phpunit/includes/_tests-integration-pods.php
+++ b/tests/phpunit/includes/_tests-integration-pods.php
@@ -11,7 +11,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 	 * The pod name
 	 *
 	 * @var string
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	private $pod_name = 'foo';
 
@@ -19,7 +19,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 	 * The id of the test pods
 	 *
 	 * @var int
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	private $pod_id;
 
@@ -70,7 +70,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::valid
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_valid() {
 
@@ -80,7 +80,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 	/**
 	 * @covers Pods::exists
 	 * @uses   ::pods
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists() {
 
@@ -91,7 +91,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 	/**
 	 * @covers Pods::row
 	 * uses    ::pods
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_row() {
 
@@ -102,7 +102,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::find
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_find() {
 
@@ -112,7 +112,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::fetch
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_fetch() {
 
@@ -122,7 +122,7 @@ class Test_Pods extends \Pods_Unit_Tests\Pods_UnitTestCase {
 	/**
 	 * @covers Pods::display
 	 * @uses   Pods::fetch
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_display() {
 

--- a/tests/phpunit/includes/tests-pods-api.php
+++ b/tests/phpunit/includes/tests-pods-api.php
@@ -14,7 +14,7 @@ class Test_Pods_Api extends Pods_UnitTestCase {
 
 	/**
 	 * @covers PodsAPI::init
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_init() {
 
@@ -26,7 +26,7 @@ class Test_Pods_Api extends Pods_UnitTestCase {
 	 *
 	 * @covers  PodsAPI::init
 	 * @depends test_method_exists_init
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_init_no_pod() {
 
@@ -35,7 +35,7 @@ class Test_Pods_Api extends Pods_UnitTestCase {
 
 	/**
 	 * @covers PodsAPI::__construct
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_construct_no_pod() {
 

--- a/tests/phpunit/includes/tests-pods.php
+++ b/tests/phpunit/includes/tests-pods.php
@@ -23,7 +23,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 * The pods system under test
 	 *
 	 * @var   \Pods
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	private $pods;
 
@@ -41,7 +41,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 * Test the add method when passing empty parameters
 	 *
 	 * @covers Pods::add
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_add_empty() {
 
@@ -55,7 +55,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::exists
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_exists() {
 
@@ -66,7 +66,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 * Test pod does not exist
 	 *
 	 * @covers Pods::exists
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_false() {
 
@@ -75,7 +75,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::exists
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists() {
 
@@ -85,7 +85,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::valid
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_valid() {
 
@@ -97,7 +97,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::valid
 	 * @depends test_method_exists_valid
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_valid_invalid() {
 
@@ -107,7 +107,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::valid
 	 * @depends test_method_exists_valid
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_valid_iterator() {
 
@@ -119,7 +119,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::valid
 	 * @depends test_method_exists_valid
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_valid() {
 
@@ -129,7 +129,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::is_iterator
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_is_iterator() {
 
@@ -140,7 +140,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::stop_iterator
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_stop_iterator() {
 
@@ -152,7 +152,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::rewind
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_rewind_exists() {
 
@@ -162,7 +162,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::rewind
 	 * @depends test_method_rewind_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_rewind() {
 
@@ -173,7 +173,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::current
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_current_exists() {
 
@@ -185,7 +185,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::current
 	 * @depends test_method_current_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_current_iterator_false() {
 
@@ -198,7 +198,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::current
 	 * @depends test_method_current_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_current_iterator_true() {
 
@@ -208,7 +208,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::key
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_key_exists() {
 
@@ -220,7 +220,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::key
 	 * @depends test_method_key_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_key_iterator_false() {
 
@@ -234,7 +234,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::key
 	 * @depends test_method_key_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_key() {
 
@@ -245,7 +245,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::next
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_next_exists() {
 
@@ -257,7 +257,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::next
 	 * @depends test_method_next_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_next_iterator_false() {
 
@@ -272,7 +272,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::next
 	 * @depends test_method_next_exists
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_next() {
 
@@ -284,7 +284,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::input
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_input() {
 
@@ -296,7 +296,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::input
 	 * @depends test_method_exists_input
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_input_field_string_missing_field() {
 
@@ -309,7 +309,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::input
 	 * @depends test_method_exists_input
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_input_field_empty_array() {
 
@@ -319,7 +319,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::row
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_row() {
 
@@ -329,7 +329,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::row
 	 * @depends test_method_exists_row
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_row_false() {
 
@@ -339,7 +339,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::row
 	 * @depends test_method_exists_row
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_row() {
 
@@ -349,7 +349,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::data
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_data() {
 
@@ -359,7 +359,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::data
 	 * @depends test_method_exists_data
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_data_empty_rows() {
 
@@ -370,7 +370,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	/**
 	 * @covers  Pods::data
 	 * @depends test_method_exists_data
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_data() {
 
@@ -380,7 +380,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::__get
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_get() {
 
@@ -392,7 +392,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::__get
 	 * @depends test_method_exists_get
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_get() {
 
@@ -406,7 +406,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::__get
 	 * @depends test_method_exists_get
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_get_deprecated_property() {
 
@@ -422,7 +422,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::__get
 	 * @depends test_method_exists_get
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_get_deprecated_property_error() {
 
@@ -439,7 +439,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::__call
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_exists_call() {
 
@@ -451,7 +451,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::__call
 	 * @depends test_method_exists_call
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_call_method_does_not_exist() {
 
@@ -466,7 +466,7 @@ class Test_Pods extends Pods_UnitTestCase {
 	 *
 	 * @covers  Pods::__call
 	 * @depends test_method_exists_call
-	 * @since   3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_call_deprecated_method_error() {
 
@@ -481,7 +481,7 @@ class Test_Pods extends Pods_UnitTestCase {
 
 	/**
 	 * @covers Pods::id
-	 * @since  3.0
+	 * @since 3.0.0
 	 */
 	public function test_method_id_field_does_not_exist() {
 

--- a/tests/phpunit/includes/tests-shortcodes.php
+++ b/tests/phpunit/includes/tests-shortcodes.php
@@ -45,7 +45,7 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 	}
 
 	/**
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	public function test_shortcode_pods() {
 
@@ -113,7 +113,7 @@ class Test_Shortcodes extends Pods_UnitTestCase {
 	 * PR 2339
 	 *
 	 * @link  https://github.com/pods-framework/pods/pull/2339
-	 * @since 3.0
+	 * @since 3.0.0
 	 */
 	public function test_shortcode_pods_field_in_shortcode() {
 

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -174,7 +174,7 @@ if ( 0 < $pod->id() ) {
 		 * @param Pods   $pod Current Pods object.
 		 * @param PodsUI $obj Current PodsUI object.
 		 *
-		 * @since 2.5
+		 * @since 2.5.0
 		 */
 		do_action( 'pods_meta_box_pre', $pod, $obj );
 		?>
@@ -253,7 +253,7 @@ if ( 0 < $pod->id() ) {
 												 * @param Pods   $pod Current Pods object.
 												 * @param PodsUI $obj Current PodsUI object.
 												 *
-												 * @since 2.5
+												 * @since 2.5.0
 												 */
 												do_action( 'pods_ui_form_misc_pub_actions', $pod, $obj );
 												?>
@@ -300,7 +300,7 @@ if ( 0 < $pod->id() ) {
 										 * @param Pods   $pod Current Pods object.
 										 * @param PodsUI $obj Current PodsUI object.
 										 *
-										 * @since 2.5
+										 * @since 2.5.0
 										 */
 										do_action( 'pods_ui_form_submit_area', $pod, $obj );
 										?>
@@ -319,7 +319,7 @@ if ( 0 < $pod->id() ) {
 								 * @param Pods   $pod Current Pods object.
 								 * @param PodsUI $obj Current PodsUI object.
 								 *
-								 * @since 2.5
+								 * @since 2.5.0
 								 */
 								do_action( 'pods_ui_form_publish_area', $pod, $obj );
 								?>
@@ -463,7 +463,7 @@ if ( 0 < $pod->id() ) {
 							 * @param Pods   $pod Current Pods object.
 							 * @param PodsUI $obj Current PodsUI object.
 							 *
-							 * @since 2.5
+							 * @since 2.5.0
 							 */
 							if ( pods_v( 'readonly', $field['options'], pods_v( 'readonly', $field, false ) ) || apply_filters( 'pods_ui_form_title_readonly', false, $pod, $obj ) ) {
 								?>

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -142,7 +142,7 @@ foreach ( $field_tab_options[ 'additional-field' ] as $field_type => $field_type
  *
  * Currently only context 'side' is available
  *
- * @since 2.7
+ * @since 2.7.0
  * @see https://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes
  * @param array $pod The Pod object as an array
  */


### PR DESCRIPTION
Documentation code standards for the _contents_ (not the position in DocBlock) of `@since` and `@deprecated` tags.

Fixes #4995.

