### PR TITLE
Only flush rewrite rules in an admin context

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1127,6 +1127,11 @@ class PodsInit {
 	 */
 	public function flush_rewrite_rules() {
 
+		// Only run $wp_rewrite->flush_rules() in an admin context.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$flush = (int) pods_transient_get( 'pods_flush_rewrites' );
 
 		if ( 1 === $flush ) {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/44142#comment:14

Changelog: Fixes cases where there may be "500 Internal Server Error" messages when Pods clears it's caches and flushes rewrites