### PR TITLE
Feature/4992 interpolated hook names

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -4458,8 +4458,9 @@ class Pods implements Iterator {
 			return pods_ui( $this );
 		}//end if
 
+		$pod_name = $this->pod;
 		do_action( 'pods_admin_ui_custom', $this );
-		do_action( 'pods_admin_ui_custom_' . $this->pod, $this );
+		do_action( "pods_admin_ui_custom_{$pod_name}", $this );
 
 		return null;
 	}

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1158,10 +1158,11 @@ class Pods implements Iterator {
 				}
 
 				if ( isset( $this->fields[ $params->name ], $this->fields[ $params->name ]['type'] ) ) {
+					$field_type = $this->fields[ $params->name ]['type'];
 					/**
 					 * Modify value returned by field() after its retrieved, but before its validated or formatted
 					 *
-					 * Filter name is set dynamically with name of field: "pods_pods_field_{field_name}"
+					 * Filter name is set dynamically with name of field: "pods_pods_field_{field_type}"
 					 *
 					 * @since unknown
 					 *
@@ -1170,7 +1171,7 @@ class Pods implements Iterator {
 					 * @param array             $params Params array passed to field().
 					 * @param object|Pods       $this   Current Pods object.
 					 */
-					$v = apply_filters( 'pods_pods_field_' . $this->fields[ $params->name ]['type'], null, $this->fields[ $params->name ], $this->row, $params, $this );
+					$v = apply_filters( "pods_pods_field_{$field_type}", null, $this->fields[ $params->name ], $this->row, $params, $this );
 
 					if ( null !== $v ) {
 						return $v;
@@ -4361,7 +4362,8 @@ class Pods implements Iterator {
 				}
 			}//end if
 
-			$manage = apply_filters( 'pods_admin_ui_fields_' . $this->pod, apply_filters( 'pods_admin_ui_fields', $manage, $this->pod, $this ), $this->pod, $this );
+			$pod_name = $this->pod;
+			$manage   = apply_filters( "pods_admin_ui_fields_{$pod_name}", apply_filters( 'pods_admin_ui_fields', $manage, $this->pod, $this ), $this->pod, $this );
 
 			$icon = pods_v( 'ui_icon', $this->pod_data['options'] );
 
@@ -4443,7 +4445,8 @@ class Pods implements Iterator {
 			}
 
 			// @todo Customize the Add New / Manage links to point to their correct menu items.
-			$ui = apply_filters( 'pods_admin_ui_' . $this->pod, apply_filters( 'pods_admin_ui', $ui, $this->pod, $this ), $this->pod, $this );
+			$pod_name = $this->pod;
+			$ui       = apply_filters( "pods_admin_ui_{$pod_name}", apply_filters( 'pods_admin_ui', $ui, $this->pod, $this ), $this->pod, $this );
 
 			// Override UI options.
 			foreach ( $options as $option => $value ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3312,6 +3312,7 @@ class PodsAPI {
 			$params->track_changed_fields = false;
 		}
 
+		$pod_name = $params->pod;
 		/**
 		 * Override $params['track_changed_fields']
 		 *
@@ -3321,7 +3322,7 @@ class PodsAPI {
 		 *
 		 * @since 2.3.19
 		 */
-		$track_changed_fields = apply_filters( 'pods_api_save_pod_item_track_changed_fields_' . $params->pod, (boolean) $params->track_changed_fields, $params );
+		$track_changed_fields = apply_filters( "pods_api_save_pod_item_track_changed_fields_{$pod_name}", (boolean) $params->track_changed_fields, $params );
 
 		$changed_fields = array();
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -214,7 +214,9 @@ class PodsAdmin {
 						continue;
 					}
 
-					$pod = apply_filters( 'pods_advanced_content_type_pod_data_' . $pod['name'], $pod, $pod['name'] );
+					$pod_name = $pod['name'];
+
+					$pod = apply_filters( "pods_advanced_content_type_pod_data_{$pod_name}", $pod, $pod['name'] );
 					$pod = apply_filters( 'pods_advanced_content_type_pod_data', $pod, $pod['name'] );
 
 					if ( 1 === (int) pods_v( 'show_in_menu', $pod['options'], 0 ) ) {
@@ -789,7 +791,9 @@ class PodsAdmin {
 				'actions_disabled' => $actions_disabled,
 			);
 
-			$ui = apply_filters( 'pods_admin_ui_' . $pod->pod, apply_filters( 'pods_admin_ui', $ui, $pod->pod, $pod ), $pod->pod, $pod );
+			$pod_pod_name = $pod->pod;
+
+			$ui = apply_filters( "pods_admin_ui_{$pod_pod_name}", apply_filters( 'pods_admin_ui', $ui, $pod->pod, $pod ), $pod->pod, $pod );
 
 			// Force disabled actions, do not pass go, do not collect $two_hundred
 			$ui['actions_disabled'] = $actions_disabled;
@@ -1146,6 +1150,9 @@ class PodsAdmin {
 
 		$addtl_args = compact( array( 'fields', 'labels', 'admin_ui', 'advanced' ) );
 
+		$pod_type = $pod['type'];
+		$pod_name = $pod['name'];
+
 		/**
 		 * Add or modify tabs in Pods editor for a specific Pod
 		 *
@@ -1155,12 +1162,12 @@ class PodsAdmin {
 		 *
 		 * @since  unknown
 		 */
-		$tabs = apply_filters( 'pods_admin_setup_edit_tabs_' . $pod['type'] . '_' . $pod['name'], $tabs, $pod, $addtl_args );
+		$tabs = apply_filters( "pods_admin_setup_edit_tabs_{$pod_type}_{$pod_name}", $tabs, $pod, $addtl_args );
 
 		/**
 		 * Add or modify tabs for any Pod in Pods editor of a specific post type.
 		 */
-		$tabs = apply_filters( 'pods_admin_setup_edit_tabs_' . $pod['type'], $tabs, $pod, $addtl_args );
+		$tabs = apply_filters( "pods_admin_setup_edit_tabs_{$pod_type}", $tabs, $pod, $addtl_args );
 
 		/**
 		 * Add or modify tabs in Pods editor for all pods.
@@ -1611,6 +1618,8 @@ class PodsAdmin {
 				),
 			);
 
+			$post_type_name = pods_v( 'name', $pod, 'post_type', true );
+
 			$options['advanced'] = array(
 				'public'                  => array(
 					'label'             => __( 'Public', 'pods' ),
@@ -1754,7 +1763,7 @@ class PodsAdmin {
 					'help'        => __( 'help', 'pods' ),
 					'type'        => 'pick',
 					'pick_object' => 'post-status',
-					'default'     => apply_filters( 'pods_api_default_status_' . pods_v( 'name', $pod, 'post_type', true ), 'draft', $pod ),
+					'default'     => apply_filters( "pods_api_default_status_{$post_type_name}", 'draft', $pod ),
 				),
 			);
 		} elseif ( 'taxonomy' === $pod['type'] ) {
@@ -2202,6 +2211,9 @@ class PodsAdmin {
 			);
 		}//end if
 
+		$pod_type = $pod['type'];
+		$pod_name = $pod['name'];
+
 		/**
 		 * Add admin fields to the Pods editor for a specific Pod
 		 *
@@ -2210,7 +2222,7 @@ class PodsAdmin {
 		 *
 		 * @since  unkown
 		 */
-		$options = apply_filters( 'pods_admin_setup_edit_options_' . $pod['type'] . '_' . $pod['name'], $options, $pod );
+		$options = apply_filters( "pods_admin_setup_edit_options_{$pod_type}_{$pod_name}", $options, $pod );
 
 		/**
 		 * Add admin fields to the Pods editor for any Pod of a specific content type.
@@ -2218,7 +2230,7 @@ class PodsAdmin {
 		 * @param array  $options The Options fields.
 		 * @param object $pod     Current Pods object.
 		 */
-		$options = apply_filters( 'pods_admin_setup_edit_options_' . $pod['type'], $options, $pod );
+		$options = apply_filters( "pods_admin_setup_edit_options_{$pod_type}", $options, $pod );
 
 		/**
 		 * Add admin fields to the Pods editor for all Pods
@@ -2315,7 +2327,7 @@ class PodsAdmin {
 			 * @param array       $options Tabs, indexed by label,
 			 * @param object|Pods $pod     Pods object for the Pod this UI is for.
 			 */
-			$options['additional-field'][ $type ] = apply_filters( 'pods_admin_setup_edit_' . $type . '_additional_field_options', $options['additional-field'][ $type ], $type, $options, $pod );
+			$options['additional-field'][ $type ] = apply_filters( "pods_admin_setup_edit_{$type}_additional_field_options", $options['additional-field'][ $type ], $type, $options, $pod );
 			$options['additional-field'][ $type ] = apply_filters( 'pods_admin_setup_edit_additional_field_options', $options['additional-field'][ $type ], $type, $options, $pod );
 		}//end foreach
 
@@ -3209,7 +3221,9 @@ class PodsAdmin {
 
 		$params->method = $method->name;
 
-		$params = apply_filters( 'pods_api_' . $method->name, $params, $method );
+		$method_name = $method->name;
+
+		$params = apply_filters( "pods_api_{$method_name}", $params, $method );
 
 		$api = pods_api();
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -802,7 +802,7 @@ class PodsAdmin {
 		} else {
 			$pod_pod_name = $pod->pod;
 			do_action( 'pods_admin_ui_custom', $pod );
-			do_action( "pods_admin_ui_custom_{$pod_pod_name}, $pod );
+			do_action( "pods_admin_ui_custom_{$pod_pod_name}", $pod );
 		}//end if
 	}
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -800,8 +800,9 @@ class PodsAdmin {
 
 			pods_ui( $ui );
 		} else {
+			$pod_pod_name = $pod->pod;
 			do_action( 'pods_admin_ui_custom', $pod );
-			do_action( 'pods_admin_ui_custom_' . $pod->pod, $pod );
+			do_action( "pods_admin_ui_custom_{$pod_pod_name}, $pod );
 		}//end if
 	}
 

--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -111,7 +111,7 @@ class PodsComponents {
 		foreach ( $this->components as $component => $component_data ) {
 			$component_id = $component_data['ID'];
 
-			$component_data['MustUse'] = apply_filters( 'pods_component_require_' . $component_id, $component_data['MustUse'], $component_data );
+			$component_data['MustUse'] = apply_filters( "pods_component_require_{$component_id}", $component_data['MustUse'], $component_data );
 
 			if ( empty( $component_data['MustUse'] ) && ( ! isset( $this->settings['components'][ $component ] ) || 0 === $this->settings['components'][ $component ] ) ) {
 				continue;
@@ -254,7 +254,7 @@ class PodsComponents {
 		foreach ( (array) $this->components as $component => $component_data ) {
 			$component_id = $component_data['ID'];
 
-			$component_data['MustUse'] = apply_filters( 'pods_component_require_' . $component_id, $component_data['MustUse'], $component_data );
+			$component_data['MustUse'] = apply_filters( "pods_component_require_{$component_id}", $component_data['MustUse'], $component_data );
 
 			if ( false === $component_data['MustUse'] && ( ! isset( $this->settings['components'][ $component ] ) || 0 === $this->settings['components'][ $component ] ) ) {
 				continue;
@@ -760,7 +760,7 @@ class PodsComponents {
 		// Cleaning up $params
 		unset( $params->action, $params->component, $params->method, $params->_wpnonce );
 
-		$params = (object) apply_filters( 'pods_component_ajax_' . $component . '_' . $method, $params, $component, $method );
+		$params = (object) apply_filters( "pods_component_ajax_{$component}_{$method}", $params, $component, $method );
 
 		$output = false;
 

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -129,7 +129,7 @@ class PodsForm {
 
 		$output = ob_get_clean();
 
-		return apply_filters( 'pods_form_ui_' . $type, $output, $name, $label, $help, $attributes, $options );
+		return apply_filters( "pods_form_ui_{$type}", $output, $name, $label, $help, $attributes, $options );
 	}
 
 	/**
@@ -168,7 +168,7 @@ class PodsForm {
 
 		$output = ob_get_clean();
 
-		return apply_filters( 'pods_form_ui_' . $type, $output, $name, $message, $attributes, $options );
+		return apply_filters( "pods_form_ui_{$type}", $output, $name, $message, $attributes, $options );
 	}
 
 	/**
@@ -201,7 +201,7 @@ class PodsForm {
 		}
 
 		$options = self::options( $type, $options );
-		$options = apply_filters( 'pods_form_ui_field_' . $type . '_options', $options, $value, $name, $pod, $id );
+		$options = apply_filters( "pods_form_ui_field_{$type}_options", $options, $value, $name, $pod, $id );
 
 		if ( null === $value || ( '' === $value && 'boolean' === $type ) || ( ! empty( $pod ) && empty( $id ) ) ) {
 			$value = self::default_value( $value, $type, $name, $options, $pod, $id );
@@ -216,7 +216,7 @@ class PodsForm {
 			return false;
 		}
 
-		$value           = apply_filters( 'pods_form_ui_field_' . $type . '_value', $value, $name, $options, $pod, $id );
+		$value           = apply_filters( "pods_form_ui_field_{$type}_value", $value, $name, $options, $pod, $id );
 		$form_field_type = self::$field_type;
 
 		ob_start();
@@ -246,7 +246,7 @@ class PodsForm {
 		 *
 		 * @deprecated 2.7.0
 		 */
-		if ( true === apply_filters( 'pods_form_ui_field_' . $type . '_override', false, $name, $value, $options, $pod, $id ) ) {
+		if ( true === apply_filters( "pods_form_ui_field_{$type}_override", false, $name, $value, $options, $pod, $id ) ) {
 			/**
 			 * pods_form_ui_field_{$type} action leaves too much to be done by developer.
 			 *
@@ -287,7 +287,7 @@ class PodsForm {
 		 *
 		 * It is not intended for replacing but augmenting input markup.
 		 */
-		return apply_filters( 'pods_form_ui_field_' . $type, $output, $name, $value, $options, $pod, $id );
+		return apply_filters( "pods_form_ui_field_{$type}", $output, $name, $value, $options, $pod, $id );
 	}
 
 	/**
@@ -468,7 +468,7 @@ class PodsForm {
 	 */
 	public static function attributes( $attributes, $name = null, $type = null, $options = null ) {
 
-		$attributes = (array) apply_filters( 'pods_form_ui_field_' . $type . '_attributes', $attributes, $name, $options );
+		$attributes = (array) apply_filters( "pods_form_ui_field_{$type}_attributes", $attributes, $name, $options );
 
 		foreach ( $attributes as $attribute => $value ) {
 			if ( null === $value ) {
@@ -491,7 +491,7 @@ class PodsForm {
 	 */
 	public static function data( $data, $name = null, $type = null, $options = null ) {
 
-		$data = (array) apply_filters( 'pods_form_ui_field_' . $type . '_data', $data, $name, $options );
+		$data = (array) apply_filters( "pods_form_ui_field_{$type}_data", $data, $name, $options );
 
 		foreach ( $data as $key => $value ) {
 			if ( null === $value ) {
@@ -591,7 +591,7 @@ class PodsForm {
 			$attributes['maxlength'] = $max_length;
 		}
 
-		$attributes = (array) apply_filters( 'pods_form_ui_field_' . $type . '_merge_attributes', $attributes, $name, $options );
+		$attributes = (array) apply_filters( "pods_form_ui_field_{$type}_merge_attributes", $attributes, $name, $options );
 
 		return $attributes;
 	}
@@ -703,7 +703,7 @@ class PodsForm {
 			self::field_loader( $type );
 		}
 
-		$options = apply_filters( 'pods_field_' . $type . '_options', (array) self::$loaded[ $type ]->options(), $type );
+		$options = apply_filters( "pods_field_{$type}_options", (array) self::$loaded[ $type ]->options(), $type );
 
 		$first_field = current( $options );
 
@@ -756,7 +756,7 @@ class PodsForm {
 
 		self::field_loader( $type );
 
-		$options = apply_filters( 'pods_field_' . $type . '_ui_options', (array) self::$loaded[ $type ]->ui_options(), $type );
+		$options = apply_filters( "pods_field_{$type}_ui_options", (array) self::$loaded[ $type ]->ui_options(), $type );
 
 		$first_field = current( $options );
 
@@ -866,7 +866,7 @@ class PodsForm {
 				self::field_loader( $type );
 
 				if ( method_exists( self::$loaded[ $type ], 'options' ) ) {
-					$options = apply_filters( 'pods_field_' . $type . '_options', (array) self::$loaded[ $type ]->options(), $type );
+					$options = apply_filters( "pods_field_{$type}_options", (array) self::$loaded[ $type ]->options(), $type );
 				}
 			}
 		}//end if
@@ -1089,7 +1089,7 @@ class PodsForm {
 			}//end if
 		}//end if
 
-		$value = apply_filters( 'pods_form_display_' . $type, $value, $name, $options, $pod, $id, $traverse );
+		$value = apply_filters( "pods_form_display_{$type}", $value, $name, $options, $pod, $id, $traverse );
 
 		return $value;
 	}
@@ -1115,7 +1115,7 @@ class PodsForm {
 			$regex = self::$loaded[ $type ]->regex( $options );
 		}
 
-		$regex = apply_filters( 'pods_field_' . $type . '_regex', $regex, $options, $type );
+		$regex = apply_filters( "pods_field_{$type}_regex", $regex, $options, $type );
 
 		return $regex;
 	}
@@ -1141,7 +1141,7 @@ class PodsForm {
 			$prepare = self::$loaded[ $type ]->prepare( $options );
 		}
 
-		$prepare = apply_filters( 'pods_field_' . $type . '_prepare', $prepare, $options, $type );
+		$prepare = apply_filters( "pods_field_{$type}_prepare", $prepare, $options, $type );
 
 		return $prepare;
 	}
@@ -1173,7 +1173,7 @@ class PodsForm {
 			$validate = self::$loaded[ $type ]->validate( $value, $name, $options, $fields, $pod, $id, $params );
 		}
 
-		$validate = apply_filters( 'pods_field_' . $type . '_validate', $validate, $value, $name, $options, $fields, $pod, $id, $type, $params );
+		$validate = apply_filters( "pods_field_{$type}_validate", $validate, $value, $name, $options, $fields, $pod, $id, $type, $params );
 
 		return $validate;
 	}

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -254,7 +254,7 @@ class PodsForm {
 			 *
 			 * @deprecated 2.7.0
 			 */
-			do_action( 'pods_form_ui_field_' . $type, $name, $value, $options, $pod, $id );
+			do_action( "pods_form_ui_field_{$type}", $name, $value, $options, $pod, $id );
 		} elseif ( ! empty( $helper ) && 0 < strlen( pods_v( 'code', $helper ) ) && false === strpos( $helper['code'], '$this->' ) && ( ! defined( 'PODS_DISABLE_EVAL' ) || ! PODS_DISABLE_EVAL ) ) {
 			/**
 			 * Input helpers are deprecated and not guaranteed to work properly.
@@ -277,7 +277,7 @@ class PodsForm {
 			 *
 			 * @deprecated 2.7.0
 			 */
-			do_action( 'pods_form_ui_field_' . $type, $name, $value, $options, $pod, $id );
+			do_action( "pods_form_ui_field_{$type}", $name, $value, $options, $pod, $id );
 		}//end if
 
 		$output = ob_get_clean();

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -955,7 +955,7 @@ class PodsInit {
 			 * @param string $taxonomy      Taxonomy name
 			 * @param array  $ct_post_types Associated Post Types
 			 */
-			$options = apply_filters( 'pods_register_taxonomy_' . $taxonomy, $options, $taxonomy, $ct_post_types );
+			$options = apply_filters( "pods_register_taxonomy_{$taxonomy}", $options, $taxonomy, $ct_post_types );
 
 			/**
 			 * Allow filtering of taxonomy options.
@@ -999,7 +999,7 @@ class PodsInit {
 			 * @param array  $options   Post type options
 			 * @param string $post_type Post type name
 			 */
-			$options = apply_filters( 'pods_register_post_type_' . $post_type, $options, $post_type );
+			$options = apply_filters( "pods_register_post_type_{$post_type}", $options, $post_type );
 
 			/**
 			 * Allow filtering of post type options.

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1087,7 +1087,7 @@ class PodsMeta {
 			$pod_type = 'media';
 		}
 
-		do_action( 'pods_meta_' . __FUNCTION__, $post );
+		do_action( 'pods_meta_meta_post', $post );
 
 		$hidden_fields = array();
 
@@ -1163,7 +1163,8 @@ class PodsMeta {
 					$dep_classes = $dep_options['classes'];
 					$dep_data    = $dep_options['data'];
 
-					do_action( 'pods_meta_' . __FUNCTION__ . '_' . $field['name'], $post, $field, $pod );
+					$field_name = $field['name'];
+					do_action( "pods_meta_meta_post_{$field_name}", $post, $field, $pod );
 					?>
 					<tr class="form-field pods-field pods-field-input <?php echo esc_attr( 'pods-form-ui-row-type-' . $field['type'] . ' pods-form-ui-row-name-' . PodsForm::clean( $field['name'], true ) ); ?> <?php echo esc_attr( $dep_classes ); ?>" <?php PodsForm::data( $dep_data ); ?>">
 					<th scope="row" valign="top"><?php echo PodsForm::label( 'pods_meta_' . $field['name'], $field['label'], $field['help'], $field ); ?></th>
@@ -1181,14 +1182,14 @@ class PodsMeta {
 					</td>
 					</tr>
 					<?php
-					do_action( 'pods_meta_' . __FUNCTION__ . '_' . $field['name'] . '_post', $post, $field, $pod );
+					do_action( "pods_meta_meta_post_{$field_name}_post", $post, $field, $pod );
 				}
 			}
 			?>
 		</table>
 
 		<?php
-		do_action( 'pods_meta_' . __FUNCTION__ . '_post', $post );
+		do_action( 'pods_meta_meta_post_post', $post );
 
 		foreach ( $hidden_fields as $hidden_field ) {
 			$field_data = $hidden_field['field'];
@@ -1629,7 +1630,7 @@ class PodsMeta {
 		wp_enqueue_style( 'pods-form' );
 		wp_enqueue_script( 'pods' );
 
-		do_action( 'pods_meta_' . __FUNCTION__, $tag, $taxonomy );
+		do_action( 'pods_meta_meta_taxonomy', $tag, $taxonomy );
 
 		$taxonomy_name = $taxonomy;
 
@@ -1707,7 +1708,7 @@ class PodsMeta {
 			}
 		}
 
-		do_action( 'pods_meta_' . __FUNCTION__ . '_post', $tag, $taxonomy );
+		do_action( 'pods_meta_meta_taxonomy_post', $tag, $taxonomy );
 	}
 
 	/**
@@ -1855,7 +1856,7 @@ class PodsMeta {
 		wp_enqueue_style( 'pods-form' );
 		wp_enqueue_script( 'pods' );
 
-		do_action( 'pods_meta_' . __FUNCTION__, $user_id );
+		do_action( 'pods_meta_meta_user', $user_id );
 
 		$groups = $this->groups_get( 'user', 'user' );
 
@@ -1942,7 +1943,7 @@ class PodsMeta {
 			}
 		}
 
-		do_action( 'pods_meta_' . __FUNCTION__ . '_post', $user_id );
+		do_action( 'pods_meta_meta_user_post', $user_id );
 	}
 
 	/**
@@ -2083,7 +2084,7 @@ class PodsMeta {
 		wp_enqueue_style( 'pods-form' );
 		wp_enqueue_script( 'pods' );
 
-		do_action( 'pods_meta_' . __FUNCTION__, $commenter, $user_identity );
+		do_action( 'pods_meta_meta_comment_new_logged_in', $commenter, $user_identity );
 
 		$groups = $this->groups_get( 'comment', 'comment' );
 
@@ -2141,7 +2142,7 @@ class PodsMeta {
 			}
 		}
 
-		do_action( 'pods_meta_' . __FUNCTION__ . '_post', $commenter, $user_identity );
+		do_action( 'pods_meta_meta_comment_new_logged_in_post', $commenter, $user_identity );
 	}
 
 	/**
@@ -2281,7 +2282,7 @@ class PodsMeta {
 		wp_enqueue_style( 'pods-form' );
 		wp_enqueue_script( 'pods' );
 
-		do_action( 'pods_meta_' . __FUNCTION__, $comment, $metabox );
+		do_action( 'pods_meta_meta_comment', $comment, $metabox );
 
 		$hidden_fields = array();
 
@@ -2346,7 +2347,7 @@ class PodsMeta {
 			echo PodsForm::field( 'pods_meta_' . $field_data['name'], $hidden_field['value'], 'hidden', $field_data );
 		}
 
-		do_action( 'pods_meta_' . __FUNCTION__ . '_post', $comment, $metabox );
+		do_action( 'pods_meta_meta_comment_post', $comment, $metabox );
 	}
 
 	/**

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -780,9 +780,11 @@ class PodsMeta {
 			'priority' => $priority
 		);
 
+		$pod_type = $pod['type'];
+
 		// Filter group data, pass vars separately for reference down the line (in case array changed by other filter)
-		$group = apply_filters( 'pods_meta_group_add_' . $pod['type'] . '_' . $object_name, $group, $pod, $label, $fields );
-		$group = apply_filters( 'pods_meta_group_add_' . $pod['type'], $group, $pod, $label, $fields );
+		$group = apply_filters( "pods_meta_group_add_{$pod_type}_{$object_name}", $group, $pod, $label, $fields );
+		$group = apply_filters( "pods_meta_group_add_{$pod_type}", $group, $pod, $label, $fields );
 		$group = apply_filters( 'pods_meta_group_add', $group, $pod, $label, $fields );
 
 		self::$groups[ $pod['type'] ][ $object_name ][] = $group;
@@ -1476,7 +1478,7 @@ class PodsMeta {
 			}
 		}
 
-		$form_fields = apply_filters( 'pods_meta_' . __FUNCTION__, $form_fields );
+		$form_fields = apply_filters( 'pods_meta_meta_media', $form_fields );
 
 		return $form_fields;
 	}
@@ -2212,7 +2214,7 @@ class PodsMeta {
 			}
 		}
 
-		$form_fields = apply_filters( 'pods_meta_' . __FUNCTION__, $form_fields );
+		$form_fields = apply_filters( 'pods_meta_meta_comment_new', $form_fields );
 
 		return $form_fields;
 	}

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -525,7 +525,8 @@ class PodsUI {
 		// @todo This is also done in setup(), maybe a better / more central way?
 		if ( is_object( $this->pod ) && ! empty( $this->pod->pod_data['options'] ) ) {
 			$pod_options = $this->pod->pod_data['options'];
-			$pod_options = apply_filters( 'pods_advanced_content_type_pod_data_' . $this->pod->pod_data['name'], $pod_options, $this->pod->pod_data['name'] );
+			$pod_name    = $this->pod->pod_data['name'];
+			$pod_options = apply_filters( "pods_advanced_content_type_pod_data_{$pod_name}", $pod_options, $this->pod->pod_data['name'] );
 			$pod_options = apply_filters( 'pods_advanced_content_type_pod_data', $pod_options, $this->pod->pod_data['name'] );
 
 			$this->label = array_merge( $this->label, $pod_options );
@@ -1025,7 +1026,8 @@ class PodsUI {
 
 		if ( is_object( $this->pod ) ) {
 			$pod_data = $this->pod->pod_data;
-			$pod_data = apply_filters( 'pods_advanced_content_type_pod_data_' . $this->pod->pod_data['name'], $pod_data, $this->pod->pod_data['name'] );
+			$pod_name = $this->pod->pod_data['name'];
+			$pod_data = apply_filters( "pods_advanced_content_type_pod_data_{$pod_name}", $pod_data, $this->pod->pod_data['name'] );
 			$pod_data = apply_filters( 'pods_advanced_content_type_pod_data', $pod_data, $this->pod->pod_data['name'] );
 
 			$this->label = array_merge( $this->label, $pod_data['options'] );

--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -363,12 +363,12 @@ class PodsView {
 			}//end if
 
 			if ( $result ) {
-				do_action( 'set_transient_' . $key );
+				do_action( "set_transient_{$key}" );
 				do_action( 'setted_transient', $key );
 			}
 		}//end if
 
-		do_action( 'pods_view_set_' . $cache_mode, $original_key, $value, $expires, $group );
+		do_action( "pods_view_set_{$cache_mode}", $original_key, $value, $expires, $group );
 
 		return $value;
 	}
@@ -450,7 +450,7 @@ class PodsView {
 		} elseif ( 'option-cache' === $cache_mode ) {
 			global $_wp_using_ext_object_cache;
 
-			do_action( 'delete_transient_' . $key, $key );
+			do_action( "delete_transient_{$key}", $key );
 
 			if ( $_wp_using_ext_object_cache ) {
 				$result = wp_cache_delete( $key, ( empty( $group ) ? 'pods_option_cache' : $group ) );
@@ -472,7 +472,7 @@ class PodsView {
 			}
 		}//end if
 
-		do_action( 'pods_view_clear_' . $cache_mode, $original_key, $group );
+		do_action( "pods_view_clear_{$cache_mode}", $original_key, $group );
 
 		return true;
 	}

--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -120,7 +120,7 @@ class PodsView {
 			self::set( 'pods-view-' . $cache_key . $view_id, $output, $expires, $cache_mode, 'pods_view' );
 		}
 
-		$output = apply_filters( 'pods_view_output_' . $cache_key, $output, $view, $data, $expires, $cache_mode );
+		$output = apply_filters( "pods_view_output_{$cache_key}", $output, $view, $data, $expires, $cache_mode );
 		$output = apply_filters( 'pods_view_output', $output, $view, $data, $expires, $cache_mode );
 
 		return $output;
@@ -211,7 +211,7 @@ class PodsView {
 		} elseif ( 'option-cache' === $cache_mode && ! in_array( $cache_mode, $nocache ) ) {
 			global $_wp_using_ext_object_cache;
 
-			$pre = apply_filters( 'pre_transient_' . $key, false );
+			$pre = apply_filters( "pre_transient_{$key}", false );
 
 			if ( false !== $pre ) {
 				$value = $pre;
@@ -263,7 +263,7 @@ class PodsView {
 			}//end if
 
 			if ( false !== $value ) {
-				$value = apply_filters( 'transient_' . $key, $value );
+				$value = apply_filters( "transient_{$key}", $value );
 			}
 		} else {
 			$value = false;
@@ -278,7 +278,7 @@ class PodsView {
 			}
 		}
 
-		$value = apply_filters( 'pods_view_get_' . $cache_mode, $value, $original_key, $group );
+		$value = apply_filters( "pods_view_get_{$cache_mode}", $value, $original_key, $group );
 
 		return $value;
 	}
@@ -335,7 +335,7 @@ class PodsView {
 		} elseif ( 'option-cache' === $cache_mode ) {
 			global $_wp_using_ext_object_cache;
 
-			$value = apply_filters( 'pre_set_transient_' . $key, $value );
+			$value = apply_filters( "pre_set_transient_{$key}", $value );
 
 			if ( $_wp_using_ext_object_cache ) {
 				$result = wp_cache_set( $key, $value, ( empty( $group ) ? 'pods_option_cache' : $group ) );

--- a/classes/fields/code.php
+++ b/classes/fields/code.php
@@ -114,7 +114,7 @@ class PodsField_Code extends PodsField {
 
 		$field_type = 'codemirror';
 
-		do_action( 'pods_form_ui_field_code_' . $field_type, $name, $value, $options, $pod, $id );
+		do_action( "pods_form_ui_field_code_{$field_type}", $name, $value, $options, $pod, $id );
 		do_action( 'pods_form_ui_field_code', $field_type, $name, $value, $options, $pod, $id );
 
 		pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -58,6 +58,8 @@ class PodsField_File extends PodsField {
 			$image_sizes[ $size ] = ucwords( str_replace( '-', ' ', $size ) );
 		}
 
+		$type = static::$type;
+
 		$options = array(
 			static::$type . '_format_type'            => array(
 				'label'      => __( 'Upload Limit', 'pods' ),
@@ -74,7 +76,8 @@ class PodsField_File extends PodsField {
 				'default'    => 'attachment',
 				'type'       => 'pick',
 				'data'       => apply_filters(
-					'pods_form_ui_field_' . static::$type . '_uploader_options', array(
+					"pods_form_ui_field_{$type}_uploader_options",
+					array(
 						'attachment' => __( 'Upload and/or Select (Media Library)', 'pods' ),
 						'plupload'   => __( 'Upload only (Plupload)', 'pods' ),
 					)
@@ -122,10 +125,11 @@ class PodsField_File extends PodsField {
 			),
 			static::$type . '_type'                   => array(
 				'label'      => __( 'Restrict File Types', 'pods' ),
-				'default'    => apply_filters( 'pods_form_ui_field_' . static::$type . '_type_default', 'images' ),
+				'default'    => apply_filters( "pods_form_ui_field_{$type}_type_default", 'images' ),
 				'type'       => 'pick',
 				'data'       => apply_filters(
-					'pods_form_ui_field_' . static::$type . '_type_options', array(
+					"pods_form_ui_field_{$type}_type_options",
+					array(
 						'images' => __( 'Images (jpg, jpeg, png, gif)', 'pods' ),
 						'video'  => __( 'Video (mpg, mov, flv, mp4, etc..)', 'pods' ),
 						'audio'  => __( 'Audio (mp3, m4a, wav, wma, etc..)', 'pods' ),
@@ -140,17 +144,18 @@ class PodsField_File extends PodsField {
 				'label'       => __( 'Allowed File Extensions', 'pods' ),
 				'description' => __( 'Separate file extensions with a comma (ex. jpg,png,mp4,mov)', 'pods' ),
 				'depends-on'  => array( static::$type . '_type' => 'other' ),
-				'default'     => apply_filters( 'pods_form_ui_field_' . static::$type . '_extensions_default', '' ),
+				'default'     => apply_filters( "pods_form_ui_field_{$type}_extensions_default", '' ),
 				'type'        => 'text',
 			),
 			static::$type . '_field_template'         => array(
 				'label'      => __( 'List Style', 'pods' ),
 				'help'       => __( 'You can choose which style you would like the files to appear within the form.', 'pods' ),
 				'depends-on' => array( static::$type . '_type' => 'images' ),
-				'default'    => apply_filters( 'pods_form_ui_field_' . static::$type . '_template_default', 'rows' ),
+				'default'    => apply_filters( "pods_form_ui_field_{$type}_template_default", 'rows' ),
 				'type'       => 'pick',
 				'data'       => apply_filters(
-					'pods_form_ui_field_' . static::$type . '_type_templates', array(
+					"pods_form_ui_field_{$type}_type_templates",
+					array(
 						'rows'  => __( 'Rows', 'pods' ),
 						'tiles' => __( 'Tiles', 'pods' ),
 					)
@@ -652,7 +657,8 @@ class PodsField_File extends PodsField {
 			$value = array( $value );
 		}
 
-		$image_size = apply_filters( 'pods_form_ui_field_' . static::$type . '_ui_image_size', 'thumbnail', $id, $value, $name, $options, $pod );
+		$type       = static::$type;
+		$image_size = apply_filters( "pods_form_ui_field_{$type}_ui_image_size", 'thumbnail', $id, $value, $name, $options, $pod );
 
 		return $this->images( $id, $value, $name, $options, $pod, $image_size );
 
@@ -710,7 +716,7 @@ class PodsField_File extends PodsField {
 			$data[ $image_size ] = ucwords( str_replace( '-', ' ', $image_size ) );
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_image_sizes', $data, $name, $value, $options, $pod, $id );
 
 	}
 

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -2569,7 +2569,7 @@ class PodsField_Pick extends PodsField {
 			$data[ $post_status->name ] = $post_status->label;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_post_stati', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -2596,7 +2596,7 @@ class PodsField_Pick extends PodsField {
 			$data[ $key ] = $wp_roles->role_names[ $key ];
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_roles', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -2700,7 +2700,7 @@ class PodsField_Pick extends PodsField {
 			$data[ $capability ] = $capability;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_capabilities', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -2727,7 +2727,7 @@ class PodsField_Pick extends PodsField {
 			$data[ $image_size ] = ucwords( str_replace( '-', ' ', $image_size ) );
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_image_sizes', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -3013,7 +3013,7 @@ class PodsField_Pick extends PodsField {
 			'AX' => __( 'Åland Islands' ),
 		);
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_countries', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -3086,7 +3086,7 @@ class PodsField_Pick extends PodsField {
 			'WY' => __( 'Wyoming' ),
 		);
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_us_states', $data, $name, $value, $options, $pod, $id );
 
 	}
 
@@ -3121,7 +3121,7 @@ class PodsField_Pick extends PodsField {
 			'YT' => __( 'Yukon' ),
 		);
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_ca_provinces', $data, $name, $value, $options, $pod, $id );
 
 	}
 

--- a/classes/fields/wysiwyg.php
+++ b/classes/fields/wysiwyg.php
@@ -240,7 +240,8 @@ class PodsField_WYSIWYG extends PodsField {
 			$field_type = 'cleditor';
 		} else {
 			// Support custom WYSIWYG integration
-			do_action( 'pods_form_ui_field_wysiwyg_' . pods_v( static::$type . '_editor', $options ), $name, $value, $options, $pod, $id );
+			$editor_type = pods_v( static::$type . '_editor', $options );
+			do_action( "pods_form_ui_field_wysiwyg_{$editor_type}", $name, $value, $options, $pod, $id );
 			do_action( 'pods_form_ui_field_wysiwyg', pods_v( static::$type . '_editor', $options ), $name, $value, $options, $pod, $id );
 
 			return;

--- a/components/Advanced-Relationships.php
+++ b/components/Advanced-Relationships.php
@@ -115,7 +115,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 			$data[ $theme->Template ] = $theme->Name;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_themes', $data, $name, $value, $options, $pod, $id );
 	}
 
 	/**
@@ -157,7 +157,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 			$data[ $page_template_file ] = $page_template;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_page_templates', $data, $name, $value, $options, $pod, $id );
 	}
 
 	/**
@@ -185,7 +185,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 			}
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_sidebars', $data, $name, $value, $options, $pod, $id );
 	}
 
 	/**
@@ -217,7 +217,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 			$data[ $post_type->name ] = $post_type->label;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_post_types', $data, $name, $value, $options, $pod, $id );
 	}
 
 	/**
@@ -249,7 +249,7 @@ class Pods_Advanced_Relationships extends PodsComponent {
 			$data[ $taxonomy->name ] = $taxonomy->label;
 		}
 
-		return apply_filters( 'pods_form_ui_field_pick_' . __FUNCTION__, $data, $name, $value, $options, $pod, $id );
+		return apply_filters( 'pods_form_ui_field_pick_data_taxonomies', $data, $name, $value, $options, $pod, $id );
 	}
 
 }

--- a/components/Helpers.php
+++ b/components/Helpers.php
@@ -510,10 +510,12 @@ class Pods_Helpers extends PodsComponent {
 			}
 		}//end if
 
+		$slug = $helper['slug'];
+
 		$out = ob_get_clean();
 
 		$out = apply_filters( 'pods_helpers_post_helper', $out, $params, $helper );
-		$out = apply_filters( "pods_helpers_post_helper_{$helper['slug']}", $out, $params, $helper );
+		$out = apply_filters( "pods_helpers_post_helper_{$slug}", $out, $params, $helper );
 
 		return $out;
 	}

--- a/components/Helpers.php
+++ b/components/Helpers.php
@@ -513,7 +513,7 @@ class Pods_Helpers extends PodsComponent {
 		$out = ob_get_clean();
 
 		$out = apply_filters( 'pods_helpers_post_helper', $out, $params, $helper );
-		$out = apply_filters( 'pods_helpers_post_helper_' . $helper['slug'], $out, $params, $helper );
+		$out = apply_filters( "pods_helpers_post_helper_{$helper['slug']}", $out, $params, $helper );
 
 		return $out;
 	}

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -518,8 +518,10 @@ class Pods_Templates extends PodsComponent {
 			}
 		}
 
+		$slug = $template['slug'];
+
 		$code = apply_filters( 'pods_templates_pre_template', $code, $template, $obj );
-		$code = apply_filters( 'pods_templates_pre_template_' . $template['slug'], $code, $template, $obj );
+		$code = apply_filters( "pods_templates_pre_template_{$slug}", $code, $template, $obj );
 
 		ob_start();
 
@@ -553,7 +555,7 @@ class Pods_Templates extends PodsComponent {
 		$out = ob_get_clean();
 
 		$out = apply_filters( 'pods_templates_post_template', $out, $code, $template, $obj );
-		$out = apply_filters( 'pods_templates_post_template_' . $template['slug'], $out, $code, $template, $obj );
+		$out = apply_filters( "pods_templates_post_template_{$slug}", $out, $code, $template, $obj );
 
 		return $out;
 	}

--- a/includes/data.php
+++ b/includes/data.php
@@ -785,7 +785,7 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				$output = apply_filters( 'pods_var_post_id', $post_id, $default, $var, $strict, $params );
 				break;
 			default:
-				$output = apply_filters( 'pods_var_' . $type, $default, $var, $strict, $params );
+				$output = apply_filters( "pods_var_{$type}", $default, $var, $strict, $params );
 		}//end switch
 	}//end if
 
@@ -973,7 +973,7 @@ function pods_v_set( $value, $var, $type = 'get' ) {
 				$ret = $pods->save( $var, $value );
 			}
 		} else {
-			$ret = apply_filters( 'pods_var_set_' . $type, $value, $var );
+			$ret = apply_filters( "pods_var_set_{$type}", $value, $var );
 		}//end if
 	}//end if
 

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -15,7 +15,7 @@ if ( ! isset( $duplicate ) ) {
 $groups = PodsInit::$meta->groups_get( $pod->pod_data['type'], $pod->pod_data['name'], $fields );
 
 $pod_options = $pod->pod_data['options'];
-$pod_options = apply_filters( 'pods_advanced_content_type_pod_data_' . $pod->pod_data['name'], $pod_options, $pod->pod_data['name'] );
+$pod_options = apply_filters( "pods_advanced_content_type_pod_data_{$pod->pod_data['name']}", $pod_options, $pod->pod_data['name'] );
 $pod_options = apply_filters( 'pods_advanced_content_type_pod_data', $pod_options, $pod->pod_data['name'] );
 
 $group_fields       = array();

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -14,8 +14,9 @@ if ( ! isset( $duplicate ) ) {
 
 $groups = PodsInit::$meta->groups_get( $pod->pod_data['type'], $pod->pod_data['name'], $fields );
 
+$pod_name    = $pod->pod_data['name'];
 $pod_options = $pod->pod_data['options'];
-$pod_options = apply_filters( "pods_advanced_content_type_pod_data_{$pod->pod_data['name']}", $pod_options, $pod->pod_data['name'] );
+$pod_options = apply_filters( "pods_advanced_content_type_pod_data_{$pod_name}", $pod_options, $pod->pod_data['name'] );
 $pod_options = apply_filters( 'pods_advanced_content_type_pod_data', $pod_options, $pod->pod_data['name'] );
 
 $group_fields       = array();

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -85,7 +85,9 @@ foreach ( $pod[ 'fields' ] as $_field => $_data ) {
     }
 }
 
-$field_defaults = apply_filters( 'pods_field_defaults', apply_filters( 'pods_field_defaults_' . $pod[ 'name' ], $field_defaults, $pod ) );
+$pod_name = $pod[ 'name' ];
+
+$field_defaults = apply_filters( 'pods_field_defaults', apply_filters( "pods_field_defaults_{$pod_name}", $field_defaults, $pod ) );
 
 $pick_table = pods_transient_get( 'pods_tables' );
 
@@ -115,9 +117,9 @@ $field_settings = array(
     'sister_id' => array( '' => __( 'No Related Fields Found', 'pods' ) )
 );
 
-$field_settings = apply_filters( 'pods_field_settings', apply_filters( 'pods_field_settings_' . $pod[ 'name' ], $field_settings, $pod ) );
+$field_settings = apply_filters( 'pods_field_settings', apply_filters( "pods_field_settings_{$pod_name}", $field_settings, $pod ) );
 
-$pod[ 'fields' ] = apply_filters( 'pods_fields_edit', apply_filters( 'pods_fields_edit_' . $pod[ 'name' ], $pod[ 'fields' ], $pod ) );
+$pod[ 'fields' ] = apply_filters( 'pods_fields_edit', apply_filters( "pods_fields_edit_{$pod_name}", $pod[ 'fields' ], $pod ) );
 
 global $wpdb;
 $max_length_name = 64;


### PR DESCRIPTION
## Description
PHPCS: Convert filter and action hook names to be interpolated

Where the value was stored in something other than a scalar variable, a scalar variable has been added nearby with the value assigned. This keeps the name of the hooks cleaner.

See #4992.

I've not added commits to adjust existing interpolated hook names to scalar variables. These can be added if desired.

## Types of changes
Coding standards / improved generated documentation.

## ChangeLog
Improvement: Use interpolated hook names, per WPCS, #4992 (@GaryJones)

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
