### PR TITLE
PHPCS: Fix Squiz.PHP.DisallowMultipleAssignments

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1697,9 +1697,12 @@ class PodsAPI {
 			$params = pods_sanitize( $params );
 		}
 
-		$old_id = $old_name = $old_storage = null;
+		$old_id      = null;
+		$old_name    = null;
+		$old_storage = null;
 
-		$old_fields = $old_options = array();
+		$old_fields  = array();
+		$old_options = array();
 
 		if ( isset( $params->name ) && ! isset( $params->object ) ) {
 			$params->name = pods_clean_name( $params->name );
@@ -2175,7 +2178,8 @@ class PodsAPI {
 				$built_in[ $built_in_type ][ $built_in_object ] = (int) $val;
 			}
 
-			$lookup_option = $lookup_built_in = false;
+			$lookup_option   = false;
+			$lookup_built_in = false;
 
 			$lookup_name = $pod['name'];
 
@@ -2476,7 +2480,13 @@ class PodsAPI {
 
 		unset( $params->pod_data );
 
-		$old_id = $old_name = $old_type = $old_definition = $old_simple = $old_options = $old_sister_id = null;
+		$old_id         = null;
+		$old_name       = null;
+		$old_type       = null;
+		$old_definition = null;
+		$old_simple     = null;
+		$old_options    = null;
+		$old_sister_id  = null;
 
 		if ( ! empty( $field ) ) {
 			$old_id        = pods_var( 'id', $field );
@@ -2634,7 +2644,8 @@ class PodsAPI {
 		$object_fields = (array) pods_var_raw( 'object_fields', $pod, array(), null, true );
 
 		if ( 0 < $old_id && defined( 'PODS_FIELD_STRICT' ) && ! PODS_FIELD_STRICT ) {
-			$params->id = $field['id'] = $old_id;
+			$params->id  = $old_id;
+			$field['id'] = $old_id;
 		}
 
 		// Add new field
@@ -3517,7 +3528,8 @@ class PodsAPI {
 		$active_columns     =& $fields_active; // @deprecated 2.0.0
 		$params->tbl_row_id =& $params->id; // @deprecated 2.0.0
 
-		$pre_save_helpers = $post_save_helpers = array();
+		$pre_save_helpers  = array();
+		$post_save_helpers = array();
 
 		$pieces = array(
 			'fields',
@@ -3601,7 +3613,11 @@ class PodsAPI {
 			}
 		}
 
-		$table_data = $table_formats = $update_values = $rel_fields = $rel_field_ids = array();
+		$table_data    = array();
+		$table_formats = array();
+		$update_values = array();
+		$rel_fields    = array();
+		$rel_field_ids = array();
 
 		$object_type = $pod['type'];
 
@@ -3613,7 +3629,9 @@ class PodsAPI {
 			$object_ID = 'term_id';
 		}
 
-		$object_data = $object_meta = $post_term_data = array();
+		$object_data    = array();
+		$object_meta    = array();
+		$post_term_data = array();
 
 		if ( 'settings' === $object_type ) {
 			$object_data['option_id'] = $pod['name'];
@@ -3644,7 +3662,10 @@ class PodsAPI {
 				 && isset( $_POST['icl_ajx_action'] ) && isset( $_POST['_icl_nonce'] )
 				 && wp_verify_nonce( $_POST['_icl_nonce'], $_POST['icl_ajx_action'] . '_nonce' ) )
 			) {
-				$options['unique'] = $fields[ $field ]['options']['unique'] = $options['required'] = $fields[ $field ]['options']['required'] = 0;
+				$options['unique']                       = 0;
+				$fields[ $field ]['options']['unique']   = 0;
+				$options['required']                     = 0;
+				$fields[ $field ]['options']['required'] = 0;
 			} else {
 				// Validate value
 				$validate = $this->handle_field_validation( $value, $field, $object_fields, $fields, $pod, $params );
@@ -4341,7 +4362,8 @@ class PodsAPI {
 			}
 		}
 
-		$related_pod_id = $related_field_id = 0;
+		$related_pod_id   = 0;
+		$related_field_id = 0;
 
 		if ( 'pick' === $field['type'] && isset( PodsField_Pick::$related_data[ $field['id'] ] ) && ! empty( PodsField_Pick::$related_data[ $field['id'] ]['related_field'] ) ) {
 			$related_pod_id   = PodsField_Pick::$related_data[ $field['id'] ]['related_pod']['id'];
@@ -5494,7 +5516,8 @@ class PodsAPI {
 			$bypass_helpers = true;
 		}
 
-		$pre_delete_helpers = $post_delete_helpers = array();
+		$pre_delete_helpers  = array();
+		$post_delete_helpers = array();
 
 		if ( false === $bypass_helpers ) {
 			// Plugin hook
@@ -5827,7 +5850,8 @@ class PodsAPI {
 
 		if ( ! empty( $params->id ) || ! empty( $params->name ) ) {
 			if ( ! isset( $params->name ) ) {
-				$pod = get_post( $dummy = (int) $params->id );
+				$dummy = (int) $params->id;
+				$pod   = get_post( $dummy );
 			} else {
 				$pod = get_posts( array(
 					'name'           => $params->name,
@@ -6034,7 +6058,8 @@ class PodsAPI {
 			}
 
 			if ( ! isset( $params->name ) ) {
-				$pod = get_post( $dummy = (int) $params->id );
+				$dummy = (int) $params->id;
+				$pod   = get_post( $dummy );
 			} else {
 				$pod = get_posts( array(
 					'name'           => $params->name,
@@ -6543,7 +6568,8 @@ class PodsAPI {
 
 		if ( ( ! empty( $params->id ) || ! empty( $params->name ) ) && isset( $params->pod_id ) && ! empty( $params->pod_id ) ) {
 			if ( ! isset( $params->name ) ) {
-				$field = get_post( $dummy = (int) $params->id );
+				$dummy = (int) $params->id;
+				$field = get_post( $dummy );
 			} else {
 				$field = get_posts( array(
 					'name'           => $params->name,
@@ -6597,7 +6623,8 @@ class PodsAPI {
 		if ( isset( $params->post_title ) ) {
 			$_field = $params;
 		} elseif ( isset( $params->id ) && ! empty( $params->id ) ) {
-			$_field = get_post( $dumb = (int) $params->id );
+			$dummy = (int) $params->id;
+			$_field = get_post( $dummy );
 		} else {
 			if ( ! isset( $params->pod ) ) {
 				$params->pod = '';
@@ -8091,10 +8118,14 @@ class PodsAPI {
 			$info['type'] = 'pod';
 			global $wpdb;
 
-			$info['table'] = $info['meta_table'] = $wpdb->prefix . 'pods_' . ( empty( $object ) ? $name : $object );
+			$info['meta_table'] = $wpdb->prefix . 'pods_' . ( empty( $object ) ? $name : $object );
+			$info['table']      = $info['meta_table'];
 
 			if ( is_array( $info['pod'] ) && 'pod' === pods_v( 'type', $info['pod'] ) ) {
-				$info['pod_field_index'] = $info['field_index'] = $info['meta_field_index'] = $info['meta_field_value'] = pods_v( 'pod_index', $info['pod']['options'], 'id', true );
+				$info['meta_field_value'] = pods_v( 'pod_index', $info['pod']['options'], 'id', true );
+				$info['pod_field_index']  = $info['meta_field_value'];
+				$info['field_index']      = $info['meta_field_value'];
+				$info['meta_field_index'] = $info['meta_field_value'];
 
 				$slug_field = get_posts( array(
 					'post_type'      => '_pods_field',
@@ -8114,7 +8145,8 @@ class PodsAPI {
 				if ( ! empty( $slug_field[0] ) ) {
 					$slug_field = $slug_field[0];
 
-					$info['field_slug'] = $info['pod_field_slug'] = $slug_field->post_name;
+					$info['pod_field_slug'] = $slug_field->post_name;
+					$info['field_slug']     = $slug_field->post_name;
 				}
 
 				if ( 1 == pods_v( 'hierarchical', $info['pod']['options'], 0 ) ) {
@@ -8123,7 +8155,8 @@ class PodsAPI {
 					if ( ! empty( $parent_field ) && isset( $info['pod']['fields'][ $parent_field ] ) ) {
 						$info['object_hierarchical'] = true;
 
-						$info['pod_field_parent']    = $info['field_parent'] = $parent_field . '_select';
+						$info['field_parent']        = $parent_field . '_select';
+						$info['pod_field_parent']    = $info['field_parent'];
 						$info['field_parent_select'] = '`' . $parent_field . '`.`id` AS `' . $info['field_parent'] . '`';
 					}
 				}
@@ -8221,8 +8254,9 @@ class PodsAPI {
 
 		$transient = 'pods_' . $wpdb->prefix . '_get_table_info_' . md5( $object_type . '_object_' . $object . '_name_' . $name . '_pod_' . $pod_name . '_field_' . $field_name );
 
-		$current_language      = false;
-		$current_language_t_id = $current_language_tt_id = 0;
+		$current_language       = false;
+		$current_language_t_id  = 0;
+		$current_language_tt_id = 0;
 
 		// Get current language data
 		$lang_data = PodsInit::$i18n->get_current_language_data();
@@ -8399,12 +8433,16 @@ class PodsAPI {
 				'nav_menu',
 				'post_format'
 			) ) || 'taxonomy' === pods_var_raw( 'type', $info['pod'] ) ) {
-			$info['table'] = $info['meta_table'] = $wpdb->terms;
+			$info['table']      = $wpdb->terms;
+			$info['meta_table'] = $wpdb->terms;
 
 			$info['join']['tt']          = "LEFT JOIN `{$wpdb->term_taxonomy}` AS `tt` ON `tt`.`term_id` = `t`.`term_id`";
 			$info['join']['tr']          = "LEFT JOIN `{$wpdb->term_relationships}` AS `tr` ON `tr`.`term_taxonomy_id` = `tt`.`term_taxonomy_id`";
-			$info['field_id']            = $info['meta_field_id'] = 'term_id';
-			$info['field_index']         = $info['meta_field_index'] = $info['meta_field_value'] = 'name';
+			$info['meta_field_id']       = 'term_id';
+			$info['field_id']            = 'term_id';
+			$info['meta_field_value']    = 'name';
+			$info['field_index']         = 'name';
+			$info['meta_field_index']    = 'name';
 			$info['field_slug']          = 'slug';
 			$info['field_type']          = 'taxonomy';
 			$info['field_parent']        = 'parent';
@@ -8597,7 +8635,9 @@ class PodsAPI {
 			if ( ! empty( $field ) && is_array( $field ) ) {
 				$info['table']       = pods_var_raw( 'pick_table', pods_var_raw( 'options', $field, $field ) );
 				$info['field_id']    = pods_var_raw( 'pick_table_id', pods_var_raw( 'options', $field, $field ) );
-				$info['field_index'] = $info['meta_field_index'] = $info['meta_field_value'] = pods_var_raw( 'pick_table_index', pods_var_raw( 'options', $field, $field ) );
+				$info['meta_field_value'] = pods_var_raw( 'pick_table_index', pods_var_raw( 'options', $field, $field ) );
+				$info['field_index']      = $info['meta_field_value'];
+				$info['meta_field_index'] = $info['meta_field_value'];
 			}
 		}
 

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -638,11 +638,13 @@ class PodsData {
 		}
 
 		$wheres        = array();
-		$where_formats = $where_format = (array) $where_format;
+		$where_format  = (array) $where_format;
+		$where_formats = $where_format;
 
 		foreach ( (array) array_keys( $where ) as $field ) {
 			if ( ! empty( $where_format ) ) {
-				$form = ( $form = array_shift( $where_formats ) ) ? $form : $where_format[0];
+				$form = array_shift( $where_formats );
+				$form = $form ? $form : $where_format[0];
 			} elseif ( isset( self::$field_types[ $field ] ) ) {
 				$form = self::$field_types[ $field ];
 			} elseif ( isset( $wpdb->field_types[ $field ] ) ) {
@@ -678,7 +680,8 @@ class PodsData {
 
 		global $wpdb;
 
-		$cache_key = $results = false;
+		$cache_key = false;
+		$results   = false;
 
 		/**
 		 * Filter select parameters before the query
@@ -1103,7 +1106,8 @@ class PodsData {
 		// Search.
 		if ( ! empty( $params->search ) && ! empty( $params->fields ) ) {
 			if ( false !== $params->search_query && 0 < strlen( $params->search_query ) ) {
-				$where = $having = array();
+				$where  = array();
+				$having = array();
 
 				if ( false !== $params->search_across ) {
 					foreach ( $params->fields as $key => $field ) {
@@ -1222,7 +1226,8 @@ class PodsData {
 
 			// Filter.
 			foreach ( $params->filters as $filter ) {
-				$where = $having = array();
+				$where  = array();
+				$having = array();
 
 				if ( ! isset( $params->fields[ $filter ] ) ) {
 					continue;
@@ -1376,13 +1381,17 @@ class PodsData {
 
 			preg_match_all( '/`?[\w\-]+`?(?:\\.`?[\w\-]+`?)+(?=[^"\']*(?:"[^"]*"[^"]*|\'[^\']*\'[^\']*)*$)/', $haystack, $found, PREG_PATTERN_ORDER );
 
-			$found = (array) @current( $found );
-			$find  = $replace = $traverse = array();
+			$found    = (array) @current( $found );
+			$find     = array();
+			$replace  = array();
+			$traverse = array();
 
 			foreach ( $found as $key => $value ) {
 				$value = str_replace( '`', '', $value );
 				$value = explode( '.', $value );
-				$dot   = $last_value = array_pop( $value );
+
+				$last_value = array_pop( $value );
+				$dot        = $last_value;
 
 				if ( 't' === $value[0] ) {
 					continue;
@@ -2058,7 +2067,9 @@ class PodsData {
 					$filter = 'raw';
 					$term   = $id;
 
-					if ( 'id' !== $mode || ! $_term = wp_cache_get( $term, $taxonomy ) ) {
+					$_term = wp_cache_get( $term, $taxonomy );
+
+					if ( 'id' !== $mode || ! $_term ) {
 						$_term = $wpdb->get_row( $wpdb->prepare( "SELECT t.*, tt.* FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy = %s AND {$term_where} LIMIT 1", $taxonomy, $term ) );
 
 						if ( $_term ) {

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -236,7 +236,8 @@ class PodsForm {
 
 		// @todo Move into DFV field method or PodsObject later
 		if ( ( ! isset( $options['data'] ) || empty( $options['data'] ) ) && is_object( self::$loaded[ $type ] ) && method_exists( self::$loaded[ $type ], 'data' ) ) {
-			$data = $options['data'] = self::$loaded[ $type ]->data( $name, $value, $options, $pod, $id, true );
+			$options['data'] = self::$loaded[ $type ]->data( $name, $value, $options, $pod, $id, true );
+			$data            = $options['data'];
 		}
 
 		/**
@@ -914,9 +915,12 @@ class PodsForm {
 	 */
 	public static function dependencies( $options, $prefix = '' ) {
 
-		$options    = (array) $options;
-		$classes    = $data = array();
-		$depends_on = $excludes_on = $wildcard_on = array();
+		$options     = (array) $options;
+		$classes     = array();
+		$data        = array();
+		$depends_on  = array();
+		$excludes_on = array();
+		$wildcard_on = array();
 
 		if ( isset( $options['depends-on'] ) ) {
 			$depends_on = (array) $options['depends-on'];

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -499,8 +499,10 @@ class PodsInit {
 				'taxonomies' => array(),
 			);
 
-			$pods_post_types      = $pods_taxonomies = array();
-			$supported_post_types = $supported_taxonomies = array();
+			$pods_post_types      = array();
+			$pods_taxonomies      = array();
+			$supported_post_types = array();
+			$supported_taxonomies = array();
 
 			$post_format_post_types = array();
 

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -329,7 +329,7 @@ class PodsMeta {
 				pods_transient_set( 'pods_pod_' . $pod_name, $pod );
 			}
 
-			self::$$type = array_merge( self::$$type, $objects );
+			self::${$type} = array_merge( self::${$type}, $objects );
 		}
 	}
 
@@ -491,13 +491,17 @@ class PodsMeta {
 		}
 
 		if ( in_array( $type, array( 'wp-links', 'link' ), true ) ) {
-			$object_type = $object = 'link';
+			$object_type = 'link';
+			$object      = 'link';
 		} elseif ( in_array( $type, array( 'wp-media', 'media' ), true ) ) {
-			$object_type = $object = 'media';
+			$object_type = 'media';
+			$object      = 'media';
 		} elseif ( in_array( $type, array( 'wp-users', 'user' ), true ) ) {
-			$object_type = $object = 'user';
+			$object_type = 'user';
+			$object      = 'user';
 		} elseif ( in_array( $type, array( 'wp-comments', 'comment' ), true ) ) {
-			$object_type = $object = 'comment';
+			$object_type = 'comment';
+			$object      = 'comment';
 		} elseif ( 'taxonomy' === $type ) {
 			$object_type = 'taxonomy';
 			if ( ! $obj ) {
@@ -586,13 +590,17 @@ class PodsMeta {
 		}
 
 		if ( in_array( $type, array( 'wp-links', 'link' ), true ) ) {
-			$object_type = $object = 'link';
+			$object_type = 'link';
+			$object      = 'link';
 		} elseif ( in_array( $type, array( 'wp-media', 'media' ), true ) ) {
-			$object_type = $object = 'media';
+			$object_type = 'media';
+			$object      = 'media';
 		} elseif ( in_array( $type, array( 'wp-users', 'user' ), true ) ) {
-			$object_type = $object = 'user';
+			$object_type = 'user';
+			$object      = 'user';
 		} elseif ( in_array( $type, array( 'wp-comments', 'comment' ), true ) ) {
-			$object_type = $object = 'comment';
+			$object_type = 'comment';
+			$object      = 'comment';
 		} elseif ( 'taxonomy' === $type ) {
 			$object_type = 'taxonomy';
 			if ( ! method_exists( $obj, 'get_taxonomy' ) ) {

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1692,7 +1692,7 @@ class PodsUI {
 						array(
 							'action' . $this->num => 'add',
 							'id' . $this->num     => '',
-							'do' . $this->num = '',
+							'do' . $this->num     => '',
 						), self::$allowed, $this->exclusion()
 					);
 
@@ -2006,7 +2006,7 @@ class PodsUI {
 						array(
 							'action' . $this->num => 'add',
 							'id' . $this->num     => '',
-							'do' . $this->num = '',
+							'do' . $this->num     => '',
 						), self::$allowed, $this->exclusion()
 					);
 
@@ -2234,7 +2234,8 @@ class PodsUI {
 						continue;
 					}
 
-					if ( $callback = $this->callback( 'delete', $id ) ) {
+					$callback = $this->callback( 'delete', $id );
+					if ( $callback ) {
 						$check = $callback;
 					} elseif ( is_object( $this->pod ) ) {
 						$check = $this->pod->delete( $id );
@@ -2450,7 +2451,8 @@ class PodsUI {
 		$value = null;
 
 		// use PodsData to get field
-		if ( $callback = $this->callback( 'get_field', $field ) ) {
+		$callback = $this->callback( 'get_field', $field );
+		if ( $callback ) {
 			return $callback;
 		}
 
@@ -3357,7 +3359,9 @@ class PodsUI {
 
 							$data_filter = 'filter_' . $filter;
 
-							$start = $end = $value_label = '';
+							$start       = '';
+							$end         = '';
+							$value_label = '';
 
 							if ( in_array( $filter_field['type'], array( 'date', 'datetime', 'time' ) ) ) {
 								$start = pods_var_raw( 'filter_' . $filter . '_start', 'get', '', null, true );
@@ -4441,8 +4445,10 @@ class PodsUI {
 	 */
 	public function screen_meta() {
 
-		$screen_html = $help_html = '';
-		$screen_link = $help_link = '';
+		$screen_html = '';
+		$help_html   = '';
+		$screen_link = '';
+		$help_link   = '';
 		if ( ! empty( $this->screen_options ) && ! empty( $this->help ) ) {
 			foreach ( $this->ui_page as $page ) {
 				if ( isset( $this->screen_options[ $page ] ) ) {
@@ -4771,7 +4777,8 @@ class PodsUI {
 			$value = call_user_func_array( $tag[1], array( $value, $field_name, $this->row, &$this ) );
 		}
 
-		$before = $after = '';
+		$before = '';
+		$after  = '';
 
 		if ( isset( $tag[2] ) && ! empty( $tag[2] ) ) {
 			$before = $tag[2];

--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -406,7 +406,8 @@ class PodsView {
 			$group_key = $group . '_';
 		}
 
-		$full_key = $original_key = $key;
+		$full_key     = $key;
+		$original_key = $key;
 
 		if ( true !== $key ) {
 			// Get proper cache key

--- a/components/Migrate-Packages/Migrate-Packages.php
+++ b/components/Migrate-Packages/Migrate-Packages.php
@@ -384,12 +384,13 @@ class Pods_Migrate_Packages extends PodsComponent {
 					}
 
 					if ( isset( $existing_fields[ $field['name'] ] ) ) {
-						if ( $existing_field = pods_api()->load_field(
+						$existing_field = pods_api()->load_field(
 							array(
 								'name' => $field['name'],
 								'pod'  => $pod['name'],
 							)
-						) ) {
+						);
+						if ( $existing_field ) {
 							$pod['fields'][ $k ]['id'] = $existing_field['id'];
 						}
 					}

--- a/components/Roles/Roles.php
+++ b/components/Roles/Roles.php
@@ -176,7 +176,9 @@ class Pods_Roles extends PodsComponent {
 
 		$capabilities = $this->get_capabilities();
 
-		$role_name = $role_label = $role_capabilities = null;
+		$role_name         = null;
+		$role_label        = null;
+		$role_capabilities = null;
 
 		foreach ( $wp_roles->role_objects as $key => $role ) {
 			if ( $key != $id ) {

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -404,7 +404,9 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknow
 
 			$field_name = $tag[0];
 
-			$helper_name = $before = $after = '';
+			$helper_name = '';
+			$before      = '';
+			$after       = '';
 
 			if ( isset( $data[ $field_name ] ) ) {
 				$value = $data[ $field_name ];

--- a/deprecated/classes/Pods.php
+++ b/deprecated/classes/Pods.php
@@ -147,7 +147,9 @@ class Pods_Deprecated {
 					$pick_val    = $pick_pod['name'];
 				}
 
-				$pick_table = $pick_join = $pick_where = '';
+				$pick_table = '';
+				$pick_join  = '';
+				$pick_where = '';
 
 				$pick_field_id   = 'id';
 				$pick_field_name = 'name';

--- a/deprecated/list_filters.php
+++ b/deprecated/list_filters.php
@@ -22,7 +22,9 @@
 					$pick_object = $pick_pod['type'];
 					$pick_val    = $pick_pod['object'];
 				}
-				$pick_table     = $pick_join = $pick_where = '';
+				$pick_table     = '';
+				$pick_join      = '';
+				$pick_where     = '';
 				$pick_column_id = 'id';
 				switch ( $pick_object ) {
 					case 'pod':

--- a/includes/data.php
+++ b/includes/data.php
@@ -403,7 +403,8 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				$output = get_stylesheet_directory_uri();
 				break;
 			case 'site-url':
-				$blog_id = $scheme = null;
+				$blog_id = null;
+				$scheme  = null;
 				$path    = '';
 
 				if ( is_array( $var ) ) {
@@ -421,7 +422,8 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				$output = get_site_url( $blog_id, $path, $scheme );
 				break;
 			case 'home-url':
-				$blog_id = $scheme = null;
+				$blog_id = null;
+				$scheme  = null;
 				$path    = '';
 
 				if ( is_array( $var ) ) {
@@ -439,7 +441,8 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				$output = get_home_url( $blog_id, $path, $scheme );
 				break;
 			case 'admin-url':
-				$blog_id = $scheme = null;
+				$blog_id = null;
+				$scheme  = null;
 				$path    = '';
 
 				if ( is_array( $var ) ) {
@@ -463,7 +466,8 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 				$output = content_url( $var );
 				break;
 			case 'plugins-url':
-				$path = $plugin = '';
+				$path   = '';
+				$plugin = '';
 
 				if ( is_array( $var ) ) {
 					if ( isset( $var[0] ) ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -777,7 +777,8 @@ function pods_shortcode( $tags, $content = null ) {
 
 			if ( ! empty( $pod ) ) {
 				$tags['name'] = get_post_type();
-				$id           = $tags['id'] = get_the_ID();
+				$id           = get_the_ID();
+				$tags['id']   = get_the_ID();
 			}
 		}
 

--- a/includes/media.php
+++ b/includes/media.php
@@ -210,7 +210,9 @@ function pods_attachment_import( $url, $post_parent = null, $featured = false ) 
 
 	$title = substr( $filename, 0, ( strrpos( $filename, '.' ) ) );
 
-	if ( ! ( ( $uploads = wp_upload_dir( current_time( 'mysql' ) ) ) && false === $uploads['error'] ) ) {
+	$uploads = wp_upload_dir( current_time( 'mysql' ) );
+
+	if ( ! ( $uploads && false === $uploads['error'] ) ) {
 		return 0;
 	}
 
@@ -252,7 +254,7 @@ function pods_attachment_import( $url, $post_parent = null, $featured = false ) 
 	require_once ABSPATH . 'wp-admin/includes/media.php';
 	require_once ABSPATH . 'wp-admin/includes/image.php';
 
-	wp_update_attachment_metadata( $attachment_id, $meta_data = wp_generate_attachment_metadata( $attachment_id, $new_file ) );
+	wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $new_file ) );
 
 	if ( 0 < $post_parent && $featured ) {
 		update_post_meta( $post_parent, '_thumbnail_id', $attachment_id );

--- a/sql/update-2.0-beta.php
+++ b/sql/update-2.0-beta.php
@@ -140,7 +140,8 @@ if ( version_compare( $pods_version, '2.0.0-b-14', '<' ) ) {
 
 		$sql = explode( ";\n", str_replace( array( "\r", 'wp_' ), array( "\n", $wpdb->prefix ), $sql ) );
 
-		for ( $i = 0, $z = count( $sql ); $i < $z; $i ++ ) {
+		$z = count( $sql );
+		for ( $i = 0; $i < $z; $i ++ ) {
 			$query = trim( $sql[ $i ] );
 
 			if ( empty( $query ) ) {

--- a/sql/upgrade/PodsUpgrade.php
+++ b/sql/upgrade/PodsUpgrade.php
@@ -77,7 +77,8 @@ class PodsUpgrade {
 
 			$sql = explode( ";\n", str_replace( array( "\r", 'wp_' ), array( "\n", $wpdb->prefix ), $sql ) );
 
-			for ( $i = 0, $z = count( $sql ); $i < $z; $i ++ ) {
+			$z = count( $sql );
+			for ( $i = 0; $i < $z; $i ++ ) {
 				$query = trim( $sql[ $i ] );
 
 				if ( empty( $query ) ) {

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -396,9 +396,12 @@ class Pods_UnitTestCase extends \WP_UnitTestCase {
 	 */
 	public function go_to( $url ) {
 
-		$GLOBALS['_SERVER']['REQUEST_URI'] = $url = str_replace( network_home_url(), '', $url );
+		$url = str_replace( network_home_url(), '', $url );
 
-		$_GET = $_POST = array();
+		$GLOBALS['_SERVER']['REQUEST_URI'] = $url;
+
+		$_GET  = array();
+		$_POST = array();
 
 		foreach (
 			array(

--- a/tests/phpunit/includes/tests-traversal.php
+++ b/tests/phpunit/includes/tests-traversal.php
@@ -734,7 +734,8 @@ class Test_Traversal extends Pods_UnitTestCase {
 		$podsrel_field_id = $field['id'];
 		$podsrel_item_id  = $data['id'];
 
-		$prefix = $suffix = '';
+		$prefix = '';
+		$suffix = '';
 
 		if ( in_array( $field_type, array( 'pick', 'taxonomy', 'avatar', 'author' ) ) ) {
 			if ( ! isset( self::$related_items[ $field_name ] ) ) {
@@ -831,7 +832,8 @@ class Test_Traversal extends Pods_UnitTestCase {
 					$related_pod_storage_type = 'meta';
 				}
 
-				$related_prefix = $related_suffix = '';
+				$related_prefix = '';
+				$related_suffix = '';
 
 				$related_where = array();
 
@@ -1324,7 +1326,8 @@ class Test_Traversal extends Pods_UnitTestCase {
 						$this->assertEquals( $check_display_index, $p->display( $related_traverse_index ), sprintf( 'Deep Related Item index field display value not as expected (%s) [%s]', $related_traverse_index, $variant_id ) );
 					}//end if
 				} elseif ( 'none' !== $related_pod_storage_type ) {
-					$check_related_value = $check_related_value_display = '';
+					$check_related_value         = '';
+					$check_related_value_display = '';
 
 					if ( isset( $related_data['data'][ $related_pod_field['name'] ] ) ) {
 						$check_related_value = $related_data['data'][ $related_pod_field['name'] ];

--- a/ui/admin/setup-edit-field-fluid.php
+++ b/ui/admin/setup-edit-field-fluid.php
@@ -42,7 +42,8 @@ $pick_object = trim( pods_v_sanitized( 'pick_object', $field ) . '-' . pods_v_sa
 								continue;
 							}
 
-							$class = $extra_classes = '';
+							$class         = '';
+							$extra_classes = '';
 
 							$tab = sanitize_title( $tab );
 

--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -48,7 +48,8 @@ if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array
 		'00:00:00',
 	), true
 ) ) {
-	$formatted_date = $value = '';
+	$formatted_date = '';
+	$value          = '';
 } elseif ( 'text' !== $type ) {
 	$formatted_date = $value;
 

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -72,7 +72,8 @@ if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array
 		'00:00:00',
 	), true
 ) ) {
-	$formatted_date = $value = '';
+	$formatted_date = '';
+	$value          = '';
 } elseif ( 'text' !== $type ) {
 	$formatted_date = $value;
 

--- a/ui/fields/slider.php
+++ b/ui/fields/slider.php
@@ -20,7 +20,8 @@ $values[0] = max( $values[0], pods_var( $form_field_type . '_min', $options, 0 )
 $values[1] = min( $values[1], pods_var( $form_field_type . '_min', $options, 100 ) );
 
 if ( 0 == pods_var( $form_field_type . '_range', $options, 0 ) ) {
-	$output_value = $value = $values[0];
+	$value        = $values[0];
+	$output_value = $value;
 } else {
 	$value        = implode( ',', $values );
 	$output_value = implode( ' - ', $values );

--- a/ui/fields/time.php
+++ b/ui/fields/time.php
@@ -52,7 +52,8 @@ if ( 1 == pods_var( $form_field_type . '_allow_empty', $options, 1 ) && in_array
 		'00:00:00',
 	), true
 ) ) {
-	$formatted_date = $value = '';
+	$formatted_date = '';
+	$value          = '';
 } elseif ( 'text' !== $type ) {
 	$formatted_date = $value;
 


### PR DESCRIPTION
## Description

Fixes: #5021 

Fixes a total of 102 errors and 0 warnings found in 24 files.

This sniff checks for assignments that are not the first block of code on a line - typically chained setting of variables, or assignment inside conditions.

See #3181.

## Screenshots (jpeg or gifs if applicable):

Before:

![screenshot 2018-06-08 18 36 10](https://user-images.githubusercontent.com/88371/41172178-ec17a804-6b4a-11e8-8874-1aa3b97d2061.png)


After:

![screenshot 2018-06-08 18 32 11](https://user-images.githubusercontent.com/88371/41172031-6d2888ec-6b4a-11e8-84b3-f9a8fb5849bb.png)


## Types of changes
Code standards.

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
