### PR TITLE
Add _total and _total_found special fields

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -917,26 +917,12 @@ class Pods implements Iterator {
 		} elseif ( in_array( $params->name, array(
 			'_total',
 			'_total_found',
-			'_total_s',
-			'_total_found_s',
 		), true ) ) {
 			// Handle total values.
 			if ( '_total' === $params->name ) {
 				$value = $this->total();
 			} elseif ( '_total_found' === $params->name ) {
 				$value = $this->total_found();
-			} elseif ( '_total_s' === $params->name ) {
-				$value = '';
-
-				if ( 1 !== $this->total() ) {
-					$value = 's';
-				}
-			} elseif ( '_total_found_s' === $params->name ) {
-				$value = '';
-
-				if ( 1 !== $this->total_found() ) {
-					$value = 's';
-				}
 			}
 		}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -902,6 +902,7 @@ class Pods implements Iterator {
 			'user',
 			'comment',
 		), true ) ) ) {
+			// Handle detail page links.
 			if ( 0 < strlen( $this->detail_page ) ) {
 				$value = get_home_url() . '/' . $this->do_magic_tags( $this->detail_page );
 			} elseif ( in_array( $this->pod_data['type'], array( 'post_type', 'media' ), true ) ) {
@@ -912,6 +913,30 @@ class Pods implements Iterator {
 				$value = get_author_posts_url( $this->id() );
 			} elseif ( 'comment' === $this->pod_data['type'] ) {
 				$value = get_comment_link( $this->id() );
+			}
+		} elseif ( in_array( $params->name, array(
+			'_total',
+			'_total_found',
+			'_total_s',
+			'_total_found_s',
+		), true ) ) {
+			// Handle total values.
+			if ( '_total' === $params->name ) {
+				$value = $this->total();
+			} elseif ( '_total_found' === $params->name ) {
+				$value = $this->total_found();
+			} elseif ( '_total_s' === $params->name ) {
+				$value = '';
+
+				if ( 1 !== $this->total() ) {
+					$value = 's';
+				}
+			} elseif ( '_total_found_s' === $params->name ) {
+				$value = '';
+
+				if ( 1 !== $this->total_found() ) {
+					$value = 's';
+				}
 			}
 		}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1014,7 +1014,7 @@ class Pods implements Iterator {
 			}
 
 			$value = $this->row[ $params->name ];
-		} elseif ( empty( $value ) ) {
+		} elseif ( null !== $value ) {
 			$object_field_found = false;
 
 			if ( 'object_field' === $field_type ) {

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -964,7 +964,7 @@ class Pods implements Iterator {
 			$params->output = 'arrays';
 		}
 
-		if ( empty( $value ) && in_array( $field_data['type'], $tableless_field_types, true ) ) {
+		if ( null === $value && in_array( $field_data['type'], $tableless_field_types, true ) ) {
 			$params->raw = true;
 
 			$value = false;
@@ -982,7 +982,7 @@ class Pods implements Iterator {
 			}
 		}
 
-		if ( empty( $value ) && isset( $this->row[ $params->name ] ) && ( ! in_array( $field_data['type'], $tableless_field_types, true ) || 'arrays' === $params->output ) ) {
+		if ( in_array( $value, array( false, null ), true ) && isset( $this->row[ $params->name ] ) && ( ! in_array( $field_data['type'], $tableless_field_types, true ) || 'arrays' === $params->output ) ) {
 			if ( empty( $field_data ) || in_array( $field_data['type'], array(
 				'boolean',
 				'number',
@@ -1000,7 +1000,7 @@ class Pods implements Iterator {
 			}
 
 			$value = $this->row[ $params->name ];
-		} elseif ( null !== $value ) {
+		} elseif ( in_array( $value, array( false, null ), true ) ) {
 			$object_field_found = false;
 
 			if ( 'object_field' === $field_type ) {

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -915,11 +915,14 @@ class Pods implements Iterator {
 				$value = get_comment_link( $this->id() );
 			}
 		} elseif ( in_array( $params->name, array(
+			'_position',
 			'_total',
 			'_total_found',
 		), true ) ) {
-			// Handle total values.
-			if ( '_total' === $params->name ) {
+			// Handle special values.
+			if ( '_position' === $params->name ) {
+				$value = $this->position();
+			} elseif ( '_total' === $params->name ) {
 				$value = $this->total();
 			} elseif ( '_total_found' === $params->name ) {
 				$value = $this->total_found();

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -581,6 +581,8 @@ class Pods_Templates extends PodsComponent {
 
 		$code = trim( $code );
 
+		$code = apply_filters( 'pods_templates_pre_do_template', $code, $obj );
+
 		if ( false !== strpos( $code, '<?' ) && ( ! defined( 'PODS_DISABLE_EVAL' ) || ! PODS_DISABLE_EVAL ) ) {
 			pods_deprecated( 'Pod Template PHP code has been deprecated, please use WP Templates instead of embedding PHP.', '2.3' );
 

--- a/components/Templates/class-pods_templates.php
+++ b/components/Templates/class-pods_templates.php
@@ -42,16 +42,6 @@ class Pods_Templates_Frontier {
 	/**
 	 * @var      array
 	 */
-	protected $element_instances = array();
-
-	/**
-	 * @var      array
-	 */
-	protected $element_css_once = array();
-
-	/**
-	 * @var      array
-	 */
 	protected $elements = array();
 
 	/**
@@ -67,7 +57,6 @@ class Pods_Templates_Frontier {
 		add_filter( 'pods_templates_pre_template', 'frontier_prefilter_template', 25, 4 );
 		// Load admin style sheet and JavaScript.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_stylescripts' ), 20 );
-		add_action( 'wp_footer', array( $this, 'footer_scripts' ) );
 		add_action( 'init', array( $this, 'activate_metaboxes' ) );
 	}
 
@@ -95,65 +84,18 @@ class Pods_Templates_Frontier {
 
 		$screen = get_current_screen();
 
-		if ( ! isset( $this->plugin_screen_hook_suffix ) ) {
-			return;
-		}
-
-		if ( in_array( $screen->id, $this->plugin_screen_hook_suffix, true ) ) {
-			$slug = array_search( $screen->id, $this->plugin_screen_hook_suffix );
-			// $configfiles = glob( $this->get_path( __FILE__ ) .'configs/'.$slug.'-*.php' );
-			if ( file_exists( $this->get_path( __FILE__ ) . 'configs/fieldgroups-' . $slug . '.php' ) ) {
-				include $this->get_path( __FILE__ ) . 'configs/fieldgroups-' . $slug . '.php';
-			}
-
-			if ( ! empty( $configfiles ) ) {
-
-				foreach ( $configfiles as $key => $fieldfile ) {
-					include $fieldfile;
-					if ( ! empty( $group['scripts'] ) ) {
-						foreach ( $group['scripts'] as $script ) {
-							wp_enqueue_script( $this->plugin_slug . '-' . strtok( $script, '.' ), $this->get_url( 'assets/js/' . $script, __FILE__ ), array( 'jquery' ) );
-						}
-					}
-					if ( ! empty( $group['styles'] ) ) {
-						foreach ( $group['styles'] as $style ) {
-							wp_enqueue_style( $this->plugin_slug . '-' . strtok( $style, '.' ), $this->get_url( 'assets/css/' . $style, __FILE__ ) );
-						}
-					}
-				}
-			}
-			wp_enqueue_style( $this->plugin_slug . '-admin-styles', $this->get_url( 'assets/css/panel.css', __FILE__ ), array(), self::VERSION );
+		if ( $screen && $screen->id === $this->plugin_screen_hook_suffix ) {
+			wp_enqueue_style( $this->plugin_slug . '-admin-styles', self::get_url( 'assets/css/panel.css', __FILE__ ), array(), self::VERSION );
 			wp_enqueue_style( 'pods-codemirror' );
-			wp_enqueue_script( $this->plugin_slug . '-admin-scripts', $this->get_url( 'assets/js/panel.js', __FILE__ ), array(), self::VERSION );
+			wp_enqueue_script( $this->plugin_slug . '-admin-scripts', self::get_url( 'assets/js/panel.js', __FILE__ ), array(), self::VERSION );
 			wp_enqueue_script( 'pods_codemirror' );
 			wp_enqueue_script( 'pods-codemirror-overlay' );
 			wp_enqueue_script( 'pods-codemirror-hints' );
-			wp_enqueue_script( $this->plugin_slug . '-cm-editor', $this->get_url( 'assets/js/editor1.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
+			wp_enqueue_script( $this->plugin_slug . '-cm-editor', self::get_url( 'assets/js/editor1.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
 			wp_enqueue_script( 'pods-codemirror-mode-xml' );
 			wp_enqueue_script( 'pods-codemirror-mode-html' );
 			wp_enqueue_script( 'pods-codemirror-mode-css' );
 		}//end if
-
-	}
-
-	/**
-	 * Process a field value
-	 *
-	 * @param $type
-	 * @param $value
-	 *
-	 * @return mixed
-	 */
-	public function process_value( $type, $value ) {
-
-		switch ( $type ) {
-			default:
-				return $value;
-				break;
-
-		}
-
-		return $value;
 
 	}
 
@@ -180,27 +122,28 @@ class Pods_Templates_Frontier {
 	public function add_metaboxes( $slug, $post = false ) {
 
 		if ( ! empty( $post ) ) {
-			if ( ! in_array( $post->post_type, array( '_pods_template' ), true ) ) {
+			if ( ! '_pods_template' === $post->post_type ) {
 				return;
 			}
 		} else {
 			$screen = get_current_screen();
-			if ( ! in_array( $screen->base, array( '_pods_template' ), true ) ) {
+
+			if ( $screen && '_pods_template' !== $screen->base ) {
 				return;
 			}
 		}
 
-		$this->plugin_screen_hook_suffix[ $slug ] = $slug;
+		$this->plugin_screen_hook_suffix = $slug;
 
 		// Required Styles for metabox
-		wp_enqueue_style( $this->plugin_slug . '-view_template-styles', $this->get_url( 'assets/css/styles-view_template.css', __FILE__ ), array(), self::VERSION );
+		wp_enqueue_style( $this->plugin_slug . '-view_template-styles', self::get_url( 'assets/css/styles-view_template.css', __FILE__ ), array(), self::VERSION );
 
 		// Required scripts for metabox
 		wp_enqueue_script( 'jquery-ui-resizable' );
-		wp_enqueue_script( $this->plugin_slug . '-handlebarsjs', $this->get_url( 'assets/js/handlebars2.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
-		wp_enqueue_script( $this->plugin_slug . '-baldrickjs', $this->get_url( 'assets/js/jquery.baldrick3.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
-		wp_enqueue_script( $this->plugin_slug . '-handlebars-baldrick', $this->get_url( 'assets/js/handlebars.baldrick2.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
-		wp_enqueue_style( $this->plugin_slug . '-pod_reference-styles', $this->get_url( 'assets/css/styles-pod_reference.css', __FILE__ ), array(), self::VERSION );
+		wp_enqueue_script( $this->plugin_slug . '-handlebarsjs', self::get_url( 'assets/js/handlebars2.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
+		wp_enqueue_script( $this->plugin_slug . '-baldrickjs', self::get_url( 'assets/js/jquery.baldrick3.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
+		wp_enqueue_script( $this->plugin_slug . '-handlebars-baldrick', self::get_url( 'assets/js/handlebars.baldrick2.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
+		wp_enqueue_style( $this->plugin_slug . '-pod_reference-styles', self::get_url( 'assets/css/styles-pod_reference.css', __FILE__ ), array(), self::VERSION );
 
 		// add metabox
 		add_meta_box(
@@ -247,18 +190,18 @@ class Pods_Templates_Frontier {
 			$content = '';
 		}
 
-		if ( file_exists( $this->get_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.php' ) ) {
-			include $this->get_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.php';
-		} elseif ( file_exists( $this->get_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.html' ) ) {
-			include $this->get_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.html';
+		if ( file_exists( plugin_dir_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.php' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.php';
+		} elseif ( file_exists( plugin_dir_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.html' ) ) {
+			include plugin_dir_path( __FILE__ ) . 'includes/element-' . $args['args']['slug'] . '.html';
 		}
 		// add script
-		if ( file_exists( $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.php' ) ) {
+		if ( file_exists( plugin_dir_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.php' ) ) {
 			echo "<script type=\"text/javascript\">\r\n";
-			include $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.php';
+			include plugin_dir_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.php';
 			echo "</script>\r\n";
-		} elseif ( file_exists( $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.js' ) ) {
-			wp_enqueue_script( $this->plugin_slug . '-' . $args['args']['slug'] . '-script', $this->get_url( 'assets/js/scripts-' . $args['args']['slug'] . '.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
+		} elseif ( file_exists( plugin_dir_path( __FILE__ ) . 'assets/js/scripts-' . $args['args']['slug'] . '.js' ) ) {
+			wp_enqueue_script( $this->plugin_slug . '-' . $args['args']['slug'] . '-script', self::get_url( 'assets/js/scripts-' . $args['args']['slug'] . '.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
 		}
 
 	}
@@ -281,7 +224,7 @@ class Pods_Templates_Frontier {
 		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 			return $post->ID;
 		}
-		if ( $post->post_type == 'revision' ) {
+		if ( 'revision' === $post->post_type ) {
 			return;
 		}
 
@@ -292,198 +235,6 @@ class Pods_Templates_Frontier {
 
 			delete_post_meta( $post->ID, $prefix );
 			add_post_meta( $post->ID, $prefix, $_POST[ $prefix ] );
-		}
-	}
-
-	/**
-	 * create and register an instance ID
-	 *
-	 * @param $id
-	 * @param $process
-	 *
-	 * @return string
-	 */
-	public function element_instance_id( $id, $process ) {
-
-		$this->element_instances[ $id ][ $process ][] = true;
-		$count                                        = count( $this->element_instances[ $id ][ $process ] );
-		if ( $count > 1 ) {
-			return $id . ( $count - 1 );
-		}
-
-		return $id;
-	}
-
-	/**
-	 * Render the element
-	 *
-	 * @param      $atts
-	 * @param      $content
-	 * @param      $slug
-	 * @param bool    $head
-	 *
-	 * @return string|void
-	 */
-	public function render_element( $atts, $content, $slug, $head = false ) {
-
-		$raw_atts = $atts;
-
-		if ( ! empty( $head ) ) {
-			$instanceID = $this->element_instance_id( 'pods_templates' . $slug, 'header' );
-		} else {
-			$instanceID = $this->element_instance_id( 'pods_templates' . $slug, 'footer' );
-		}
-
-		// $configfiles = glob($this->get_path( __FILE__ ) .'configs/'.$slug.'-*.php');
-		if ( file_exists( $this->get_path( __FILE__ ) . 'configs/fieldgroups-' . $slug . '.php' ) ) {
-			include $this->get_path( __FILE__ ) . 'configs/fieldgroups-' . $slug . '.php';
-
-			$defaults = array();
-			foreach ( $configfiles as $file ) {
-
-				include $file;
-				foreach ( $group['fields'] as $variable => $conf ) {
-					if ( ! empty( $group['multiple'] ) ) {
-						$value = array( $this->process_value( $conf['type'], $conf['default'] ) );
-					} else {
-						$value = $this->process_value( $conf['type'], $conf['default'] );
-					}
-					if ( ! empty( $group['multiple'] ) ) {
-						if ( isset( $atts[ $variable . '_1' ] ) ) {
-							$index = 1;
-							$value = array();
-							while ( isset( $atts[ $variable . '_' . $index ] ) ) {
-								$value[] = $this->process_value( $conf['type'], $atts[ $variable . '_' . $index ] );
-								$index ++;
-							}
-						} elseif ( isset( $atts[ $variable ] ) ) {
-							if ( is_array( $atts[ $variable ] ) ) {
-								foreach ( $atts[ $variable ] as &$varval ) {
-									$varval = $this->process_value( $conf['type'], $varval );
-								}
-								$value = $atts[ $variable ];
-							} else {
-								$value[] = $this->process_value( $conf['type'], $atts[ $variable ] );
-							}
-						}
-					} else {
-						if ( isset( $atts[ $variable ] ) ) {
-							$value = $this->process_value( $conf['type'], $atts[ $variable ] );
-						}
-					}//end if
-
-					if ( ! empty( $group['multiple'] ) && ! empty( $value ) ) {
-						foreach ( $value as $key => $val ) {
-							$groups[ $group['master'] ][ $key ][ $variable ] = $val;
-						}
-					}
-					$defaults[ $variable ] = $value;
-				}//end foreach
-			}//end foreach
-			$atts = $defaults;
-		}//end if
-
-		// pull in the assets
-		$assets = array();
-		if ( file_exists( $this->get_path( __FILE__ ) . 'assets/assets-' . $slug . '.php' ) ) {
-			include $this->get_path( __FILE__ ) . 'assets/assets-' . $slug . '.php';
-		}
-
-		ob_start();
-		if ( file_exists( $this->get_path( __FILE__ ) . 'includes/element-' . $slug . '.php' ) ) {
-			include $this->get_path( __FILE__ ) . 'includes/element-' . $slug . '.php';
-		} else {
-			if ( file_exists( $this->get_path( __FILE__ ) . 'includes/element-' . $slug . '.html' ) ) {
-				include $this->get_path( __FILE__ ) . 'includes/element-' . $slug . '.html';
-			}
-		}
-		$out = ob_get_clean();
-
-		if ( ! empty( $head ) ) {
-
-			// process headers - CSS
-			if ( file_exists( $this->get_path( __FILE__ ) . 'assets/css/styles-' . $slug . '.php' ) ) {
-				ob_start();
-				include $this->get_path( __FILE__ ) . 'assets/css/styles-' . $slug . '.php';
-				$this->element_header_styles[] = ob_get_clean();
-				add_action( 'wp_head', array( $this, 'header_styles' ) );
-			} else {
-				if ( file_exists( $this->get_path( __FILE__ ) . 'assets/css/styles-' . $slug . '.css' ) ) {
-					wp_enqueue_style( $this->plugin_slug . '-' . $slug . '-styles', $this->get_url( 'assets/css/styles-' . $slug . '.css', __FILE__ ), array(), self::VERSION );
-				}
-			}
-			// process headers - JS
-			if ( file_exists( $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $slug . '.php' ) ) {
-				ob_start();
-				include $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $slug . '.php';
-				$this->element_footer_scripts[] = ob_get_clean();
-			} else {
-				if ( file_exists( $this->get_path( __FILE__ ) . 'assets/js/scripts-' . $slug . '.js' ) ) {
-					wp_enqueue_script( $this->plugin_slug . '-' . $slug . '-script', $this->get_url( 'assets/js/scripts-' . $slug . '.js', __FILE__ ), array( 'jquery' ), self::VERSION, true );
-				}
-			}
-			// get clean do shortcode for header checking
-			ob_start();
-			pods_do_shortcode(
-				$out, array(
-					'each',
-					'pod_sub_template',
-					'once',
-					'pod_once_template',
-					'before',
-					'pod_before_template',
-					'after',
-					'pod_after_template',
-					'if',
-					'pod_if_field',
-				)
-			);
-			ob_get_clean();
-
-			return;
-		}//end if
-
-		return pods_do_shortcode(
-			$out, array(
-				'each',
-				'pod_sub_template',
-				'once',
-				'pod_once_template',
-				'before',
-				'pod_before_template',
-				'after',
-				'pod_after_template',
-				'if',
-				'pod_if_field',
-			)
-		);
-	}
-
-	/**
-	 * Render any header styles
-	 */
-	public function header_styles() {
-
-		if ( ! empty( $this->element_header_styles ) ) {
-			echo "<style type=\"text/css\">\r\n";
-			foreach ( $this->element_header_styles as $styles ) {
-				echo $styles . "\r\n";
-			}
-			echo "</style>\r\n";
-		}
-	}
-
-	/**
-	 * Render any footer scripts
-	 */
-	public function footer_scripts() {
-
-		if ( ! empty( $this->element_footer_scripts ) ) {
-			echo "<script type=\"text/javascript\">\r\n";
-			foreach ( $this->element_footer_scripts as $script ) {
-				echo $script . "\r\n";
-			}
-			echo "</script>\r\n";
 		}
 	}
 
@@ -503,20 +254,6 @@ class Pods_Templates_Frontier {
 		}
 
 		return trailingslashit( plugins_url( $path, __FILE__ ) );
-	}
-
-	/**
-	 *
-	 * Get the current URL
-	 *
-	 * @param null $src
-	 *
-	 * @return string
-	 */
-	public static function get_path( $src = null ) {
-
-		return plugin_dir_path( $src );
-
 	}
 
 }

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -242,7 +242,13 @@ function frontier_template_once_blocks( $atts, $code ) {
 		$frontier_once_hashes = array();
 	}
 
-	$blockhash = md5( $code . $atts['id'] );
+	$id = '';
+
+	if ( ! empty( $atts['id'] ) ) {
+		$id = $atts['id'];
+	}
+
+	$blockhash = md5( trim( $code . $id ) );
 	if ( in_array( $blockhash, $frontier_once_hashes, true ) ) {
 		return '';
 	}

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Utility function for processesing fromtier based templates
+ * Utility function for processing frontier based templates
  *
  * @package Pods_Frontier_Template_Editor\view_template
  */
 
 // add filters
 add_filter( 'pods_templates_post_template', 'frontier_end_template', 25, 4 );
-add_filter( 'pods_templates_do_template', 'frontier_do_shortcode', 25, 1 );
+add_filter( 'pods_templates_do_template', 'frontier_do_shortcode', 25, 3 );
 
 // template shortcode handlers
 add_shortcode( 'pod_sub_template', 'frontier_do_subtemplate' );
@@ -40,12 +40,14 @@ function frontier_get_shortcodes() {
 }
 
 /**
- * @param $content
+ * @param string $content Content.
+ * @param string $code    Template code.
+ * @param Pods   $pod     Pods object.
  *
  * @return string
  * @since 2.4.3
  */
-function frontier_do_shortcode( $content ) {
+function frontier_do_shortcode( $content, $code, $pod ) {
 
 	$content = pods_do_shortcode( $content, frontier_get_shortcodes() );
 
@@ -268,8 +270,17 @@ function frontier_template_once_blocks( $atts, $code ) {
  */
 function frontier_do_subtemplate( $atts, $content ) {
 
-	$out        = null;
-	$pod        = pods( $atts['pod'], $atts['id'] );
+	if ( empty( $atts['pod'] ) || empty( $atts['id'] ) ) {
+		return '';
+	}
+
+	$out = null;
+	$pod = pods( $atts['pod'], $atts['id'] );
+
+	if ( ! $pod || ! $pod->valid() || ! $pod->exists() || empty( $atts['field'] ) ) {
+		return '';
+	}
+
 	$field_name = $atts['field'];
 
 	$entries = $pod->field( $field_name );
@@ -461,10 +472,12 @@ function frontier_pseudo_magic_tags( $template, $data, $pod = null, $skip_unknow
 /**
  * processes template code within an each command from the base template
  *
- * @param array attributes from template
- * @param string template to be processed
+ * @param string $code     Template code to be processed.
+ * @param array  $template Attributes from template.
+ * @param Pods   $pod      Pod object.
  *
- * @return null
+ * @return string
+ *
  * @since 2.4.0
  */
 function frontier_prefilter_template( $code, $template, $pod ) {

--- a/tests/phpunit/includes/Shortcodes/Test_After.php
+++ b/tests/phpunit/includes/Shortcodes/Test_After.php
@@ -18,13 +18,6 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 	public static function wpSetUpBeforeClass() {
 
-		add_shortcode(
-			'test_after_recurse', function ( $args, $content ) {
-
-				return do_shortcode( $content );
-			}
-		);
-
 		self::$pod_id = pods_api()->save_pod(
 			array(
 				'storage' => 'meta',
@@ -51,138 +44,73 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		pods_api()->save_field( $params );
 
-		$params = array(
-			'pod'              => self::$pod_name,
-			'pod_id'           => self::$pod_id,
-			'name'             => 'related_field',
-			'type'             => 'pick',
-			'pick_object'      => 'post_type',
-			'pick_val'         => self::$pod_name,
-			'pick_format_type' => 'multi',
-		);
-
-		pods_api()->save_field( $params );
-
 	}
 
 	public static function wpTearDownAfterClass() {
 
-		if ( shortcode_exists( 'test_after_recurse' ) ) {
-			remove_shortcode( 'test_after_recurse' );
-		}
 		pods_api()->delete_pod( array( 'id' => self::$pod_id ) );
 
-	}
-
-	public function test_psuedo_shortcodes() {
-
-		// Make sure our pseudo shortcodes are working properly
-		$this->assertEquals( 'abc123', do_shortcode( '[test_after_recurse]abc123[/test_after_recurse]' ) );
 	}
 
 	public function test_after_simple() {
 
 		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+
+		$pod = pods( $pod_name );
+
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
 				'number1'       => 123,
 				'number2'       => 456,
-				'related_field' => $sub_ids,
 			)
 		);
-		$content = base64_encode( '{@number1}_{@number2}' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+
+		$pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'secondary post',
+				'number1'       => 321,
+				'number2'       => 654,
+			)
+		);
+
+		$content = '{@number1}. [after]Done[/after]';
+
+		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+
+		$this->assertEquals( '123. 321. Done', $shortcode_output );
 	}
 
-	public function test_after_with_nested_if() {
+	public function test_after_magic_tags() {
 
 		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+
+		$pod = pods( $pod_name );
+
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
 				'number1'       => 123,
 				'number2'       => 456,
-				'related_field' => $sub_ids,
 			)
 		);
-		$content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
-		// Testing [after] inside [if]
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template]" );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
 
-		// Testing [after] inside [if] with [else]
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
-
-		// Testing [after] inside [if] with [else] and no relationships
-		$main_id       = $pod->add(
-			array(
-				'post_status' => 'publish',
-				'name'        => 'post with no related fields',
-				'number1'     => 123,
-				'number2'     => 456,
-			)
-		);
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
-		$this->assertEquals( 'No related field', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
-	}
-
-	public function test_after_nested_in_external() {
-
-		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
-				'name'          => 'main post',
-				'number1'       => 123,
-				'number2'       => 456,
-				'related_field' => $sub_ids,
+				'name'          => 'secondary post',
+				'number1'       => 321,
+				'number2'       => 654,
 			)
 		);
-		$content = base64_encode( '{@number1}_{@number2}' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[test_after_recurse][pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template][/test_after_recurse]" ) );
+
+		$content = '{@number1}. [after]Total records: {@_total}[/after]';
+
+		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+
+		$this->assertEquals( '123. 321. Total Records: 2', $shortcode_output );
 	}
 }

--- a/tests/phpunit/includes/Shortcodes/Test_After.php
+++ b/tests/phpunit/includes/Shortcodes/Test_After.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Pods_Unit_Tests\Shortcodes;
+
+/**
+ * Class Test_After
+ *
+ * @package Pods_Unit_Tests
+ * @group   pods_acceptance_tests
+ * @group   pods-shortcodes
+ * @group   pods-shortcodes-after
+ */
+class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
+
+	protected static $pod_name = 'test_after';
+
+	protected static $pod_id;
+
+	public static function wpSetUpBeforeClass() {
+
+		add_shortcode(
+			'test_after_recurse', function ( $args, $content ) {
+
+				return do_shortcode( $content );
+			}
+		);
+
+		self::$pod_id = pods_api()->save_pod(
+			array(
+				'storage' => 'meta',
+				'type'    => 'post_type',
+				'name'    => self::$pod_name,
+			)
+		);
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number1',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number2',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'              => self::$pod_name,
+			'pod_id'           => self::$pod_id,
+			'name'             => 'related_field',
+			'type'             => 'pick',
+			'pick_object'      => 'post_type',
+			'pick_val'         => self::$pod_name,
+			'pick_format_type' => 'multi',
+		);
+
+		pods_api()->save_field( $params );
+
+	}
+
+	public static function wpTearDownAfterClass() {
+
+		if ( shortcode_exists( 'test_after_recurse' ) ) {
+			remove_shortcode( 'test_after_recurse' );
+		}
+		pods_api()->delete_pod( array( 'id' => self::$pod_id ) );
+
+	}
+
+	public function test_psuedo_shortcodes() {
+
+		// Make sure our pseudo shortcodes are working properly
+		$this->assertEquals( 'abc123', do_shortcode( '[test_after_recurse]abc123[/test_after_recurse]' ) );
+	}
+
+	public function test_after_simple() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+	}
+
+	public function test_after_with_nested_if() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+		// Testing [after] inside [if]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template]" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [after] inside [if] with [else]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [after] inside [if] with [else] and no relationships
+		$main_id       = $pod->add(
+			array(
+				'post_status' => 'publish',
+				'name'        => 'post with no related fields',
+				'number1'     => 123,
+				'number2'     => 456,
+			)
+		);
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( 'No related field', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+	}
+
+	public function test_after_nested_in_external() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[test_after_recurse][pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template][/test_after_recurse]" ) );
+	}
+}

--- a/tests/phpunit/includes/Shortcodes/Test_After.php
+++ b/tests/phpunit/includes/Shortcodes/Test_After.php
@@ -58,7 +58,7 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -78,7 +78,9 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}. [after]Done[/after]';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( '123. 321. Done', $shortcode_output );
 	}
@@ -89,7 +91,7 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -109,7 +111,9 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}. [after]Total records: {@_total}[/after]';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( '123. 321. Total Records: 2', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_After.php
+++ b/tests/phpunit/includes/Shortcodes/Test_After.php
@@ -78,7 +78,7 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}. [after]Done[/after]';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( '123. 321. Done', $shortcode_output );
 	}
@@ -109,7 +109,7 @@ class Test_After extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}. [after]Total records: {@_total}[/after]';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( '123. 321. Total Records: 2', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_Before.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Before.php
@@ -78,7 +78,7 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '[before]Start[/before] {@number1}.';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( 'Start 123. 321.', $shortcode_output );
 	}
@@ -109,7 +109,7 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '[before]Total records: {@_total}[/before] {@number1}.';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( 'Total Records: 2 123. 321.', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_Before.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Before.php
@@ -83,7 +83,7 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 		$this->assertEquals( 'Start 123. 321.', $shortcode_output );
 	}
 
-	public function test_after_magic_tags() {
+	public function test_before_magic_tags() {
 
 		$pod_name = self::$pod_name;
 

--- a/tests/phpunit/includes/Shortcodes/Test_Before.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Before.php
@@ -58,7 +58,7 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -78,7 +78,9 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '[before]Start[/before] {@number1}.';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( 'Start 123. 321.', $shortcode_output );
 	}
@@ -89,7 +91,7 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -109,7 +111,9 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '[before]Total records: {@_total}[/before] {@number1}.';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( 'Total Records: 2 123. 321.', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_Before.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Before.php
@@ -18,13 +18,6 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 	public static function wpSetUpBeforeClass() {
 
-		add_shortcode(
-			'test_before_recurse', function ( $args, $content ) {
-
-				return do_shortcode( $content );
-			}
-		);
-
 		self::$pod_id = pods_api()->save_pod(
 			array(
 				'storage' => 'meta',
@@ -51,138 +44,73 @@ class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		pods_api()->save_field( $params );
 
-		$params = array(
-			'pod'              => self::$pod_name,
-			'pod_id'           => self::$pod_id,
-			'name'             => 'related_field',
-			'type'             => 'pick',
-			'pick_object'      => 'post_type',
-			'pick_val'         => self::$pod_name,
-			'pick_format_type' => 'multi',
-		);
-
-		pods_api()->save_field( $params );
-
 	}
 
 	public static function wpTearDownAfterClass() {
 
-		if ( shortcode_exists( 'test_before_recurse' ) ) {
-			remove_shortcode( 'test_before_recurse' );
-		}
 		pods_api()->delete_pod( array( 'id' => self::$pod_id ) );
 
-	}
-
-	public function test_psuedo_shortcodes() {
-
-		// Make sure our pseudo shortcodes are working properly
-		$this->assertEquals( 'abc123', do_shortcode( '[test_before_recurse]abc123[/test_before_recurse]' ) );
 	}
 
 	public function test_before_simple() {
 
 		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+
+		$pod = pods( $pod_name );
+
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
 				'number1'       => 123,
 				'number2'       => 456,
-				'related_field' => $sub_ids,
 			)
 		);
-		$content = base64_encode( '{@number1}_{@number2}' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+
+		$pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'secondary post',
+				'number1'       => 321,
+				'number2'       => 654,
+			)
+		);
+
+		$content = '[before]Start[/before] {@number1}.';
+
+		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+
+		$this->assertEquals( 'Start 123. 321.', $shortcode_output );
 	}
 
-	public function test_before_with_nested_if() {
+	public function test_after_magic_tags() {
 
 		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+
+		$pod = pods( $pod_name );
+
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
 				'number1'       => 123,
 				'number2'       => 456,
-				'related_field' => $sub_ids,
 			)
 		);
-		$content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
-		// Testing [before] inside [if]
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template]" );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
 
-		// Testing [before] inside [if] with [else]
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
-
-		// Testing [before] inside [if] with [else] and no relationships
-		$main_id       = $pod->add(
-			array(
-				'post_status' => 'publish',
-				'name'        => 'post with no related fields',
-				'number1'     => 123,
-				'number2'     => 456,
-			)
-		);
-		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
-		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
-		$this->assertEquals( 'No related field', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
-	}
-
-	public function test_before_nested_in_external() {
-
-		$pod_name = self::$pod_name;
-		$sub_ids  = array();
-		$pod      = pods( $pod_name );
-		for ( $x = 1; $x <= 5; $x ++ ) {
-			$sub_ids[] = $pod->add(
-				array(
-					'post_status' => 'publish',
-					'name'        => $x,
-					'number1'     => $x,
-					'number2'     => $x * $x,
-				)
-			);
-		}
-		$main_id = $pod->add(
+		$pod->add(
 			array(
 				'post_status'   => 'publish',
-				'name'          => 'main post',
-				'number1'       => 123,
-				'number2'       => 456,
-				'related_field' => $sub_ids,
+				'name'          => 'secondary post',
+				'number1'       => 321,
+				'number2'       => 654,
 			)
 		);
-		$content = base64_encode( '{@number1}_{@number2}' );
-		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[test_before_recurse][pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template][/test_before_recurse]" ) );
+
+		$content = '[before]Total records: {@_total}[/before] {@number1}.';
+
+		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+
+		$this->assertEquals( 'Total Records: 2 123. 321.', $shortcode_output );
 	}
 }

--- a/tests/phpunit/includes/Shortcodes/Test_Before.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Before.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Pods_Unit_Tests\Shortcodes;
+
+/**
+ * Class Test_Before
+ *
+ * @package Pods_Unit_Tests
+ * @group   pods_acceptance_tests
+ * @group   pods-shortcodes
+ * @group   pods-shortcodes-before
+ */
+class Test_Before extends \Pods_Unit_Tests\Pods_UnitTestCase {
+
+	protected static $pod_name = 'test_before';
+
+	protected static $pod_id;
+
+	public static function wpSetUpBeforeClass() {
+
+		add_shortcode(
+			'test_before_recurse', function ( $args, $content ) {
+
+				return do_shortcode( $content );
+			}
+		);
+
+		self::$pod_id = pods_api()->save_pod(
+			array(
+				'storage' => 'meta',
+				'type'    => 'post_type',
+				'name'    => self::$pod_name,
+			)
+		);
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number1',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number2',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'              => self::$pod_name,
+			'pod_id'           => self::$pod_id,
+			'name'             => 'related_field',
+			'type'             => 'pick',
+			'pick_object'      => 'post_type',
+			'pick_val'         => self::$pod_name,
+			'pick_format_type' => 'multi',
+		);
+
+		pods_api()->save_field( $params );
+
+	}
+
+	public static function wpTearDownAfterClass() {
+
+		if ( shortcode_exists( 'test_before_recurse' ) ) {
+			remove_shortcode( 'test_before_recurse' );
+		}
+		pods_api()->delete_pod( array( 'id' => self::$pod_id ) );
+
+	}
+
+	public function test_psuedo_shortcodes() {
+
+		// Make sure our pseudo shortcodes are working properly
+		$this->assertEquals( 'abc123', do_shortcode( '[test_before_recurse]abc123[/test_before_recurse]' ) );
+	}
+
+	public function test_before_simple() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+	}
+
+	public function test_before_with_nested_if() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+		// Testing [before] inside [if]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template]" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [before] inside [if] with [else]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [before] inside [if] with [else] and no relationships
+		$main_id       = $pod->add(
+			array(
+				'post_status' => 'publish',
+				'name'        => 'post with no related fields',
+				'number1'     => 123,
+				'number2'     => 456,
+			)
+		);
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( 'No related field', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+	}
+
+	public function test_before_nested_in_external() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[test_before_recurse][pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template][/test_before_recurse]" ) );
+	}
+}

--- a/tests/phpunit/includes/Shortcodes/Test_Once.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Once.php
@@ -78,7 +78,7 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}.[once]HI![/once]';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( '123.HI!321.', $shortcode_output );
 	}
@@ -109,7 +109,7 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}.[once]{@number2}.[/once]';
 
-		$shortcode_output = do_shortcode( "[pods pod='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
 
 		$this->assertEquals( '123.456.321.', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_Once.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Once.php
@@ -58,7 +58,7 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -78,7 +78,9 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}.[once]HI![/once]';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( '123.HI!321.', $shortcode_output );
 	}
@@ -89,7 +91,7 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$pod = pods( $pod_name );
 
-		$pod->add(
+		$main_id = $pod->add(
 			array(
 				'post_status'   => 'publish',
 				'name'          => 'main post',
@@ -109,7 +111,9 @@ class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
 
 		$content = '{@number1}.[once]{@number2}.[/once]';
 
-		$shortcode_output = do_shortcode( "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]" );
+		$shortcode = "[pods name='{$pod_name}' orderby='t.ID']{$content}[/pods]";
+
+		$shortcode_output = apply_filters( 'the_content', $shortcode, $main_id );
 
 		$this->assertEquals( '123.456.321.', $shortcode_output );
 	}

--- a/tests/phpunit/includes/Shortcodes/Test_Once.php
+++ b/tests/phpunit/includes/Shortcodes/Test_Once.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Pods_Unit_Tests\Shortcodes;
+
+/**
+ * Class Test_Once
+ *
+ * @package Pods_Unit_Tests
+ * @group   pods_acceptance_tests
+ * @group   pods-shortcodes
+ * @group   pods-shortcodes-once
+ */
+class Test_Once extends \Pods_Unit_Tests\Pods_UnitTestCase {
+
+	protected static $pod_name = 'test_once';
+
+	protected static $pod_id;
+
+	public static function wpSetUpBeforeClass() {
+
+		add_shortcode(
+			'test_once_recurse', function ( $args, $content ) {
+
+				return do_shortcode( $content );
+			}
+		);
+
+		self::$pod_id = pods_api()->save_pod(
+			array(
+				'storage' => 'meta',
+				'type'    => 'post_type',
+				'name'    => self::$pod_name,
+			)
+		);
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number1',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'    => self::$pod_name,
+			'pod_id' => self::$pod_id,
+			'name'   => 'number2',
+			'type'   => 'number',
+		);
+
+		pods_api()->save_field( $params );
+
+		$params = array(
+			'pod'              => self::$pod_name,
+			'pod_id'           => self::$pod_id,
+			'name'             => 'related_field',
+			'type'             => 'pick',
+			'pick_object'      => 'post_type',
+			'pick_val'         => self::$pod_name,
+			'pick_format_type' => 'multi',
+		);
+
+		pods_api()->save_field( $params );
+
+	}
+
+	public static function wpTearDownAfterClass() {
+
+		if ( shortcode_exists( 'test_once_recurse' ) ) {
+			remove_shortcode( 'test_once_recurse' );
+		}
+		pods_api()->delete_pod( array( 'id' => self::$pod_id ) );
+
+	}
+
+	public function test_psuedo_shortcodes() {
+
+		// Make sure our pseudo shortcodes are working properly
+		$this->assertEquals( 'abc123', do_shortcode( '[test_once_recurse]abc123[/test_once_recurse]' ) );
+	}
+
+	public function test_once_simple() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+	}
+
+	public function test_once_with_nested_if() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template]" ) );
+		// Testing [once] inside [if]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template]" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [once] inside [if] with [else]
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+
+		// Testing [once] inside [if] with [else] and no relationships
+		$main_id       = $pod->add(
+			array(
+				'post_status' => 'publish',
+				'name'        => 'post with no related fields',
+				'number1'     => 123,
+				'number2'     => 456,
+			)
+		);
+		$inner_content = base64_encode( '[if number1]{@number1}_{@number2}[/if]' );
+		$content       = base64_encode( "[pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$inner_content}[/pod_sub_template][else]No related field" );
+		$this->assertEquals( 'No related field', do_shortcode( "[pod_if_field pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_if_field]" ) );
+	}
+
+	public function test_once_nested_in_external() {
+
+		$pod_name = self::$pod_name;
+		$sub_ids  = array();
+		$pod      = pods( $pod_name );
+		for ( $x = 1; $x <= 5; $x ++ ) {
+			$sub_ids[] = $pod->add(
+				array(
+					'post_status' => 'publish',
+					'name'        => $x,
+					'number1'     => $x,
+					'number2'     => $x * $x,
+				)
+			);
+		}
+		$main_id = $pod->add(
+			array(
+				'post_status'   => 'publish',
+				'name'          => 'main post',
+				'number1'       => 123,
+				'number2'       => 456,
+				'related_field' => $sub_ids,
+			)
+		);
+		$content = base64_encode( '{@number1}_{@number2}' );
+		$this->assertEquals( '1_12_43_94_165_25', do_shortcode( "[test_once_recurse][pod_sub_template pod='{$pod_name}' id='{$main_id}' field='related_field']{$content}[/pod_sub_template][/test_once_recurse]" ) );
+	}
+}

--- a/tests/phpunit/includes/tests-traversal.php
+++ b/tests/phpunit/includes/tests-traversal.php
@@ -668,6 +668,11 @@ class Test_Traversal extends Pods_UnitTestCase {
 
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
+		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) [%s]', $p->total(), $variant_id ) );
+		$this->assertEquals( '', $p->field( '_total_s' ), sprintf( 'Total "s" value not as expected (%s) [%s]', $p->total(), $variant_id ) );
+		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
+		$this->assertEquals( '', $p->field( '_total_found_s' ), sprintf( 'Total found "s" value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
+
 	}
 
 	/**
@@ -1022,6 +1027,11 @@ class Test_Traversal extends Pods_UnitTestCase {
 		$this->assertNotEmpty( $p->fetch(), sprintf( 'Item not fetched [%s]', $variant_id ) );
 
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
+
+		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) [%s]', $p->total(), $variant_id ) );
+		$this->assertEquals( '', $p->field( '_total_s' ), sprintf( 'Total "s" value not as expected (%s) [%s]', $p->total(), $variant_id ) );
+		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
+		$this->assertEquals( '', $p->field( '_total_found_s' ), sprintf( 'Total found "s" value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
 
 	}
 

--- a/tests/phpunit/includes/tests-traversal.php
+++ b/tests/phpunit/includes/tests-traversal.php
@@ -669,9 +669,7 @@ class Test_Traversal extends Pods_UnitTestCase {
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
 		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) [%s]', $p->total(), $variant_id ) );
-		$this->assertEquals( '', $p->field( '_total_s' ), sprintf( 'Total "s" value not as expected (%s) [%s]', $p->total(), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
-		$this->assertEquals( '', $p->field( '_total_found_s' ), sprintf( 'Total found "s" value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
 
 	}
 
@@ -1029,9 +1027,7 @@ class Test_Traversal extends Pods_UnitTestCase {
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
 		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) [%s]', $p->total(), $variant_id ) );
-		$this->assertEquals( '', $p->field( '_total_s' ), sprintf( 'Total "s" value not as expected (%s) [%s]', $p->total(), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
-		$this->assertEquals( '', $p->field( '_total_found_s' ), sprintf( 'Total found "s" value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
 
 	}
 

--- a/tests/phpunit/includes/tests-traversal.php
+++ b/tests/phpunit/includes/tests-traversal.php
@@ -668,8 +668,8 @@ class Test_Traversal extends Pods_UnitTestCase {
 
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
-		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) [%s]', $p->total(), $variant_id ) );
-		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) [%s]', $p->total_found(), $variant_id ) );
+		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%s) %s [%s]', $p->total(), var_export( $p->field( '_total' ), true ), $variant_id ) );
+		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%s) %s [%s]', $p->total_found(), var_export( $p->field( '_total_found' ), true ), $variant_id ) );
 
 	}
 

--- a/tests/phpunit/includes/tests-traversal.php
+++ b/tests/phpunit/includes/tests-traversal.php
@@ -668,6 +668,7 @@ class Test_Traversal extends Pods_UnitTestCase {
 
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
+		$this->assertEquals( 1, (int) $p->field( '_position' ), sprintf( 'Position value not as expected (%1$s) %2$s [%3$s]', $p->position(), var_export( $p->field( '_position' ), true ), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%1$s) %2$s [%3$s]', $p->total(), var_export( $p->field( '_total' ), true ), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%1$s) %2$s [%3$s]', $p->total_found(), var_export( $p->field( '_total_found' ), true ), $variant_id ) );
 
@@ -1026,6 +1027,7 @@ class Test_Traversal extends Pods_UnitTestCase {
 
 		$this->assertEquals( (string) $data['id'], (string) $p->id(), sprintf( 'Item ID not as expected (%s) [%s]', $data['field_id'], $variant_id ) );
 
+		$this->assertEquals( 1, (int) $p->field( '_position' ), sprintf( 'Position value not as expected (%1$s) %2$s [%3$s]', $p->position(), var_export( $p->field( '_position' ), true ), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total' ), sprintf( 'Total value not as expected (%1$s) %2$s [%3$s]', $p->total(), var_export( $p->field( '_total' ), true ), $variant_id ) );
 		$this->assertEquals( 1, (int) $p->field( '_total_found' ), sprintf( 'Total found value not as expected (%1$s) %2$s [%3$s]', $p->total_found(), var_export( $p->field( '_total_found' ), true ), $variant_id ) );
 


### PR DESCRIPTION
Fixes #5039

## Example

```
Currently showing {@_total} rows out of {@_total_found} rows found.
```

- [x] `_total` Pods::total()
- [x] `_total_found` Pods::total_found()
- [ ] Get `[once]` handling magic tags
- [ ] Get `[before]` handling magic tags
- [ ] Get `[after]` handling magic tags