### PR TITLE
i18n: Fix compat issue with `get_current_screen()`

### DIFF
--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -327,11 +327,14 @@ final class PodsI18n {
 						$current_language = '';
 					}
 
+					/**
+					 * Polylang support.
+					 * In polylang the preferred language could be anything.
+					 */
 					if ( 'PLL' === $translator && pll_is_translated_post_type( $current_post_type ) ) {
 
 						/**
-						 * Polylang support (1.5.4+).
-						 * In polylang the preferred language could be anything.
+						 * Polylang (1.5.4+).
 						 * We only want the related objects if they are not translatable OR the same language as the current object.
 						 */
 						if ( function_exists( 'pll_get_post_language' ) ) {
@@ -340,8 +343,7 @@ final class PodsI18n {
 						}
 
 						/**
-						 * Polylang support (1.0.1+).
-						 * In polylang the preferred language could be anything.
+						 * Polylang (1.0.1+).
 						 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language.
 						 */
 						if ( ! empty( $_GET['new_lang'] ) ) {
@@ -378,11 +380,14 @@ final class PodsI18n {
 						$current_language = '';
 					}
 
+					/**
+					 * Polylang support.
+					 * In polylang the preferred language could be anything.
+					 */
 					if ( 'PLL' === $translator && pll_is_translated_taxonomy( $current_taxonomy ) ) {
 
 						/**
-						 * Polylang support (1.5.4+).
-						 * In polylang the preferred language could be anything.
+						 * Polylang (1.5.4+).
 						 * We only want the related objects if they are not translatable OR the same language as the current object.
 						 */
 						if ( $current_tag_id && function_exists( 'pll_get_term_language' ) ) {
@@ -391,8 +396,7 @@ final class PodsI18n {
 						}
 
 						/**
-						 * Polylang support (1.0.1+).
-						 * In polylang the preferred language could be anything.
+						 * Polylang (1.0.1+).
 						 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language.
 						 */
 						if ( ! empty( $_GET['new_lang'] ) ) {

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -257,8 +257,8 @@ final class PodsI18n {
 		}
 
 		/**
-		 * @var $sitepress SitePress object
-		 * @var $polylang  Polylang object
+		 * @var \SitePress $sitepress object
+		 * @var \Polylang $polylang  object
 		 */
 		/*
 		 * @todo wpml-comp Remove global object usage
@@ -269,36 +269,36 @@ final class PodsI18n {
 		$translator       = false;
 		$current_language = false;
 
-		// Multilingual support
+		// Multilingual support.
 		if ( did_action( 'wpml_loaded' ) && apply_filters( 'wpml_setting', true, 'auto_adjust_ids' ) ) {
-			// WPML support
+			// WPML support.
 			$translator = 'WPML';
 
-			// Get the global current language (if set)
+			// Get the global current language (if set).
 			$wpml_language    = apply_filters( 'wpml_current_language', null );
-			$current_language = ( $wpml_language != 'all' ) ? $wpml_language : '';
+			$current_language = ( 'all' !== $wpml_language ) ? $wpml_language : '';
 
 		} elseif ( ( function_exists( 'PLL' ) || is_object( $polylang ) ) && function_exists( 'pll_current_language' ) ) {
-			// Polylang support
+			// Polylang support.
 			$translator = 'PLL';
 
-			// Get the global current language (if set)
+			// Get the global current language (if set).
 			$current_language = pll_current_language( 'slug' );
 		}
 
 		/**
-		 * Admin functions that overwrite the current language
+		 * Admin functions that overwrite the current language.
 		 *
 		 * @since 2.6.6
 		 */
 		if ( is_admin() && ! empty( $translator ) ) {
-			if ( $translator == 'PLL' ) {
+			if ( 'PLL' === $translator ) {
 				/**
-				 * Polylang support
+				 * Polylang support.
 				 * Get the current user's preferred language.
-				 * This is a user meta setting that will overwrite the language returned from pll_current_language()
+				 * This is a user meta setting that will overwrite the language returned from pll_current_language().
 				 *
-				 * @see polylang/admin/admin-base.php -> init_user()
+				 * @see \PLL_Admin_Base::init_user() (polylang/admin/admin-base.php)
 				 */
 				$current_language = get_user_meta( get_current_user_id(), 'pll_filter_content', true );
 			}
@@ -416,21 +416,21 @@ final class PodsI18n {
 			);
 
 			/**
-			 * Polylang support
-			 * Get the language taxonomy object for the current language
+			 * Polylang support.
+			 * Get the language taxonomy object for the current language.
 			 */
-			if ( $translator == 'PLL' ) {
+			if ( 'PLL' === $translator ) {
 				$current_language_t = false;
 
-				// Get the language term object
+				// Get the language term object.
 				if ( function_exists( 'PLL' ) && isset( PLL()->model ) && method_exists( PLL()->model, 'get_language' ) ) {
-					// Polylang 1.8 and newer
+					// Polylang 1.8 and newer.
 					$current_language_t = PLL()->model->get_language( $current_language );
 				} elseif ( is_object( $polylang ) && isset( $polylang->model ) && method_exists( $polylang->model, 'get_language' ) ) {
 					// Polylang 1.2 - 1.7.x
 					$current_language_t = $polylang->model->get_language( $current_language );
 				} elseif ( is_object( $polylang ) && method_exists( $polylang, 'get_language' ) ) {
-					// Polylang 1.1.x and older
+					// Polylang 1.1.x and older.
 					$current_language_t = $polylang->get_language( $current_language );
 				}
 
@@ -450,16 +450,15 @@ final class PodsI18n {
 		 *
 		 * @since 2.6.6
 		 *
-		 * @param array|false    $lang_data  {
-		 *                                   Language data
-		 *
-		 * @type string          $language   Language slug
-		 * @type int             $t_id       Language term_id
-		 * @type int             $tt_id      Language term_taxonomy_id
-		 * @type WP_Term         $term       Language term object
+		 * @param array|false $lang_data  {
+		 *     Language data
+		 *     @type string   $language  Language slug
+		 *     @type int      $t_id      Language term_id
+		 *     @type int      $tt_id     Language term_taxonomy_id
+		 *     @type WP_Term  $term      Language term object
 		 * }
 		 *
-		 * @param string|boolean $translator Language plugin used
+		 * @param string|boolean $translator Language plugin used.
 		 */
 		$lang_data = apply_filters( 'pods_get_current_language', $lang_data, $translator );
 

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -303,88 +303,106 @@ final class PodsI18n {
 				$current_language = get_user_meta( get_current_user_id(), 'pll_filter_content', true );
 			}
 
-			// Get current language based on the object language if available
-			if ( function_exists( 'get_current_screen' ) ) {
-				$current_screen = get_current_screen();
+			// Get current language based on the object language if available.
+			$page = basename( $_SERVER['SCRIPT_NAME'] );
 
-				/**
-				 * Overwrite the current language if needed for post types
-				 */
-				if ( isset( $current_screen->base ) && ( $current_screen->base == 'post' || $current_screen->base == 'edit' ) ) {
-					if ( ! empty( $_GET['post'] ) ) {
-						/**
-						 * WPML support
-						 * In WPML the current language is always set to default on an edit screen
-						 * We need to overwrite this when the current object is not-translatable to enable relationships with different languages
-						 */
-						if ( $translator == 'WPML' && ! apply_filters( 'wpml_is_translated_post_type', false, ( get_post_type( $_GET['post'] ) ) ) ) {
-							// Overwrite the current language to nothing if this is a NOT-translatable post_type
-							$current_language = '';
-						}
+			/**
+			 * Overwrite the current language if needed for post types.
+			 */
+			if ( 'post.php' === $page || 'edit.php' === $page ) {
 
-						/**
-						 * Polylang support (1.5.4+)
-						 * In polylang the preferred language could be anything.
-						 * We only want the related objects if they are not translatable OR the same language as the current object
-						 */
-						if ( $translator == 'PLL' && function_exists( 'pll_get_post_language' ) && pll_is_translated_post_type( get_post_type( $_GET['post'] ) ) ) {
-							// Overwrite the current language if this is a translatable post_type
-							$current_language = pll_get_post_language( (int) $_GET['post'] );
-						}
-					}//end if
+				$current_post = ( ! empty( $_GET['post'] ) ) ? (int) $_GET['post'] : 0;
+
+				if ( $current_post ) {
+
+					$current_post_type = get_post_type( $current_post );
 
 					/**
-					 * Polylang support (1.0.1+)
-					 * In polylang the preferred language could be anything.
-					 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language
+					 * WPML support.
+					 * In WPML the current language is always set to default on an edit screen.
+					 * We need to overwrite this when the current object is not-translatable to enable relationships with different languages.
 					 */
-					if ( $translator == 'PLL' && ! empty( $_GET['new_lang'] ) && ! empty( $_GET['post_type'] ) && pll_is_translated_post_type( sanitize_text_field( $_GET['post_type'] ) ) ) {
-						$current_language = $_GET['new_lang'];
+					if ( 'WPML' === $translator && ! apply_filters( 'wpml_is_translated_post_type', false, $current_post_type ) ) {
+						// Overwrite the current language to nothing if this is a NOT-translatable post_type.
+						$current_language = '';
 					}
 
-					/**
-					 * Overwrite the current language if needed for taxonomies
-					 */
-				} elseif ( isset( $current_screen->base ) && ( $current_screen->base == 'term' || $current_screen->base == 'edit-tags' ) ) {
-					// @todo MAYBE: Similar function like get_post_type for taxonomies so we don't need to check for $_GET['taxonomy']
-					if ( ! empty( $_GET['taxonomy'] ) ) {
-						/*
-						 * @todo wpml-comp API call for taxonomy needed!
-						 * Suggested API call:
-						 * add_filter( 'wpml_is_translated_taxonomy', $_GET['taxonomy'], 10, 2 );
-						 */
-						/**
-						 * WPML support
-						 * In WPML the current language is always set to default on an edit screen
-						 * We need to overwrite this when the current object is not-translatable to enable relationships with different languages
-						 */
-						if ( $translator == 'WPML' && method_exists( $sitepress, 'is_translated_taxonomy' ) && ! $sitepress->is_translated_taxonomy( $_GET['taxonomy'] ) ) {
-							// Overwrite the current language to nothing if this is a NOT-translatable taxonomy
-							$current_language = '';
-						}
+					if ( 'PLL' === $translator && pll_is_translated_post_type( $current_post_type ) ) {
 
 						/**
-						 * Polylang support (1.5.4+)
+						 * Polylang support (1.5.4+).
 						 * In polylang the preferred language could be anything.
-						 * We only want the related objects if they are not translatable OR the same language as the current object
+						 * We only want the related objects if they are not translatable OR the same language as the current object.
 						 */
-						if ( $translator == 'PLL' && ! empty( $_GET['tag_ID'] ) && function_exists( 'pll_get_term_language' ) && pll_is_translated_taxonomy( sanitize_text_field( $_GET['taxonomy'] ) ) ) {
-							// Overwrite the current language if this is a translatable taxonomy
-							$current_language = pll_get_term_language( (int) $_GET['tag_ID'] );
+						if ( function_exists( 'pll_get_post_language' ) ) {
+							// Overwrite the current language if this is a translatable post_type.
+							$current_language = pll_get_post_language( $current_post );
 						}
-					}//end if
 
-					/**
-					 * Polylang support (1.0.1+)
-					 * In polylang the preferred language could be anything.
-					 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language
+						/**
+						 * Polylang support (1.0.1+).
+						 * In polylang the preferred language could be anything.
+						 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language.
+						 */
+						if ( ! empty( $_GET['new_lang'] ) ) {
+							$current_language = $_GET['new_lang'];
+						}
+					}
+				}
+			} //end if
+
+			/**
+			 * Overwrite the current language if needed for taxonomies.
+			 */
+			elseif ( 'term.php' === $page || 'edit-tags.php' === $page ) {
+
+				$current_taxonomy = ( ! empty( $_GET['taxonomy'] ) ) ? sanitize_text_field( $_GET['taxonomy'] ) : '';
+
+				// @todo MAYBE: Similar function like get_post_type for taxonomies so we don't need to check for $_GET['taxonomy']
+				if ( $current_taxonomy ) {
+
+					$current_tag_id = ( ! empty( $_GET['tag_ID'] ) ) ? (int) $_GET['tag_ID'] : 0;
+
+					/*
+					 * @todo wpml-comp API call for taxonomy needed!
+					 * Suggested API call:
+					 * add_filter( 'wpml_is_translated_taxonomy', $_GET['taxonomy'], 10, 2 );
 					 */
-					if ( $translator == 'PLL' && ! empty( $_GET['new_lang'] ) && ! empty( $_GET['taxonomy'] ) && pll_is_translated_taxonomy( sanitize_text_field( $_GET['taxonomy'] ) ) ) {
-						$current_language = $_GET['new_lang'];
+					/**
+					 * WPML support.
+					 * In WPML the current language is always set to default on an edit screen.
+					 * We need to overwrite this when the current object is not-translatable to enable relationships with different languages.
+					 */
+					if ( 'WPML' === $translator && method_exists( $sitepress, 'is_translated_taxonomy' ) && ! $sitepress->is_translated_taxonomy( $current_taxonomy ) ) {
+						// Overwrite the current language to nothing if this is a NOT-translatable taxonomy.
+						$current_language = '';
+					}
+
+					if ( 'PLL' === $translator && pll_is_translated_taxonomy( $current_taxonomy ) ) {
+
+						/**
+						 * Polylang support (1.5.4+).
+						 * In polylang the preferred language could be anything.
+						 * We only want the related objects if they are not translatable OR the same language as the current object.
+						 */
+						if ( $current_tag_id && function_exists( 'pll_get_term_language' ) ) {
+							// Overwrite the current language if this is a translatable taxonomy
+							$current_language = pll_get_term_language( $current_tag_id );
+						}
+
+						/**
+						 * Polylang support (1.0.1+).
+						 * In polylang the preferred language could be anything.
+						 * When we're adding a new object and language is set we only want the related objects if they are not translatable OR the same language.
+						 */
+						if ( ! empty( $_GET['new_lang'] ) ) {
+							$current_language = $_GET['new_lang'];
+						}
 					}
 				}//end if
 			}//end if
-		}//end if
+
+		}//end if (admin)
 
 		$current_language = pods_sanitize( sanitize_text_field( $current_language ) );
 


### PR DESCRIPTION
## Description
Instead of relying on `get_current_screen()` this patch switched to the use of the `$_SERVER['SCRIPT_NAME']` wrapped in `basename()` to get the current screen base.
The WP_Screen object isn't available until after `admin_init` which apparently is too late.

Fixes: #5060 

## ChangeLog
Fix compatibility issue with Polylang & WPML when getting the current language from the edit post and edit tax pages.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
