### PR TITLE
Bump to PHPCS 3.3 + WPCS 1.0 + PHPCompatibilityWP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,10 @@
     "wp-cli/wp-cli": "1.*",
     "phpunit/phpunit": "4.*",
     "mockery/mockery": "0.9.*",
-    "squizlabs/php_codesniffer": "2.9.1 - 3.2.3",
+    "squizlabs/php_codesniffer": "^3.3",
     "DealerDirect/phpcodesniffer-composer-installer":"0.4.*",
-    "wp-coding-standards/wpcs": "0.14.*",
-    "wimg/php-compatibility": "8.*"
+    "wp-coding-standards/wpcs": "^1",
+    "phpcompatibility/phpcompatibility-wp": "^1.0"
   },
   "suggest": {
     "wp-cli/wp-cli": "Enables access to Pods CLI commands."

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,39 +1,57 @@
 <?xml version="1.0"?>
 <ruleset name="Pods">
-	<description>Pods-customized WordPress Coding Standards</description>
+	<description>The custom ruleset for Pods</description>
 
+	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+
+	<!-- What to scan -->
 	<file>.</file>
+	<!-- Ignoring Files and Folders:
+            https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>*/.idea/*</exclude-pattern>
 	<exclude-pattern>*/.sass-cache/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/components/Markdown.php</exclude-pattern>
 
-	<arg value="s"/> <!-- Show sniff codes in all reports -->
-	<arg value="p"/> <!-- Show progress of the run -->
-	<arg name="extensions" value="php"/><!-- Only check .php files -->
-	<arg name="basepath" value="."/><!-- Strip the file paths down to the relevant bit -->
-	<arg name="colors"/><!-- Show colors in output -->
+	<!-- How to scan -->
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg name="colors"/> <!-- Show results with colors -->
+	<arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
+	<arg name="parallel" value="50"/> <!-- Enables parallel processing when available for faster results. -->
+	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
 
 	<ini name="memory_limit" value="256M"/>
 
-	<config name="minimum_supported_wp_version" value="4.5"/>
-	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra"/>
-
+	<!-- Rules: Check PHP version compatibility - see
+		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibilityWP"/>
+	<!-- For help in understanding this testVersion:
+		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="5.3-"/>
-	<rule ref="PHPCompatibility"/>
+
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<rule ref="WordPress"/>
+
+	<!-- For help in understanding these custom sniff properties:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<config name="minimum_supported_wp_version" value="4.5"/>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="prefixes" type="array" value="pods"/>
+			<property name="prefixes" type="array">
+				<element value="pods"/>
+			</property>
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="pods"/>
+			<property name="text_domain" type="array">
+				<element value="pods"/>
+			</property>
 		</properties>
 	</rule>
 
@@ -42,6 +60,7 @@
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
 	</rule>
 
 	<rule ref="WordPress.Files">


### PR DESCRIPTION
- PHP_CodeSniffer 3.3 adds some nice features. The downside is, the 3.x branch requires PHP 5.4 - as long that is available for running PHPCS, there's no reason to stick on PHPCS 2.9.1.
- WordPress Coding Standards 1.0.0 has now been released. See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.0.0
- PHPCompatibilityWP is a wrapper for PHPCompatibility, with some exclusions for back-compat functions added to WP core. See https://github.com/PHPCompatibility/PHPCompatibilityWP

- PHPCS config file gets comments to make it easier for contributors to understand.
- Clarify that this is a custom ruleset, not a standard.
- `parallel` arg added to help speed up scans.
- Switched to new format for array values - old format is deprecated as of 3.3 and removed as of PHPCS 4.
- Exclusion of long condition closing comment, since that is no longer part of the WP coding standards Handbook.

Closes #5075.