### PR TITLE
Prior to PHP 5.5, 'empty()` only supports variables

### DIFF
--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -165,7 +165,8 @@ class PodsField_Time extends PodsField_DateTime {
 	 */
 	public function is_empty( $value = null ) {
 
-		return empty( trim ( $value ) );
+		$value = trim ( $value );
+		return empty( $value );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5079