### PR TITLE
Update build tool configurations in prep for 2.8

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ export default {
 		name: 'PodsDFV', // One single object added to the global namespace
 		globals: {
 			'jquery': 'jQuery',
-			'_': '_',
+			'underscore': '_',
 			'backbone': 'Backbone',
 			'backbone.marionette': 'Marionette'
 		},
@@ -29,7 +29,7 @@ export default {
 	},
 	external: [
 		'jquery',
-		'_',
+		'underscore',
 		'backbone',
 		'backbone.marionette'
 	],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,9 +31,7 @@ export default {
 		'jquery',
 		'_',
 		'backbone',
-		'backbone.marionette',
-		'react',
-		'react-dom'
+		'backbone.marionette'
 	],
 	plugins: [
 		includePaths( includePathOptions ),


### PR DESCRIPTION
Fixes #5120

This is prep for 2.8 and to (hopefully) cut down on future merge conflicts.  2.x isn't using React so this is a configuration-only change there.  These changes produce an identical compiled bundle under 2.x so this PR needs no changelog entry.  