### PR TITLE
Compatibility with Admin Columns 3.3+

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -451,8 +451,8 @@ class PodsMeta {
 	 */
 	public function integrations() {
 
-		// `ac_is_version_gte` is since AC 3.0+
-		if ( ! function_exists( 'ac_is_version_gte' ) ) {
+		// `AC` is since AC 3.0+
+		if ( ! function_exists( 'AC' ) ) {
 			// Codepress Admin Columns < 2.x
 			add_filter( 'cac/storage_model/meta_keys', array( $this, 'cpac_meta_keys' ), 10, 2 );
 			add_filter( 'cac/post_types', array( $this, 'cpac_post_types' ), 10, 1 );


### PR DESCRIPTION
## Description
Since `ac_is_version_gte()` was removed Pods returned to the old filters of AC that generated deprecated messages.
@DGStefan mentioned this issue and the function `AC()` was also added in 3.0+ so is better to use for this check.

## ChangeLog
Fix compatibility issue with Admin Columns 3.3+
