### PR TITLE
Frontend forms conditional logic

### DIFF
--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -124,6 +124,7 @@ do_action( 'pods_form_pre_fields', $fields, $pod, $params );
 						if ( ! empty( $dependencies['classes'] ) ) {
 							$default_class .= ' ' . $dependencies['classes'];
 						}
+						$dep_data = $dependencies['data'];
 
 						/**
 						 * Filter the html class used on form field list item element.
@@ -135,7 +136,7 @@ do_action( 'pods_form_pre_fields', $fields, $pod, $params );
 						 */
 						$html_class = apply_filters( 'pods_form_html_class', 'pods-field-html-class', $field ) . $default_class;
 				?>
-					<li class="pods-field <?php echo esc_attr( $html_class, true ); ?>">
+					<li class="pods-field <?php echo esc_attr( $html_class, true ); ?>" <?php PodsForm::data( $dep_data ); ?>>
 						<div class="pods-field-label">
 							<?php echo PodsForm::label( $field_prefix . $field[ 'name' ], $field[ 'label' ], $field[ 'help' ], $field ); ?>
 						</div>

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -120,7 +120,7 @@ do_action( 'pods_form_pre_fields', $fields, $pod, $params );
 						$default_class = ' pods-form-ui-row-type-' . $field[ 'type' ] . ' pods-form-ui-row-name-' . PodsForm::clean( $field[ 'name' ] );
 
 						// Setup field conditionals.
-						$dependencies = PodsForm::dependencies( $field, '' );
+						$dependencies = PodsForm::dependencies( $field, 'pods-field-' );
 						if ( ! empty( $dependencies['classes'] ) ) {
 							$default_class .= ' ' . $dependencies['classes'];
 						}

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -209,6 +209,7 @@ if ( !$fields_only ) {
 
 				$( document ).Pods( 'validate' );
 				$( document ).Pods( 'submit' );
+				$( document ).Pods( 'dependency' );
 			}
 		} );
 	}

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -98,7 +98,7 @@ if ( !$fields_only ) {
 do_action( 'pods_form_pre_fields', $fields, $pod, $params );
 ?>
 
-			<ul class="pods-form-fields">
+			<ul class="pods-form-fields pods-dependency">
 				<?php
 					foreach ( $fields as $field ) {
 						if ( 'hidden' == $field[ 'type' ] ) {

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -119,6 +119,12 @@ do_action( 'pods_form_pre_fields', $fields, $pod, $params );
 
 						$default_class = ' pods-form-ui-row-type-' . $field[ 'type' ] . ' pods-form-ui-row-name-' . PodsForm::clean( $field[ 'name' ] );
 
+						// Setup field conditionals.
+						$dependencies = PodsForm::dependencies( $field, '' );
+						if ( ! empty( $dependencies['classes'] ) ) {
+							$default_class .= ' ' . $dependencies['classes'];
+						}
+
 						/**
 						 * Filter the html class used on form field list item element.
 						 *

--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -1261,7 +1261,7 @@
                 $( '.pods-dependency .pods-depends-on, .pods-dependency .pods-excludes-on, .pods-dependency .pods-wildcard-on' ).hide();
 
                 // Handle dependent toggle
-                $( '.pods-admin' ).on( 'change', '.pods-dependent-toggle[data-name-clean]', function ( e ) {
+                $( '.pods-admin, .pods-form-front' ).on( 'change', '.pods-dependent-toggle[data-name-clean]', function ( e ) {
                     var selectionTypeRegex = /pick-format-type$/g;
                     var elementId = $( this ).attr( 'id' );
                     var selectionType, selectionFormatId;


### PR DESCRIPTION
## Description
Fixes #5136 

## How Has This Been Tested?
I've tested this on a dev environment where I was using PodsForm on the front end. There was a need for conditionals (currently only manually configured).
I also verified this doesn't break the admin side of Pods. No issues found.

## Types of changes
The changes are only in code. No interface changes has been made, those would be related to #609 

## ChangeLog
**Enhancement:** Add pods conditional logic handling on frontend forms.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
