### PR TITLE
Add support for Taxonomy descriptions

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -824,6 +824,7 @@ class PodsInit {
 				$pods_taxonomies[ $taxonomy_name ] = array(
 					'label'                 => $ct_label,
 					'labels'                => $ct_labels,
+					'description'           => esc_html( pods_v( 'description', $taxonomy ) ),
 					'public'                => (boolean) pods_v( 'public', $taxonomy, true ),
 					'show_ui'               => (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
 					'show_in_menu'          => (boolean) pods_v( 'show_in_menu', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),


### PR DESCRIPTION
Fixes #4766

## Description
`register_taxonomy()` supports `description` but we do not have it available in the UI. This PR adds it to the UI and passes it onto `register_taxonomy()`. Follows same way we handle `description` for custom post types.

## ChangeLog
Add support for Taxonomy descriptions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
