### PR TITLE
#4961 - Fix read-only not having any effect on checkbox fields

### DIFF
--- a/ui/fields/checkbox.php
+++ b/ui/fields/checkbox.php
@@ -62,6 +62,7 @@ if ( 0 < $data_count ) {
 
 		if ( pods_var( 'readonly', $options, false ) ) {
 			$attributes['readonly'] = 'READONLY';
+			$attributes['disabled'] = 'DISABLED';
 
 			$attributes['class'] .= ' pods-form-ui-read-only';
 		}
@@ -79,6 +80,12 @@ if ( 0 < $data_count ) {
 		<div class="pods-field pods-boolean"<?php echo $indent; ?>>
 			<input<?php PodsForm::attributes( $attributes, $name, $form_field_type, $options ); ?> />
 			<?php
+			if ( isset( $attributes['readonly'] ) && isset( $attributes['checked'] ) && 'CHECKED' === $attributes['checked'] ) {
+				?>
+				<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $attributes['value'] ); ?>" />
+				<?php
+			}
+
 			if ( 0 < strlen( $label ) ) {
 				$help = pods_var_raw( 'help', $options );
 


### PR DESCRIPTION
## Description
Fixes #4961 

The "readonly" attribute only prevents the "value" attribute from changing which is not what we want in the case of checkboxes as interacting with a checkbox changes its `checked` attribute instead which is why we need to do this:

1. Add `disabled="DISABLED"` to the checkbox.
2. As a consequence of 1, even if the checkbox default value is set to `1`, the value stored will still be `0` since disabled inputs are not submitted.
3. To fix 2 we add a hidden input immediately after the checkbox only when the checkbox should be checked.
4. The hidden input will have the same name and value as the checkbox and will override it since it appears later in the html hierarchy. A bit hacky but avoids name clashes with other fields and the need for special-case back-end code.

| Default value | Result | Stored Value |
| --- | --- | --- |
| _NONE_ | Checkbox is unchecked and disabled; no hidden input | `0` |
| `0` | Checkbox is unchecked and disabled; no hidden input | `0` |
| `1` | Checkbox is checked and disabled; hidden input is present | `1` |

I decided not to include this lengthy explanation as an inline comment - let me know if I should try to condense it and add it.

Feedback is appreciated.

## How Has This Been Tested?
Manually tested a read-only checkbox field with no default value, 0 and 1 as the default value.

## Types of changes
Bug fix

## ChangeLog
Fix: Checkbox fields not respecting their `Make field "Read Only" in UI` setting.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
