### PR TITLE
pods->save() does not clear fields with shorthand syntax

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3192,7 +3192,7 @@ class Pods implements Iterator {
 	 */
 	public function save( $data = null, $value = null, $id = null, $params = null ) {
 
-		if ( !is_array($data) ) {
+		if ( $data != null && !is_array( $data ) ) {
 			$data = array( $data => $value );
 		}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3192,7 +3192,7 @@ class Pods implements Iterator {
 	 */
 	public function save( $data = null, $value = null, $id = null, $params = null ) {
 
-		if ( null !== $value ) {
+		if ( !is_array($data) ) {
 			$data = array( $data => $value );
 		}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3192,7 +3192,7 @@ class Pods implements Iterator {
 	 */
 	public function save( $data = null, $value = null, $id = null, $params = null ) {
 
-		if ( $data != null && !is_array( $data ) ) {
+		if ( $data !== null && !is_array( $data ) ) {
 			$data = array( $data => $value );
 		}
 


### PR DESCRIPTION
`pods("pod")->save("field", null);` will never fire. In the same way `pods("pod")->save("field.id", null)` will never clear a relationship due to the current `$value==null` check. It will only work if it's called with the array syntax `pods("pod")->save(array("field" => null));` which is rather confusing behaviour.

The current `$value != null` check doesn't seem to make sense, and really is supposed to check for `$data` being a string, and if so then transforming it to an array, right?

This proposed change checks instead if `$data` is an array, and if not, changes `$data` to an array, no matter the value of `$value`. This then allows clearing of fields with the shorthand syntax.
