### PR TITLE
Fix explode issues with comma characters

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3700,9 +3700,13 @@ class PodsAPI {
 				// Handle Simple Relationships
 				if ( $simple ) {
 					if ( ! is_array( $value ) ) {
-						$value = explode( ',', $value );
+						if ( 0 < strlen( $value ) ) {
+							$value = array( $value );
+						} else {
+							$value = array();
+						}
 					}
-
+					
 					$pick_limit = (int) pods_var_raw( 'pick_limit', $options, 0 );
 
 					if ( 'single' === pods_var_raw( 'pick_format_type', $options ) ) {


### PR DESCRIPTION
Fixes #2042

## Description
Simple values that contained Commas would never save correctly due to an explode if it was not provided in an array. This would affect single select fields but not multi select for that very reason.

## ChangeLog
Fix: Single simple relationships with commas in the text no longer save as empty

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
