### PR TITLE
session_id conditional never checked for tcp sessions

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -2290,8 +2290,11 @@ function pods_session_start() {
 	} elseif ( empty( $save_path ) || ! @file_exists( $save_path ) || ! is_writable( $save_path ) ) {
 		// Check if session path exists and can be written to, avoiding PHP fatal errors.
 		return false;
-	} elseif ( '' !== session_id() ) {
+	}
+
+	if ( '' !== session_id() ) {
 		// Check if session ID is already set.
+		// In separate if clause, to also check for non-file based sessions.
 		return false;
 	}
 


### PR DESCRIPTION
If you have a `tcp://` session handler, the `session_id()` check would never run and `@session_start()` would be executed even though a session was already present.

## Description
Affects `tcp://` session handlers, like memcached.

The `session_start` conditional was checking if you have a `tcp://` handler, and then proceeded to start a session. This is because the conditional was exiting when `tcp://` was detected, and the `session_id()` condition check further down never happened. 

Due to this the `session_id()` check was only executed for file based session handlers.

## Types of changes
Moved `session_id()` check outside the big conditional, so it's always executed.

## ChangeLog
Fix: Stop duplicate session starts for tcp based session handlers