### PR TITLE
Fix foreach check_value loop by checking first if it is an array

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -1815,8 +1815,12 @@ class PodsField_Pick extends PodsField {
 
 		$check_value = $value;
 
-		foreach ( $check_value as $check_k => $check_v ) {
-			$check_value[ $check_k ] = (string) $check_v;
+		if( is_array( $check_value ) ) {
+
+			foreach ( $check_value as $check_k => $check_v ) {
+				$check_value[ $check_k ] = (string) $check_v;
+			}
+			
 		}
 
 		foreach ( $data as $v => $l ) {

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -1813,16 +1813,6 @@ class PodsField_Pick extends PodsField {
 
 		$labels = array();
 
-		$check_value = $value;
-
-		if( is_array( $check_value ) ) {
-
-			foreach ( $check_value as $check_k => $check_v ) {
-				$check_value[ $check_k ] = (string) $check_v;
-			}
-			
-		}
-
 		foreach ( $data as $v => $l ) {
 			if ( ! in_array( (string) $l, $labels, true ) && ( (string) $value === (string) $v || ( is_array( $value ) && in_array( (string) $v, $value, true ) ) ) ) {
 				$labels[] = (string) $l;


### PR DESCRIPTION
## Description
Advanced search filter in Admin UI was giving (after choosing any criteria):
Warning: Invalid argument supplied for foreach() in .../wp-content/plugins/pods/classes/fields/pick.php on line 1818

Using:
Pods - Custom Content Types and Fields: 2.7.9
WordPress Version: 5.0-beta5
PHP Version: 7.2.12

## Types of changes
IF check before foreach loop to test if $check_value variable is an array or not.

## Changelog
Avoid PHP warnings by removing unused $check_value logic in PodsField_Pick