### PR TITLE
Fix issue with pods tableless access to components

### DIFF
--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -467,13 +467,13 @@ class PodsComponents {
 
 				$component_data['ID'] = sanitize_title( $component_data['ID'] );
 
-				if ( 'on' === strtolower( $component_data['DeveloperMode'] ) || 1 === $component_data['DeveloperMode'] ) {
+				if ( 'off' !== strtolower( $component_data['DeveloperMode'] ) && '0' !== $component_data['DeveloperMode'] ) {
 					$component_data['DeveloperMode'] = true;
 				} else {
 					$component_data['DeveloperMode'] = false;
 				}
 
-				if ( 'no' !== strtolower( $component_data['TablelessMode'] ) ) {
+				if ( 'off' !== strtolower( $component_data['TablelessMode'] ) && '0' !== $component_data['TablelessMode'] ) {
 					$component_data['TablelessMode'] = true;
 				} else {
 					$component_data['TablelessMode'] = false;

--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -473,7 +473,7 @@ class PodsComponents {
 					$component_data['DeveloperMode'] = false;
 				}
 
-				if ( 'on' === strtolower( $component_data['TablelessMode'] ) || 1 === $component_data['TablelessMode'] ) {
+				if ( 'no' !== strtolower( $component_data['TablelessMode'] ) ) {
 					$component_data['TablelessMode'] = true;
 				} else {
 					$component_data['TablelessMode'] = false;


### PR DESCRIPTION
## Description
Fixes #5206 

## ChangeLog
- Only disable components when using PODS_TABLELESS if the component is relying on custom tables.

## Checklist:
- [x] My code is tested.
