### PR TITLE
Use `pods_v` to prevent PHP Warning

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -1662,7 +1662,13 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 			} elseif ( in_array( $params->field['pick_object'], $simple_tableless_objects, true ) ) {
 				$simple = true;
 			} else {
-				$table = pods_api()->get_table_info( $params->field['pick_object'], $params->field['pick_val'], null, null, $params->field );
+				$table = pods_api()->get_table_info(
+					pods_v( 'pick_object', $params->field ), 
+					pods_v( 'pick_val', $params->field ),
+					null,
+					null,
+					$params->field
+				);
 
 				if ( ! empty( $table ) ) {
 					if ( null === $params->field_index ) {

--- a/includes/data.php
+++ b/includes/data.php
@@ -1666,9 +1666,9 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 				$pick_val    = pods_v( 'pick_val', $params->field );
 				$table       = null;
 
-				if ( ! empty( $pick_object ) && ! empty( $pick_val ) )
+				if ( ! empty( $pick_object ) && ! empty( $pick_val ) ) {
 					$table = pods_api()->get_table_info(
-						$pick_object, 
+						$pick_object,
 						$pick_val,
 						null,
 						null,

--- a/includes/data.php
+++ b/includes/data.php
@@ -1662,13 +1662,19 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 			} elseif ( in_array( $params->field['pick_object'], $simple_tableless_objects, true ) ) {
 				$simple = true;
 			} else {
-				$table = pods_api()->get_table_info(
-					pods_v( 'pick_object', $params->field ), 
-					pods_v( 'pick_val', $params->field ),
-					null,
-					null,
-					$params->field
-				);
+				$pick_object = pods_v( 'pick_object', $params->field );
+				$pick_val    = pods_v( 'pick_val', $params->field );
+				$table       = null;
+
+				if ( ! empty( $pick_object ) && ! empty( $pick_val ) )
+					$table = pods_api()->get_table_info(
+						$pick_object, 
+						$pick_val,
+						null,
+						null,
+						$params->field
+					);
+				}
 
 				if ( ! empty( $table ) ) {
 					if ( null === $params->field_index ) {


### PR DESCRIPTION
## Description
Fixes #5210 - PHP Warning for array key `pods_rel` not found.

## ChangeLog
- Fix PHP Warning

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
