### PR TITLE
Avoid extra user queries when not necessary

### DIFF
--- a/classes/PodsView.php
+++ b/classes/PodsView.php
@@ -192,7 +192,7 @@ class PodsView {
 		$pods_nocache = pods_var_raw( 'pods_nocache' );
 		$nocache      = array();
 
-		if ( pods_is_admin() && null !== $pods_nocache ) {
+		if ( null !== $pods_nocache && pods_is_admin() ) {
 			if ( 1 < strlen( $pods_nocache ) ) {
 				$nocache = explode( ',', $pods_nocache );
 			} else {


### PR DESCRIPTION
pods_is_admin() check was not necessary here, it should only run if the nocache break is attempted for use.

## ChangeLog
Fixed: Remove unnecessary user query on each load

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
