### PR TITLE
Add ability to auto calculate total_found

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -776,7 +776,7 @@ class PodsData {
 		if ( ! empty( $this->data ) ) {
 			$this->total = count( (array) $this->data );
 		}
-		
+
 		/**
 		 * Filters whether the total_found should be calculated right away or not.
 		 *

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -776,6 +776,20 @@ class PodsData {
 		if ( ! empty( $this->data ) ) {
 			$this->total = count( (array) $this->data );
 		}
+		
+		/**
+		 * Filters whether the total_found should be calculated right away or not.
+		 *
+		 * @param boolean  $auto_calculate_total_found Whether to auto calculate total_found.
+		 * @param array    $params                     Select parameters.
+		 * @param PodsData $this                       The current PodsData instance.
+		 *
+		 * @since 2.7.11
+		 */
+		if ( apply_filters( 'pods_data_auto_calculate_total_found', false, $params, $this ) ) {
+			// Run the calculation logic.
+			$this->calculate_totals();
+		}
 
 		return $this->data;
 	}


### PR DESCRIPTION
Needed for when hooking into shortcode output filter to show total found information about Pods query. Otherwise, there's it shows the wrong total found referencing the wrong query.

## How Has This Been Tested?
Tested "live"

## ChangeLog
Added: New `pods_data_auto_calculate_total_found` filter can be set to true to auto-calculate total_found() number right away after a Pods::find() query runs, defaults to false

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
