### PR TITLE
Fix table info handling in pods_serial_comma

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3706,7 +3706,7 @@ class PodsAPI {
 							$value = array();
 						}
 					}
-					
+
 					$pick_limit = (int) pods_var_raw( 'pick_limit', $options, 0 );
 
 					if ( 'single' === pods_var_raw( 'pick_format_type', $options ) ) {
@@ -8239,7 +8239,7 @@ class PodsAPI {
 		if ( empty( $object_type ) ) {
 			$object_type = 'post_type';
 			$object      = 'post';
-		} elseif ( empty( $object ) && in_array( $object_type, array( 'user', 'media', 'comment' ) ) ) {
+		} elseif ( empty( $object ) && in_array( $object_type, array( 'user', 'media', 'comment' ), true ) ) {
 			$object = $object_type;
 		}
 

--- a/includes/data.php
+++ b/includes/data.php
@@ -1666,7 +1666,7 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 				$pick_val    = pods_v( 'pick_val', $params->field );
 				$table       = null;
 
-				if ( ! empty( $pick_object ) && ! empty( $pick_val ) ) {
+				if ( ! empty( $pick_object ) && ( ! empty( $pick_val ) || in_array( $pick_object, array( 'user', 'media', 'comment' ), true ) ) ) {
 					$table = pods_api()->get_table_info(
 						$pick_object,
 						$pick_val,
@@ -1700,6 +1700,16 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 	}
 
 	$last = '';
+
+	// If something happens with table info, and this is a single select relationship, avoid letting user pass through.
+	if ( isset( $value['user_pass'] ) ) {
+		unset( $value['user_pass'] );
+
+		// Since we know this is a single select, just pass display name through as the fallback.
+		if ( isset( $value['display_name'] ) ) {
+			$value = array( $value['display_name'] );
+		}
+	}
 
 	$original_value = $value;
 


### PR DESCRIPTION
## Description
Fixes user, comment, and media serial comma usage.

## ChangeLog
Fixed: Serial comma display works again for Users, Comments, and Media relationships when used in Pods::display() and magic tag templating without specifying the object field you want to display.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
