### PR TITLE
Remove "2.x" prefix from the release tag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function ( grunt ) {
 		gittag: {
 			addtag: {
 				options: {
-					tag    : '2.x/<%= pkg.version %>',
+					tag    : '<%= pkg.version %>',
 					message: 'Pods <%= pkg.version %>'
 				}
 			}


### PR DESCRIPTION
Fix for #5278