### PR TITLE
DateTime/Time field enhancements

### DIFF
--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -389,13 +389,7 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function format_value_display( $value, $options, $js = false ) {
 
-		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
-			$js = false;
-		}
-		$format = $this->format_datetime( $options, $js );
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
-		}
+		$format = $this->format_display( $options, $js );
 
 		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
 			// Try default storage format.
@@ -424,6 +418,29 @@ class PodsField_DateTime extends PodsField {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Build date and/or time display format string based on options
+	 *
+	 * @since 2.7.13
+	 *
+	 * @param  array $options Field options.
+	 * @param  bool  $js      Whether to return format for jQuery UI.
+	 *
+	 * @return string
+	 */
+	public function format_display( $options, $js = false ) {
+
+		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
+			$js = false;
+		}
+		$format = $this->format_datetime( $options, $js );
+		if ( $js ) {
+			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
+		}
+
+		return $format;
 	}
 
 	/**

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -400,17 +400,20 @@ class PodsField_DateTime extends PodsField {
 		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
 			// Try default storage format.
 			$date = $this->createFromFormat( static::$storage_format, (string) $value );
-
-			// Try field format.
-			$date_local = $this->createFromFormat( $format, (string) $value );
-
+			
 			// Convert to timestamp.
 			if ( $date instanceof DateTime ) {
 				$timestamp = $date->getTimestamp();
-			} elseif ( $date_local instanceof DateTime ) {
-				$timestamp = $date_local->getTimestamp();
 			} else {
-				$timestamp = strtotime( (string) $value );
+				// Try field format.
+				$date_local = $this->createFromFormat( $format, (string) $value );
+				
+				if ( $date_local instanceof DateTime ) {
+					$timestamp = $date_local->getTimestamp();
+				} else {
+					// Fallback.
+					$timestamp = strtotime( (string) $value );
+				}
 			}
 
 			$value = date_i18n( $format, $timestamp );

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -191,28 +191,36 @@ class PodsField_Time extends PodsField_DateTime {
 		switch ( (string) pods_v( static::$type . '_type', $options, '12', true ) ) {
 			case '12':
 				$time_format = $this->get_time_formats( $js );
-				$format      = $time_format[ pods_v( static::$type . '_format', $options, 'hh_mm', true ) ];
+
+				$format = $time_format[ pods_v( static::$type . '_format', $options, 'hh_mm', true ) ];
+
 				break;
 			case '24':
 				$time_format_24 = $this->get_time_formats_24( $js );
-				$format         = $time_format_24[ pods_v( static::$type . '_format_24', $options, 'hh_mm', true ) ];
+
+				$format = $time_format_24[ pods_v( static::$type . '_format_24', $options, 'hh_mm', true ) ];
+
 				break;
 			case 'custom':
 				if ( ! $js ) {
 					$format = pods_v( static::$type . '_format_custom', $options, '' );
 				} else {
 					$format = pods_v( static::$type . '_format_custom_js', $options, '' );
+
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_format_custom', $options, '' );
 						$format = $this->convert_format( $format, array( 'source' => 'php' ) );
 					}
 				}
+
 				break;
 			default:
 				$format = get_option( 'time_format' );
+
 				if ( $js ) {
 					$format = $this->convert_format( $format, array( 'source' => 'php' ) );
 				}
+
 				break;
 		}//end switch
 

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -170,50 +170,6 @@ class PodsField_Time extends PodsField_DateTime {
 	}
 
 	/**
-	 * Convert value to the correct format for display.
-	 *
-	 * @param string $value   Field value.
-	 * @param array  $options Field options.
-	 * @param bool   $js      Return formatted from jQuery UI format? (only for custom formats).
-	 *
-	 * @return string
-	 * @since 2.7.0
-	 */
-	public function format_value_display( $value, $options, $js = false ) {
-
-		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
-			$js = false;
-		}
-		$format = $this->format_datetime( $options, $js );
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
-		}
-
-		if ( ! $this->is_empty( $value ) ) {
-			// Try default storage format.
-			$date = $this->createFromFormat( static::$storage_format, (string) $value );
-
-			// Try field format.
-			$date_local = $this->createFromFormat( $format, (string) $value );
-
-			if ( $date instanceof DateTime ) {
-				$value = $date->format( $format );
-			} elseif ( $date_local instanceof DateTime ) {
-				$value = $date_local->format( $format );
-			} else {
-				$value = date_i18n( $format, strtotime( (string) $value ) );
-			}
-		} elseif ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
-			$value = date_i18n( $format );
-		} else {
-			$value = '';
-		}
-
-		return $value;
-	}
-
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function format_datetime( $options, $js = false ) {


### PR DESCRIPTION
Some enhancements for the Date/Time fields I've found after #5297

- The Time field didn't reflect the changes made in #5297.
  - Removed redundant method override in PodsField_Time (`format_value_display()`)
- Minor performance enhancement (do not create local DateTime instance if it isn't required)
- Get format for display in a separate method (better for testing & class inheritance)
- Sync code format between DateTime/Time field classes.