### PR TITLE
Field Container: Default to empty string for value if it is passed as null or undefined

### DIFF
--- a/ui/js/pods-dfv/src/components/field-container.js
+++ b/ui/js/pods-dfv/src/components/field-container.js
@@ -4,7 +4,7 @@ const useState = React.useState;
 
 export const PodsDFVFieldContainer = ( props ) => {
 	const Field = props.fieldComponent;
-	const [ value, setValue ] = useState( props.fieldItemData[ 0 ] );
+	const [ value, setValue ] = useState( props.fieldItemData[ 0 ] || '' );
 	const [ validationMessages, setValidationMessages ] = useState( [] );
 
 	return (


### PR DESCRIPTION
React will treat an input as an uncontrolled input if the value state is set to null or undefined.  