### PR TITLE
Fix typo `width` > `with`

### DIFF
--- a/classes/fields/currency.php
+++ b/classes/fields/currency.php
@@ -95,7 +95,7 @@ class PodsField_Currency extends PodsField_Number {
 					'after_space'           => __( 'After with space (ex. 100 $)', 'pods' ),
 					'none'                  => __( 'None (ex. 100)', 'pods' ),
 					'beforeaftercode'       => __( 'Before with Currency Code after (ex. $100 USD)', 'pods' ),
-					'beforeaftercode_space' => __( 'Before width space and with Currency Code after (ex. $ 100 USD)', 'pods' ),
+					'beforeaftercode_space' => __( 'Before with space and with Currency Code after (ex. $ 100 USD)', 'pods' ),
 				),
 			),
 			static::$type . '_format'           => array(


### PR DESCRIPTION
Fixed #5386

## Changelog:
- Fix typo: "width" to "with"

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
