### PR TITLE
Add Pods debug information to Site Info area

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -3717,6 +3717,10 @@ class PodsAdmin {
 					'label' => __( 'Pods Install Location', 'pods' ),
 					'value' => PODS_DIR,
 				),
+				'pods-developer'                  => array(
+					'label' => __( 'Pods Developer Activated' ),
+					'value' => ( pods_developer() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
 				'pods-tableless-mode'             => array(
 					'label' => __( 'Pods Tableless Mode Activated', 'pods' ),
 					'value' => ( pods_tableless() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
@@ -3724,6 +3728,18 @@ class PodsAdmin {
 				'pods-light-mode'                 => array(
 					'label' => __( 'Pods Light Mode Activated', 'pods' ),
 					'value' => ( pods_light() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-strict'                     => array(
+					'label' => __( 'Pods Strict Activated' ),
+					'value' => ( pods_strict() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-allow-deprecated'           => array(
+					'label' => __( 'Pods Allow Deprecated' ),
+					'value' => ( pods_allow_deprecated() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-api-cache'                  => array(
+					'label' => __( 'Pods API Cache Activated' ),
+					'value' => ( pods_api_cache() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
 				),
 			),
 		);

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -636,7 +636,7 @@ class PodsAdmin {
 		$parent = false;
 
 		// PODS_LIGHT disables all Pods components so remove the components menu
-		if ( defined( 'PODS_LIGHT' ) && true === PODS_LIGHT ) {
+		if ( pods_light() ) {
 			unset( $admin_menus['pods-components'] );
 		}
 
@@ -3723,7 +3723,7 @@ class PodsAdmin {
 				),
 				'pods-light-mode'                 => array(
 					'label' => __( 'Pods Light Mode Activated', 'pods' ),
-					'value' => ( defined( 'PODS_LIGHT' ) && PODS_LIGHT ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+					'value' => ( pods_light() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
 				),
 			),
 		);

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -58,7 +58,7 @@ class PodsAdmin {
 		add_action( 'admin_head-media-upload-popup', array( $this, 'register_media_assets' ) );
 
 		// Add our debug to Site Info.
-		add_filter( 'debug_information', array( $this, 'add_debug_information' );
+		add_filter( 'debug_information', array( $this, 'add_debug_information' ) );
 
 		$this->rest_admin();
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -57,6 +57,9 @@ class PodsAdmin {
 
 		add_action( 'admin_head-media-upload-popup', array( $this, 'register_media_assets' ) );
 
+		// Add our debug to Site Info.
+		add_filter( 'debug_information', array( $this, 'add_debug_information' );
+
 		$this->rest_admin();
 
 	}
@@ -3622,6 +3625,110 @@ class PodsAdmin {
 		$tabs['rest'] = __( 'REST API', 'pods' );
 
 		return $tabs;
+	}
+
+	/**
+	 * Add Pods-specific debug info to Site Info debug area.
+	 *
+	 * @since 2.7.13
+	 *
+	 * @param array $info Debug info.
+	 *
+	 * @return array Debug info with Pods-specific debug info added.
+	 */
+	public function add_debug_information( $info ) {
+		$info['pods'] = array(
+			'label'       => 'Pods',
+			'description' => __( 'Debug information for Pods installations.', 'pods' ),
+			'fields'      => array(
+				'pods-server-software'            => array(
+					'label' => __( 'Server Software', 'pods' ),
+					'value' => ! empty( $_SERVER['SERVER_SOFTWARE'] ) ? $_SERVER['SERVER_SOFTWARE'] : 'N/A',
+				),
+				'pods-user-agent'                 => array(
+					'label' => __( 'Your User Agent', 'pods' ),
+					'value' => ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : 'N/A',
+				),
+				'pods-session-save-path'          => array(
+					'label' => __( 'Session Save Path', 'pods' ),
+					'value' => session_save_path(),
+				),
+				'pods-session-save-path-exists'   => array(
+					'label' => __( 'Session Save Path Exists', 'pods' ),
+					'value' => file_exists( session_save_path() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-session-save-path-writable' => array(
+					'label' => __( 'Session Save Path Writeable', 'pods' ),
+					'value' => is_writable( session_save_path() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-session-max-lifetime'       => array(
+					'label' => __( 'Session Max Lifetime', 'pods' ),
+					'value' => ini_get( 'session.gc_maxlifetime' ),
+				),
+				'pods-opcode-cache-apc'           => array(
+					'label' => __( 'Opcode Cache: Apc', 'pods' ),
+					'value' => function_exists( 'apc_cache_info' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-opcode-cache-memcached'     => array(
+					'label' => __( 'Opcode Cache: Memcached', 'pods' ),
+					'value' => class_exists( 'eaccelerator_put' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-opcode-cache-opcache'       => array(
+					'label' => __( 'Opcode Cache: OPcache', 'pods' ),
+					'value' => function_exists( 'opcache_get_status' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-opcode-cache-redis'         => array(
+					'label' => __( 'Opcode Cache: Redis', 'pods' ),
+					'value' => class_exists( 'xcache_set' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-object-cache-apc'           => array(
+					'label' => __( 'Object Cache: APC', 'pods' ),
+					'value' => function_exists( 'apc_cache_info' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-object-cache-apcu'          => array(
+					'label' => __( 'Object Cache: APCu', 'pods' ),
+					'value' => function_exists( 'apcu_cache_info' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-object-cache-memcache'      => array(
+					'label' => __( 'Object Cache: Memcache', 'pods' ),
+					'value' => class_exists( 'Memcache' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-object-cache-memcached'     => array(
+					'label' => __( 'Object Cache: Memcached', 'pods' ),
+					'value' => class_exists( 'Memcached' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-object-cache-redis'         => array(
+					'label' => __( 'Object Cache: Redis', 'pods' ),
+					'value' => class_exists( 'Redis' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-memory-current-usage'       => array(
+					'label' => __( 'Current Memory Usage', 'pods' ),
+					'value' => number_format_i18n( memory_get_usage() / 1024 / 1024, 3 ) . 'M',
+				),
+				'pods-memory-current-usage-real'  => array(
+					'label' => __( 'Current Memory Usage (real)', 'pods' ),
+					'value' => number_format_i18n( memory_get_usage( true ) / 1024 / 1024, 3 ) . 'M',
+				),
+				'pods-network-wide'               => array(
+					'label' => __( 'Pods Network-Wide Activated', 'pods' ),
+					'value' => is_plugin_active_for_network( basename( PODS_DIR ) . '/init.php' ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-install-location'           => array(
+					'label' => __( 'Pods Install Location', 'pods' ),
+					'value' => PODS_DIR,
+				),
+				'pods-tableless-mode'             => array(
+					'label' => __( 'Pods Tableless Mode Activated', 'pods' ),
+					'value' => ( pods_tableless() ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+				'pods-light-mode'                 => array(
+					'label' => __( 'Pods Light Mode Activated', 'pods' ),
+					'value' => ( defined( 'PODS_LIGHT' ) && PODS_LIGHT ) ? __( 'Yes', 'pods' ) : __( 'No', 'pods' ),
+				),
+			),
+		);
+
+		return $info;
 	}
 
 }

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -161,7 +161,7 @@ class PodsInit {
 			return;
 		}
 
-		if ( ! defined( 'PODS_LIGHT' ) || ! PODS_LIGHT ) {
+		if ( ! pods_light() ) {
 			self::$components = pods_components();
 		}
 

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1868,6 +1868,7 @@ class PodsInit {
 	public function filter_query_monitor_conditionals( $conditionals ) {
 		$conditionals[] = 'pods_developer';
 		$conditionals[] = 'pods_tableless';
+		$conditionals[] = 'pods_light';
 		$conditionals[] = 'pods_strict';
 		$conditionals[] = 'pods_allow_deprecated';
 		$conditionals[] = 'pods_api_cache';

--- a/includes/general.php
+++ b/includes/general.php
@@ -389,6 +389,22 @@ function pods_tableless() {
 }
 
 /**
+ * Determine if Light Mode is enabled
+ *
+ * @return bool Whether Light Mode is enabled
+ *
+ * @since 2.7.13
+ */
+function pods_light() {
+
+	if ( defined( 'PODS_LIGHT' ) && PODS_LIGHT ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Determine if Strict Mode is enabled
  *
  * @param bool $include_debug Whether to include WP_DEBUG in strictness level

--- a/includes/general.php
+++ b/includes/general.php
@@ -396,7 +396,6 @@ function pods_tableless() {
  * @since 2.7.13
  */
 function pods_light() {
-
 	if ( defined( 'PODS_LIGHT' ) && PODS_LIGHT ) {
 		return true;
 	}

--- a/sql/upgrade/PodsUpgrade.php
+++ b/sql/upgrade/PodsUpgrade.php
@@ -90,7 +90,7 @@ class PodsUpgrade {
 
 			// Auto activate component.
 			if ( ! PodsInit::$components ) {
-				if ( ! defined( 'PODS_LIGHT' ) || ! PODS_LIGHT ) {
+				if ( ! pods_light() ) {
 					PodsInit::$components = pods_components();
 				}
 			}

--- a/ui/admin/settings-tools.php
+++ b/ui/admin/settings-tools.php
@@ -83,7 +83,7 @@ $versions = array(
 	'Pods Network-Wide Activated'   => ( is_plugin_active_for_network( basename( PODS_DIR ) . '/init.php' ) ? 'Yes' : 'No' ),
 	'Pods Install Location'         => PODS_DIR,
 	'Pods Tableless Mode Activated' => ( ( pods_tableless() ) ? 'Yes' : 'No' ),
-	'Pods Light Mode Activated'     => ( ( defined( 'PODS_LIGHT' ) && PODS_LIGHT ) ? 'Yes' : 'No' ),
+	'Pods Light Mode Activated'     => ( ( pods_light() ) ? 'Yes' : 'No' ),
 	'Currently Active Theme'        => $theme_name,
 	'Currently Active Plugins'      => $plugins,
 );


### PR DESCRIPTION
## Description
WP now has a great new Site Info area, it provides more details we could use when debugging so this adds our unique debug info to that and we can simplify our debug process going forward with that.

## ChangeLog
* Added: Add debug information for Pods to Site Health Info area

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
