### PR TITLE
Always convert with UTC timezone

### DIFF
--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -394,14 +394,14 @@ class PodsField_DateTime extends PodsField {
 		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
 			// Try default storage format.
 			$date = $this->createFromFormat( static::$storage_format, (string) $value );
-			
+
 			// Convert to timestamp.
 			if ( $date instanceof DateTime ) {
 				$timestamp = $date->getTimestamp();
 			} else {
 				// Try field format.
 				$date_local = $this->createFromFormat( $format, (string) $value );
-				
+
 				if ( $date_local instanceof DateTime ) {
 					$timestamp = $date_local->getTimestamp();
 				} else {
@@ -675,25 +675,19 @@ class PodsField_DateTime extends PodsField {
 
 		try {
 			if ( method_exists( 'DateTime', 'createFromFormat' ) ) {
-				$timezone = get_option( 'timezone_string' );
 
-				if ( empty( $timezone ) ) {
-					$timezone = timezone_name_from_abbr( '', get_option( 'gmt_offset' ) * HOUR_IN_SECONDS, 0 );
+				$datetimezone = new DateTimeZone( 'UTC' );
+
+				$datetime = DateTime::createFromFormat( $format, (string) $date, $datetimezone );
+
+				if ( false === $datetime ) {
+					$datetime = DateTime::createFromFormat( static::$storage_format, (string) $date, $datetimezone );
 				}
 
-				if ( ! empty( $timezone ) ) {
-					$datetimezone = new DateTimeZone( $timezone );
-
-					$datetime = DateTime::createFromFormat( $format, (string) $date, $datetimezone );
-
-					if ( false === $datetime ) {
-						$datetime = DateTime::createFromFormat( static::$storage_format, (string) $date, $datetimezone );
-					}
-
-					if ( false !== $datetime && $return_timestamp ) {
-						return $datetime;
-					}
+				if ( false !== $datetime && $return_timestamp ) {
+					return $datetime;
 				}
+
 			}//end if
 
 			if ( in_array( $datetime, array( null, false ), true ) ) {


### PR DESCRIPTION
Fixes #5382, #5402, #5403 and probably more

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
Currently after date/time values are stored into the database the date/time field convert them using the WordPress timezone setting (in cases where DateTime is available). This conversion is incorrect since it returns a different value than the user's input.

## ChangeLog
* Always convert database value for date/time fields with UTC timezone to maintain the actual value.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
