### PR TITLE
FIX Import from file with absolute path

### DIFF
--- a/classes/PodsMigrate.php
+++ b/classes/PodsMigrate.php
@@ -1290,7 +1290,7 @@ class PodsMigrate {
 		$path = ABSPATH;
 
 		// Detect path if it is set in the file param.
-		if ( false !== strpos( $file, '/' ) ) {
+		if ( false !== strpos( $file, DIRECTORY_SEPARATOR ) ) {
 			$path = dirname( $file );
 			$file = basename( $file );
 		}
@@ -1309,7 +1309,7 @@ class PodsMigrate {
 
 		$migrate = new self( $format, null, $migrate_data );
 
-		$raw_data = file_get_contents( $file );
+		$raw_data = file_get_contents( $path . DIRECTORY_SEPARATOR . $file );
 
 		// Handle processing the raw data from the format needed.
 		$data = $migrate->parse( $raw_data );


### PR DESCRIPTION
## Description
FIX Import from file with absolute path

## How Has This Been Tested?
Var $path was not used, so file cannot be imported
I test this by cli pods-api import

## ChangeLog
Fix: Import from file with absolute path (@mistraloz)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
