### PR TITLE
Fix numeric soft format issue removing decimals & numeric slider input formatting

### DIFF
--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -311,11 +311,13 @@ class PodsField_Number extends PodsField {
 		}
 
 		// Optionally remove trailing decimal zero's.
-		if ( pods_v( static::$type . '_format_soft', $options, 0 ) ) {
+		if ( pods_v( static::$type . '_format_soft', $options, false ) ) {
 			$parts = explode( $dot, $value );
 			if ( isset( $parts[1] ) ) {
 				$parts[1] = rtrim( $parts[1], '0' );
-				$parts    = array_filter( $parts );
+				if ( empty( $parts[1] ) ) {
+					unset( $parts[1] );
+				}
 			}
 			$value = implode( $dot, $parts );
 		}

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -312,17 +312,31 @@ class PodsField_Number extends PodsField {
 
 		// Optionally remove trailing decimal zero's.
 		if ( pods_v( static::$type . '_format_soft', $options, false ) ) {
-			$parts = explode( $dot, $value );
-			if ( isset( $parts[1] ) ) {
-				$parts[1] = rtrim( $parts[1], '0' );
-				if ( empty( $parts[1] ) ) {
-					unset( $parts[1] );
-				}
-			}
-			$value = implode( $dot, $parts );
+			$value = $this->trim_decimals( $value, $dot );
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Trim trailing 0 decimals from numbers.
+	 *
+	 * @since 2.7.15
+	 *
+	 * @param string $value
+	 * @param string $dot
+	 *
+	 * @return string
+	 */
+	public function trim_decimals( $value, $dot ) {
+		$parts = explode( $dot, $value );
+		if ( isset( $parts[1] ) ) {
+			$parts[1] = rtrim( $parts[1], '0' );
+			if ( empty( $parts[1] ) ) {
+				unset( $parts[1] );
+			}
+		}
+		return implode( $dot, $parts );
 	}
 
 	/**

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -283,6 +283,7 @@ class PodsField_Number extends PodsField {
 			// Slider only supports `1234.00` format so no need for replacing characters.
 			$value = str_replace( array( $thousands, $dot ), array( '', '.' ), $value );
 		}
+
 		$value = trim( $value );
 
 		$value = preg_replace( '/[^0-9\.\-]/', '', $value );
@@ -338,12 +339,15 @@ class PodsField_Number extends PodsField {
 	 */
 	public function trim_decimals( $value, $dot ) {
 		$parts = explode( $dot, $value );
+
 		if ( isset( $parts[1] ) ) {
 			$parts[1] = rtrim( $parts[1], '0' );
+
 			if ( empty( $parts[1] ) ) {
 				unset( $parts[1] );
 			}
 		}
+
 		return implode( $dot, $parts );
 	}
 

--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -279,12 +279,20 @@ class PodsField_Number extends PodsField {
 		$dot         = $format_args['dot'];
 		$decimals    = $format_args['decimals'];
 
-		$value = str_replace( array( $thousands, $dot ), array( '', '.' ), $value );
+		if ( 'slider' !== pods_v( static::$type . '_format_type', $options ) ) {
+			// Slider only supports `1234.00` format so no need for replacing characters.
+			$value = str_replace( array( $thousands, $dot ), array( '', '.' ), $value );
+		}
 		$value = trim( $value );
 
 		$value = preg_replace( '/[^0-9\.\-]/', '', $value );
 
 		$value = number_format( (float) $value, $decimals, '.', '' );
+
+		// Optionally remove trailing decimal zero's.
+		if ( pods_v( static::$type . '_format_soft', $options, false ) ) {
+			$value = $this->trim_decimals( $value, '.' );
+		}
 
 		return $value;
 	}


### PR DESCRIPTION
Fixes #5281 
Fixes #5215

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Removed `array_filter()` since it filtered all array values and it should only remove the decimals if empty. Also moved this code to a separate method to re-use in `pre_save()`.
- For slider input I've forced the input format to `1234.00` since the jQuery UI Slider only supports that input format.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fix numeric soft format issue removing decimals & numeric slider input formatting

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
