### PR TITLE
Fix issue with extending post types and reserved keywords.

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1664,7 +1664,7 @@ class PodsAPI {
 	 * $params['object'] string The object being extended (if any)
 	 * $params['storage'] string The Pod storage
 	 * $params['options'] array Options
-	 * $params['extend'] bool Extending an existing content type?
+	 * $params['create_extend'] string Create or Extend a Content Type
 	 *
 	 * @param array    $params    An associative array of parameters
 	 * @param bool     $sanitized (optional) Decides whether the params have been sanitized before being passed, will

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1679,7 +1679,7 @@ class PodsAPI {
 		$tableless_field_types    = PodsForm::tableless_field_types();
 		$simple_tableless_objects = PodsForm::simple_tableless_objects();
 
-		$extend = ( is_array( $params ) && ! empty( $params['create_extend'] ) && 'extend' === $params['create_extend']  );
+		$extend = ( is_array( $params ) && ! empty( $params['create_extend'] ) && 'extend' === $params['create_extend'] );
 		unset( $params['create_extend'] );
 
 		$load_params = (object) $params;
@@ -1767,7 +1767,8 @@ class PodsAPI {
 				in_array( $params->name, pods_reserved_keywords(), true )
 				&& in_array( pods_v( 'type', $params ), array( 'post_type', 'taxonomy' ), true )
 			) {
-			       $valid_name = false;
+				$valid_name = false;
+
 				if ( $extend ) {
 					if ( 'post_type' === pods_v( 'type', $params ) ) {
 						$valid_name = in_array( $params->name, get_post_types(), true );
@@ -1775,6 +1776,7 @@ class PodsAPI {
 						$valid_name = in_array( $params->name, get_taxonomies(), true );
 					}
 				}
+
 				if ( ! $valid_name ) {
 					return pods_error( sprintf( __( '%s is reserved for internal WordPress or Pods usage, please try a different name', 'pods' ), $params->name ), $this );
 				}

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1769,6 +1769,8 @@ class PodsAPI {
 			) {
 				$valid_name = false;
 
+				// Only if it's extending an existing content type then these
+				// names are still allowed, even if they are reserved.
 				if ( $extend ) {
 					if ( 'post_type' === pods_v( 'type', $params ) ) {
 						$valid_name = in_array( $params->name, get_post_types(), true );

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1505,12 +1505,13 @@ class PodsAPI {
 		}
 
 		$pod_params = array(
-			'name'    => '',
-			'label'   => '',
-			'type'    => '',
-			'storage' => 'table',
-			'object'  => '',
-			'options' => array()
+			'name'          => '',
+			'label'         => '',
+			'type'          => '',
+			'storage'       => 'table',
+			'object'        => '',
+			'options'       => array(),
+			'create_extend' => $params->create_extend,
 		);
 
 		if ( 'create' === $params->create_extend ) {
@@ -1663,6 +1664,7 @@ class PodsAPI {
 	 * $params['object'] string The object being extended (if any)
 	 * $params['storage'] string The Pod storage
 	 * $params['options'] array Options
+	 * $params['extend'] bool Extending an existing content type?
 	 *
 	 * @param array    $params    An associative array of parameters
 	 * @param bool     $sanitized (optional) Decides whether the params have been sanitized before being passed, will
@@ -1676,6 +1678,9 @@ class PodsAPI {
 
 		$tableless_field_types    = PodsForm::tableless_field_types();
 		$simple_tableless_objects = PodsForm::simple_tableless_objects();
+
+		$extend = ( is_array( $params ) && ! empty( $params['create_extend'] ) && 'extend' === $params['create_extend']  );
+		unset( $params['create_extend'] );
 
 		$load_params = (object) $params;
 
@@ -1709,6 +1714,8 @@ class PodsAPI {
 		}
 
 		if ( ! empty( $pod ) ) {
+			// Existing pod (update).
+
 			if ( isset( $params->id ) && 0 < $params->id ) {
 				$old_id = $params->id;
 			}
@@ -1754,12 +1761,26 @@ class PodsAPI {
 					return pods_error( sprintf( __( 'Pod %s already exists', 'pods' ), $params->name ), $this );
 				}
 			}
-		} elseif (
-			in_array( $params->name, pods_reserved_keywords(), true )
-			&& in_array( pods_v( 'type', $params ), array( 'post_type', 'taxonomy' ), true )
-		) {
-			return pods_error( sprintf( __( '%s is reserved for internal WordPress or Pods usage, please try a different name' ), $params->name ), $this );
 		} else {
+			// New pod (create).
+
+			if (
+				in_array( $params->name, pods_reserved_keywords(), true )
+				&& in_array( pods_v( 'type', $params ), array( 'post_type', 'taxonomy' ), true )
+			) {
+			       $valid_name = false;
+				if ( $extend ) {
+					if ( 'post_type' === pods_v( 'type', $params ) ) {
+						$valid_name = in_array( $params->name, get_post_types(), true );
+					} elseif ( 'taxonomy' === pods_v( 'type', $params ) ) {
+						$valid_name = in_array( $params->name, get_taxonomies(), true );
+					}
+				}
+				if ( ! $valid_name ) {
+					return pods_error( sprintf( __( '%s is reserved for internal WordPress or Pods usage, please try a different name', 'pods' ), $params->name ), $this );
+				}
+			}
+
 			$pod = array(
 				'id'          => 0,
 				'name'        => $params->name,


### PR DESCRIPTION
## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
Fix an issue related to #5428 (reserved keywords). When extending CPT or taxonomies it gave errors on (for example) `page` post type since that is also a reserved keyword.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
I've brought the `create_extend` parameter into `save_pod`. If that is set and is set to `extend` it will validate against existing CPT/Tax objects. If that name exists the name will still be valid.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
No need for an extra changelog.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
