### PR TITLE
Feature: Date/datetime year range option

### DIFF
--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -60,17 +60,17 @@ class PodsField_Date extends PodsField_DateTime {
 				'developer_mode'    => true,
 			),
 			static::$type . '_type'             => array(
-				'label'                        => __( 'Date Format Type', 'pods' ),
-				'default'                      => 'format',
+				'label'      => __( 'Date Format Type', 'pods' ),
+				'default'    => 'format',
 				// Backwards compatibility
-										'type' => 'pick',
-				'help'                         => __( 'WordPress Default is the format used in Settings, General under "Date Format".', 'pods' ) . '<br>' . __( 'Predefined Format will allow you to select from a list of commonly used date formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
-				'data'                         => array(
+				'type'       => 'pick',
+				'help'       => __( 'WordPress Default is the format used in Settings, General under "Date Format".', 'pods' ) . '<br>' . __( 'Predefined Format will allow you to select from a list of commonly used date formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
+				'data'       => array(
 					'wp'     => __( 'WordPress default', 'pods' ) . ': ' . date_i18n( get_option( 'date_format' ) ),
 					'format' => __( 'Predefined format', 'pods' ),
 					'custom' => __( 'Custom format', 'pods' ),
 				),
-				'dependency'                   => true,
+				'dependency' => true,
 			),
 			static::$type . '_format_custom'    => array(
 				'label'      => __( 'Date format for display', 'pods' ),

--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -111,7 +111,7 @@ class PodsField_Date extends PodsField_DateTime {
 				),
 				'dependency' => true,
 			),
-			static::$type . '_year_range'      => array(
+			static::$type . '_year_range_custom' => array(
 				'label'   => __( 'Year range', 'pods' ),
 				'default' => '',
 				'type'    => 'text',

--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -116,7 +116,12 @@ class PodsField_Date extends PodsField_DateTime {
 				'default' => '',
 				'type'    => 'text',
 				'help'    => sprintf(
-					'<a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%1$s</a>',
+					'%1$s<br /><a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%2$s</a>',
+					sprintf(
+						esc_html__( 'Example: %1$s for specifying a hard coded year range or %2$s for the last and next 10 years.', 'pods' ),
+						'<code>2010:2030</code>',
+						'<code>-10:+10</code>'
+					),
 					esc_html__( 'jQuery UI datepicker documentation', 'pods' )
 				),
 			),

--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -111,6 +111,15 @@ class PodsField_Date extends PodsField_DateTime {
 				),
 				'dependency' => true,
 			),
+			static::$type . '_year_range'      => array(
+				'label'   => __( 'Year range', 'pods' ),
+				'default' => '',
+				'type'    => 'text',
+				'help'    => sprintf(
+					'<a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%1$s</a>',
+					esc_html__( 'jQuery UI datepicker documentation', 'pods' )
+				),
+			),
 			static::$type . '_allow_empty'      => array(
 				'label'   => __( 'Allow empty value?', 'pods' ),
 				'default' => 1,

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -181,7 +181,7 @@ class PodsField_DateTime extends PodsField {
 					'hh_mm_ss' => date_i18n( 'H:i:s' ),
 				),
 			),
-			static::$type . '_year_range'      => array(
+			static::$type . '_year_range_custom' => array(
 				'label'   => __( 'Year range', 'pods' ),
 				'default' => '',
 				'type'    => 'text',

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -186,7 +186,12 @@ class PodsField_DateTime extends PodsField {
 				'default' => '',
 				'type'    => 'text',
 				'help'    => sprintf(
-					'<a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%1$s</a>',
+					'%1$s<br /><a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%2$s</a>',
+					sprintf(
+						esc_html__( 'Example: %1$s for specifying a hard coded year range or %2$s for the last and next 10 years.', 'pods' ),
+						'<code>2010:2030</code>',
+						'<code>-10:+10</code>'
+					),
 					esc_html__( 'jQuery UI datepicker documentation', 'pods' )
 				),
 			),

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -181,6 +181,15 @@ class PodsField_DateTime extends PodsField {
 					'hh_mm_ss' => date_i18n( 'H:i:s' ),
 				),
 			),
+			static::$type . '_year_range'      => array(
+				'label'   => __( 'Year range', 'pods' ),
+				'default' => '',
+				'type'    => 'text',
+				'help'    => sprintf(
+					'<a href="https://api.jqueryui.com/datepicker/#option-yearRange" target="_blank">%1$s</a>',
+					esc_html__( 'jQuery UI datepicker documentation', 'pods' )
+				),
+			),
 			static::$type . '_allow_empty'           => array(
 				'label'   => __( 'Allow empty value?', 'pods' ),
 				'default' => 1,

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -65,17 +65,17 @@ class PodsField_DateTime extends PodsField {
 				'developer_mode'    => true,
 			),
 			static::$type . '_type'                  => array(
-				'label'                        => __( 'Date Format Type', 'pods' ),
-				'default'                      => 'format',
+				'label'      => __( 'Date Format Type', 'pods' ),
+				'default'    => 'format',
 				// Backwards compatibility
-										'type' => 'pick',
-				'help'                         => __( 'WordPress Default is the format used in Settings, General under "Date Format".', 'pods' ) . '<br>' . __( 'Predefined Format will allow you to select from a list of commonly used date formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
-				'data'                         => array(
+				'type'       => 'pick',
+				'help'       => __( 'WordPress Default is the format used in Settings, General under "Date Format".', 'pods' ) . '<br>' . __( 'Predefined Format will allow you to select from a list of commonly used date formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
+				'data'       => array(
 					'wp'     => __( 'WordPress default', 'pods' ) . ': ' . date_i18n( get_option( 'date_format' ) ),
 					'format' => __( 'Predefined format', 'pods' ),
 					'custom' => __( 'Custom format', 'pods' ),
 				),
-				'dependency'                   => true,
+				'dependency' => true,
 			),
 			static::$type . '_format_custom'         => array(
 				'label'      => __( 'Date format for display', 'pods' ),
@@ -117,19 +117,19 @@ class PodsField_DateTime extends PodsField {
 				'dependency' => true,
 			),
 			static::$type . '_time_type'             => array(
-				'label'                        => __( 'Time Format Type', 'pods' ),
-				'excludes-on'                  => array( static::$type . '_format' => 'c' ),
-				'default'                      => '12',
+				'label'       => __( 'Time Format Type', 'pods' ),
+				'excludes-on' => array( static::$type . '_format' => 'c' ),
+				'default'     => '12',
 				// Backwards compatibility
-										'type' => 'pick',
-				'help'                         => __( 'WordPress Default is the format used in Settings, General under "Time Format".', 'pods' ) . '<br>' . __( '12/24 hour will allow you to select from a list of commonly used time formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
-				'data'                         => array(
+				'type'        => 'pick',
+				'help'        => __( 'WordPress Default is the format used in Settings, General under "Time Format".', 'pods' ) . '<br>' . __( '12/24 hour will allow you to select from a list of commonly used time formats.', 'pods' ) . '<br>' . __( 'Custom will allow you to enter your own using PHP Date/Time Strings.', 'pods' ),
+				'data'        => array(
 					'wp'     => __( 'WordPress default', 'pods' ) . ': ' . date_i18n( get_option( 'time_format' ) ),
 					'12'     => __( '12 hour', 'pods' ),
 					'24'     => __( '24 hour', 'pods' ),
 					'custom' => __( 'Custom', 'pods' ),
 				),
-				'dependency'                   => true,
+				'dependency'  => true,
 			),
 			static::$type . '_time_format_custom'    => array(
 				'label'       => __( 'Time format', 'pods' ),

--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -33,7 +33,7 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
-$year_range = pods_v( $form_field_type . '_year_range', $options, '' );
+$year_range = pods_v( $form_field_type . '_year_range_custom', $options, '' );
 if ( $year_range ) {
 	$args['yearRange'] = $year_range;
 }

--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -33,7 +33,7 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
-$year_range = pods_v( $form_field_type . '_year_range', $options, "" );
+$year_range = pods_v( $form_field_type . '_year_range', $options, '' );
 if ( $year_range ) {
 	$args['yearRange'] = $year_range;
 }

--- a/ui/fields/date.php
+++ b/ui/fields/date.php
@@ -33,6 +33,11 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
+$year_range = pods_v( $form_field_type . '_year_range', $options, "" );
+if ( $year_range ) {
+	$args['yearRange'] = $year_range;
+}
+
 $html5_format = 'Y-m-d';
 
 $date         = PodsForm::field_method( 'date', 'createFromFormat', $format, (string) $value );

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -38,7 +38,7 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
-$year_range = pods_v( $form_field_type . '_year_range', $options, "" );
+$year_range = pods_v( $form_field_type . '_year_range', $options, '' );
 if ( $year_range ) {
 	$args['yearRange'] = $year_range;
 }

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -38,6 +38,11 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
+$year_range = pods_v( $form_field_type . '_year_range', $options, "" );
+if ( $year_range ) {
+	$args['yearRange'] = $year_range;
+}
+
 if ( false !== stripos( $args['timeFormat'], 'tt' ) ) {
 	$args['ampm'] = true;
 }

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -38,7 +38,7 @@ $args = array(
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),
 );
 
-$year_range = pods_v( $form_field_type . '_year_range', $options, '' );
+$year_range = pods_v( $form_field_type . '_year_range_custom', $options, '' );
 if ( $year_range ) {
 	$args['yearRange'] = $year_range;
 }


### PR DESCRIPTION
Fixes #5442 

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
Adds a new option to change the year range for date/datetime fields.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

* Enhancement: Add year range option to date & datetime fields.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
