### PR TITLE
Force AM/PM names to prevent issues with PHP date()

### DIFF
--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -33,6 +33,9 @@ $args = array(
 	'timeFormat'  => PodsForm::field_method( 'datetime', 'format_time', $options, true ),
 	'dateFormat'  => PodsForm::field_method( 'datetime', 'format_date', $options, true ),
 	'ampm'        => false,
+	// Force AM/PM names to prevent issues with PHP date().
+	'amNames'     => array( 'AM' ),
+	'pmNames'     => array( 'PM' ),
 	'changeMonth' => true,
 	'changeYear'  => true,
 	'firstDay'    => (int) get_option( 'start_of_week', 0 ),


### PR DESCRIPTION
Fixes #5444 

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
The jQuery Timepicker adds translations for AM/PM in different languages. While this is great for UI, it's not supported in PHP in any way.
This is a quick fix that forces the jQuery Timepicker to work with AM/PM instead of the translations so PHP can correctly convert time input from fields.

If the user want's to translate on the front end he/she should use `str_replace` or similar. I cannot find anything that suggest translation of AM/PM is supported by PHP `date()` (or WordPress equivalent `date_i18n()`) so I'm not sure Pods should.
It might be a nice-to-have feature though...

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fixed: Force AM/PM names instead of translation in the timepicker to prevent saving issues.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
