### PR TITLE
Bug: jQuery date & time picker overlapping formats.

### DIFF
--- a/classes/fields/date.php
+++ b/classes/fields/date.php
@@ -169,6 +169,19 @@ class PodsField_Date extends PodsField_DateTime {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function format_display( $options, $js = false ) {
+
+		if ( $js && 'custom' === pods_v( static::$type . '_type', $options, 'format' ) ) {
+			$format = $this->format_datetime( $options, $js );
+			return $this->convert_format( $format, array( 'source' => 'jquery_ui', 'type' => 'date' ) );
+		}
+
+		return parent::format_display( $options, $js );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function format_datetime( $options, $js = false ) {
 
 		return $this->format_date( $options, $js );

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -281,8 +281,8 @@ class PodsField_DateTime extends PodsField {
 			$value = implode( ' ', $value );
 		}
 
-		// Format Value
-		$value = $this->format_value_display( $value, $options, true );
+		// @todo Remove? Format Value (done in field template).
+		//$value = $this->format_value_display( $value, $options, true );
 
 		$field_type = static::$type;
 

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -394,7 +394,6 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function format_value_display( $value, $options, $js = false ) {
 
-		// @todo Remove JS here???
 		$format = $this->format_display( $options, $js );
 
 		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
@@ -438,10 +437,26 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function format_display( $options, $js = false ) {
 
-		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
+		if ( 'custom' === pods_v( static::$type . '_type', $options, 'format' ) ) {
+			if ( $js ) {
+
+				// Gets format strings in jQuery UI format.
+				$date = $this->format_date( $options, $js );
+				$time = $this->format_time( $options, $js );
+
+				// Convert them to PHP date format.
+				$date = $this->convert_format( $date, array( 'source' => 'jquery_ui', 'type' => 'date' ) );
+				$time = $this->convert_format( $time, array( 'source' => 'jquery_ui', 'type' => 'time' ) );
+
+				return $date . ' ' . $time;
+
+			} else {
+				$format = $this->format_datetime( $options, $js );
+			}
+		} else {
 			$js = false;
+			$format = $this->format_datetime( $options, $js );
 		}
-		$format = $this->format_datetime( $options, $js );
 
 		return $format;
 	}

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -321,11 +321,8 @@ class PodsField_DateTime extends PodsField {
 				$js = false;
 			}
 
-			$format = $this->format_datetime( $options, $js );
-
-			if ( $js ) {
-				$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
-			}
+			// Value should always be passed as storage format since 2.7.15.
+			$format = static::$storage_format;
 
 			$check = $this->convert_date( $value, static::$storage_format, $format, true );
 
@@ -345,14 +342,8 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
-		$js = true;
-		if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
-			$js = false;
-		}
-		$format = $this->format_datetime( $options, $js );
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
-		}
+		// Value should always be passed as storage format since 2.7.15.
+		$format = static::$storage_format;
 
 		if ( ! empty( $value ) && ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) || ! in_array(
 			$value, array(
@@ -403,6 +394,7 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function format_value_display( $value, $options, $js = false ) {
 
+		// @todo Remove JS here???
 		$format = $this->format_display( $options, $js );
 
 		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
@@ -450,9 +442,6 @@ class PodsField_DateTime extends PodsField {
 			$js = false;
 		}
 		$format = $this->format_datetime( $options, $js );
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'jquery_ui' ) );
-		}
 
 		return $format;
 	}
@@ -495,26 +484,38 @@ class PodsField_DateTime extends PodsField {
 		switch ( (string) pods_v( static::$type . '_type', $options, 'format', true ) ) {
 			case 'wp':
 				$format = get_option( 'date_format' );
+
 				if ( $js ) {
-					$format = $this->convert_format( $format, array( 'source' => 'php' ) );
+					$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'date' ) );
 				}
+
 				break;
 			case 'custom':
 				if ( ! $js ) {
 					$format = pods_v( static::$type . '_format_custom', $options, '' );
 				} else {
 					$format = pods_v( static::$type . '_format_custom_js', $options, '' );
+					// Already in JS format.
+					$js = false;
+
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_format_custom', $options, '' );
-						$format = $this->convert_format( $format, array( 'source' => 'php' ) );
+						$js = true;
 					}
 				}
+
 				break;
 			default:
 				$date_format = $this->get_date_formats( $js );
+
 				$format      = $date_format[ pods_v( static::$type . '_format', $options, 'ymd_dash', true ) ];
+
 				break;
 		}//end switch
+
+		if ( $js ) {
+			$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'date' ) );
+		}
 
 		return $format;
 	}
@@ -549,10 +550,12 @@ class PodsField_DateTime extends PodsField {
 					$format = pods_v( static::$type . '_time_format_custom', $options, '' );
 				} else {
 					$format = pods_v( static::$type . '_time_format_custom_js', $options, '' );
+					// Already in JS format.
+					$js = false;
 
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_time_format_custom', $options, '' );
-						$format = $this->convert_format( $format, array( 'source' => 'php' ) );
+						$js = true;
 					}
 				}
 
@@ -560,12 +563,12 @@ class PodsField_DateTime extends PodsField {
 			default:
 				$format = get_option( 'time_format' );
 
-				if ( $js ) {
-					$format = $this->convert_format( $format, array( 'source' => 'php' ) );
-				}
-
 				break;
 		}//end switch
+
+		if ( $js ) {
+			$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'time' ) );
+		}
 
 		return $format;
 	}

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -601,8 +601,9 @@ class PodsField_DateTime extends PodsField {
 		$filter = 'pods_form_ui_field_date_formats';
 
 		if ( $js ) {
-			// @todo Method parameters? (Not supported by array_map)
-			$date_format = array_map( array( $this, 'convert_format' ), $date_format );
+			foreach ( $date_format as $key => $value ) {
+				$date_format[ $key ] = $this->convert_format( $value, array( 'type' => 'date' ) );
+			}
 
 			$filter = 'pods_form_ui_field_date_js_formats';
 		}
@@ -637,8 +638,9 @@ class PodsField_DateTime extends PodsField {
 		$filter = 'pods_form_ui_field_time_formats';
 
 		if ( $js ) {
-			// @todo Method parameters? (Not supported by array_map)
-			$time_format = array_map( array( $this, 'convert_format' ), $time_format );
+			foreach ( $time_format as $key => $value ) {
+				$time_format[ $key ] = $this->convert_format( $value, array( 'type' => 'time' ) );
+			}
 
 			$filter = 'pods_form_ui_field_time_js_formats';
 		}
@@ -665,8 +667,9 @@ class PodsField_DateTime extends PodsField {
 		$filter = 'pods_form_ui_field_time_formats_24';
 
 		if ( $js ) {
-			// @todo Method parameters? (Not supported by array_map)
-			$time_format_24 = array_map( array( $this, 'convert_format' ), $time_format_24 );
+			foreach ( $time_format_24 as $key => $value ) {
+				$time_format_24[ $key ] = $this->convert_format( $value, array( 'type' => 'time' ) );
+			}
 
 			$filter         = 'pods_form_ui_field_time_js_formats_24';
 		}
@@ -784,55 +787,64 @@ class PodsField_DateTime extends PodsField {
 		$args = array_merge(
 			array(
 				'source' => 'php',
+				'type'   => 'date',
 			// 'jquery_ui' for reverse.
 			), $args
 		);
 
 		// Keep keys and values sorted by string length.
-		$symbols = array(
-			// Day
-			'd' => 'dd',
-			'l' => 'DD',
-			'D' => 'D',
-			'j' => 'd',
-			'N' => '',
-			'S' => '',
-			'w' => '',
-			'z' => 'o',
-			// Week
-			'W' => '',
-			// Month
-			'F' => 'MM',
-			'm' => 'mm',
-			'M' => 'M',
-			'n' => 'm',
-			't' => '',
-			// Year
-			'L' => '',
-			'o' => '',
-			'Y' => 'yy',
-			'y' => 'y',
-			// AM/PM
-			'a' => 'tt',
-			'A' => 'TT',
-			// Swatch internet time (not supported)
-			'B' => '',
-			// Hour
-			'h' => 'hh',
-			'H' => 'HH',
-			'g' => 'h',
-			'G' => 'H',
-			// Minute
-			'i' => 'mm',
-			// Second
-			's' => 'ss',
-			// Microsecond
-			'u' => 'c',
-		);
+		if ( 'time' === $args['type'] || 'time' === static::$type ) {
 
-		if ( version_compare( PHP_VERSION, '7.0.0' ) >= 0 ) {
-			// Millisecond
-			$symbols['v'] = 'l';
+			$symbols = array(
+				// AM/PM
+				'a' => 'tt',
+				'A' => 'TT',
+				// Swatch internet time (not supported)
+				'B' => '',
+				// Hour
+				'h' => 'hh',
+				'H' => 'HH',
+				'g' => 'h',
+				'G' => 'H',
+				// Minute
+				'i' => 'mm',
+				// Second
+				's' => 'ss',
+				// Microsecond
+				'u' => 'c',
+			);
+
+			if ( version_compare( PHP_VERSION, '7.0.0' ) >= 0 ) {
+				// Millisecond
+				$symbols['v'] = 'l';
+			}
+
+		} else {
+
+			$symbols = array(
+				// Day
+				'd' => 'dd',
+				'l' => 'DD',
+				'D' => 'D',
+				'j' => 'd',
+				'N' => '',
+				'S' => '',
+				'w' => '',
+				'z' => 'o',
+				// Week
+				'W' => '',
+				// Month
+				'F' => 'MM',
+				'm' => 'mm',
+				'M' => 'M',
+				'n' => 'm',
+				't' => '',
+				// Year
+				'L' => '',
+				'o' => '',
+				'Y' => 'yy',
+				'y' => 'y',
+			);
 		}
 
 		if ( 'jquery_ui' === $args['source'] ) {

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -562,12 +562,11 @@ class PodsField_DateTime extends PodsField {
 					$format = pods_v( static::$type . '_time_format_custom', $options, '' );
 				} else {
 					$format = pods_v( static::$type . '_time_format_custom_js', $options, '' );
-					// Already in JS format.
-					$js = false;
+					$js     = false; // Already in JS format.
 
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_time_format_custom', $options, '' );
-						$js = true;
+						$js     = true;
 					}
 				}
 
@@ -807,33 +806,33 @@ class PodsField_DateTime extends PodsField {
 		if ( 'time' === $args['type'] || 'time' === static::$type ) {
 
 			$symbols = array(
-				// AM/PM
+				// AM/PM.
 				'a' => 'tt',
 				'A' => 'TT',
-				// Swatch internet time (not supported)
+				// Swatch internet time (not supported).
 				'B' => '',
-				// Hour
+				// Hour.
 				'h' => 'hh',
 				'H' => 'HH',
 				'g' => 'h',
 				'G' => 'H',
-				// Minute
+				// Minute.
 				'i' => 'mm',
-				// Second
+				// Second.
 				's' => 'ss',
-				// Microsecond
+				// Microsecond.
 				'u' => 'c',
 			);
 
 			if ( version_compare( PHP_VERSION, '7.0.0' ) >= 0 ) {
-				// Millisecond
+				// Millisecond.
 				$symbols['v'] = 'l';
 			}
 
 		} else {
 
 			$symbols = array(
-				// Day
+				// Day.
 				'd' => 'dd',
 				'l' => 'DD',
 				'D' => 'D',
@@ -842,15 +841,15 @@ class PodsField_DateTime extends PodsField {
 				'S' => '',
 				'w' => '',
 				'z' => 'o',
-				// Week
+				// Week.
 				'W' => '',
-				// Month
+				// Month.
 				'F' => 'MM',
 				'm' => 'mm',
 				'M' => 'M',
 				'n' => 'm',
 				't' => '',
-				// Year
+				// Year.
 				'L' => '',
 				'o' => '',
 				'Y' => 'yy',

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -495,12 +495,13 @@ class PodsField_DateTime extends PodsField {
 					$format = pods_v( static::$type . '_format_custom', $options, '' );
 				} else {
 					$format = pods_v( static::$type . '_format_custom_js', $options, '' );
-					// Already in JS format.
-					$js = false;
 
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_format_custom', $options, '' );
-						$js = true;
+
+						if ( $js ) {
+							$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'date' ) );
+						}
 					}
 				}
 
@@ -512,10 +513,6 @@ class PodsField_DateTime extends PodsField {
 
 				break;
 		}//end switch
-
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'date' ) );
-		}
 
 		return $format;
 	}
@@ -565,10 +562,6 @@ class PodsField_DateTime extends PodsField {
 
 				break;
 		}//end switch
-
-		if ( $js ) {
-			$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'time' ) );
-		}
 
 		return $format;
 	}

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -172,6 +172,19 @@ class PodsField_Time extends PodsField_DateTime {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function format_display( $options, $js = false ) {
+
+		if ( $js && 'custom' === pods_v( static::$type . '_type', $options, 'format' ) ) {
+			$format = $this->format_datetime( $options, $js );
+			return $this->convert_format( $format, array( 'source' => 'jquery_ui', 'type' => 'time' ) );
+		}
+
+		return parent::format_display( $options, $js );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function format_datetime( $options, $js = false ) {
 
 		return $this->format_time( $options, $js );

--- a/classes/fields/time.php
+++ b/classes/fields/time.php
@@ -209,7 +209,10 @@ class PodsField_Time extends PodsField_DateTime {
 
 					if ( empty( $format ) ) {
 						$format = pods_v( static::$type . '_format_custom', $options, '' );
-						$format = $this->convert_format( $format, array( 'source' => 'php' ) );
+
+						if ( $js ) {
+							$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'time' ) );
+						}
 					}
 				}
 
@@ -218,7 +221,7 @@ class PodsField_Time extends PodsField_DateTime {
 				$format = get_option( 'time_format' );
 
 				if ( $js ) {
-					$format = $this->convert_format( $format, array( 'source' => 'php' ) );
+					$format = $this->convert_format( $format, array( 'source' => 'php', 'type' => 'time' ) );
 				}
 
 				break;

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -97,7 +97,7 @@ switch ( $form_field_type ) {
 $date         = PodsForm::field_method( $form_field_type, 'createFromFormat', $format, (string) $value );
 $date_default = PodsForm::field_method( $form_field_type, 'createFromFormat', $mysql_format, (string) $value );
 
-$formatted_value = $value;
+$formatted_value = PodsForm::field_method( $form_field_type, 'format_value_display', $value, $options, true );
 $mysql_value     = $value;
 
 $empty_values = array(
@@ -128,6 +128,8 @@ if (
 	if ( $html5 ) {
 		// HTML5 uses mysql date format.
 		$value = $mysql_value;
+	} else {
+		$value = $formatted_value;
 	}
 }
 

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -45,7 +45,7 @@ $args = array(
 
 if ( $use_date ) {
 	$args['dateFormat']  = PodsForm::field_method( $form_field_type, 'format_date', $options, true );
-	$args['altFormat']   = PodsForm::field_method( $form_field_type, 'convert_format', $mysql_date_format );
+	$args['altFormat']   = PodsForm::field_method( $form_field_type, 'convert_format', $mysql_date_format, array( 'type' => 'date' ) );
 	$args['changeMonth'] = true;
 	$args['changeYear']  = true;
 	$args['firstDay']    = (int) get_option( 'start_of_week', 0 );
@@ -57,7 +57,7 @@ if ( $use_date ) {
 }
 if ( $use_time ) {
 	$args['timeFormat']    = PodsForm::field_method( $form_field_type, 'format_time', $options, true );
-	$args['altTimeFormat'] = PodsForm::field_method( $form_field_type, 'convert_format', $mysql_time_format );
+	$args['altTimeFormat'] = PodsForm::field_method( $form_field_type, 'convert_format', $mysql_time_format, array( 'type' => 'time' ) );
 	$args['ampm']          = ( false !== stripos( $args['timeFormat'], 'tt' ) );
 }
 


### PR DESCRIPTION
Fixes: #5238 

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
jQuery date & time pickers both use `mm` which gets formatted wrong if used both.
This PR separates formatting conversion for date and time strings.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fixed: jQuery date & time picker overlapping formats.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
