### PR TITLE
Force test matrix to extend pods

### DIFF
--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -565,6 +565,7 @@ class Pods_UnitTestCase extends \WP_UnitTestCase {
 				// Hack for 2.x
 				// @todo Remove for 3.x
 				'options' => array(),
+				'create_extend' => 'extend',
 			);
 
 			if ( 'pod' === $pod_type ) {


### PR DESCRIPTION
Tests have been broken since the reserved pods names were added

## Description
Tests at least start to run locally with this change.  Very slow on my local box so I'll let travis do the actual workload.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
