### PR TITLE
Hotfix Datetime field: Make sure $ can always be used

### DIFF
--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -147,14 +147,14 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 
 <script>
 	jQuery( function ( $ ) {
-		var $container = jQuery( '<div>' ).appendTo( 'body' ).addClass( 'pods-compat-container' ),
-			$element   = jQuery( 'input#<?php echo esc_js( $attributes['id'] ); ?>' ),
+		var $container = $( '<div>' ).appendTo( 'body' ).addClass( 'pods-compat-container' ),
+			$element   = $( 'input#<?php echo esc_js( $attributes['id'] ); ?>' ),
 			beforeShow = {
 				'beforeShow': function( textbox, instance) {
-					jQuery( '#ui-datepicker-div' ).appendTo( $container );
+					$( '#ui-datepicker-div' ).appendTo( $container );
 				}
 			},
-			args = jQuery.extend( <?php echo json_encode( $args ); ?>, beforeShow );
+			args = $.extend( <?php echo json_encode( $args ); ?>, beforeShow );
 
 		<?php
 		if ( 'text' !== $type ) {

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -146,7 +146,7 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 <input<?php PodsForm::attributes( $attributes, $name, $form_field_type, $options ); ?> />
 
 <script>
-	jQuery( function () {
+	jQuery( function ( $ ) {
 		var $container = jQuery( '<div>' ).appendTo( 'body' ).addClass( 'pods-compat-container' ),
 			$element   = jQuery( 'input#<?php echo esc_js( $attributes['id'] ); ?>' ),
 			beforeShow = {


### PR DESCRIPTION
Fixes issue since: #5442 (PR: #5443)

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fixed: Possible issue with global jQuery var ($) for datetime field.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
