### PR TITLE
UnitTests: Extend objects when using reserved keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "phpunit/phpunit": "4.*",
     "mockery/mockery": "0.9.*",
     "squizlabs/php_codesniffer": "2.9.1 - 3.2.3",
-    "DealerDirect/phpcodesniffer-composer-installer":"0.4.*",
+    "dealerdirect/phpcodesniffer-composer-installer":"0.4.*",
     "wp-coding-standards/wpcs": "1.1.*",
     "wimg/php-compatibility": "8.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "squizlabs/php_codesniffer": "2.9.1 - 3.2.3",
     "dealerdirect/phpcodesniffer-composer-installer":"0.4.*",
     "wp-coding-standards/wpcs": "1.1.*",
-    "wimg/php-compatibility": "8.*"
+    "phpcompatibility/php-compatibility": "8.*"
   },
   "suggest": {
     "wp-cli/wp-cli": "Enables access to Pods CLI commands."

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -649,6 +649,12 @@ class Pods_UnitTestCase extends \WP_UnitTestCase {
 						self::$builds[ $pod_type ][ $object ][ $storage_type ]['fields'][ $field['name'] ] = $field;
 					}
 
+					if ( in_array( $pod['name'], pods_reserved_keywords() ) ) {
+						// Extending objects when using reserved keywords.
+						// This will then accept `post`, `page` etc. as Pods object names.
+						$pod['create_extend'] = 'extend';
+					}
+
 					$id = $api->save_pod( $pod );
 
 					$load_pod = $api->load_pod( array( 'id' => $id ) );

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -649,7 +649,7 @@ class Pods_UnitTestCase extends \WP_UnitTestCase {
 						self::$builds[ $pod_type ][ $object ][ $storage_type ]['fields'][ $field['name'] ] = $field;
 					}
 
-					if ( in_array( $pod['name'], pods_reserved_keywords() ) ) {
+					if ( in_array( $pod['name'], pods_reserved_keywords(), true ) ) {
 						// Extending objects when using reserved keywords.
 						// This will then accept `post`, `page` etc. as Pods object names.
 						$pod['create_extend'] = 'extend';


### PR DESCRIPTION
Fixes: #5468 
This will then accept `post`, `page` etc. as Pods object names.

Fixes: #5475 
- Deprecation warning for uppercase + package wimg/php-compatibility

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
