### PR TITLE
Fix pods_str_replace

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -1416,8 +1416,12 @@ function pods_str_replace( $find, $replace, $string, $occurrences = - 1 ) {
 	} else {
 		$find = '/' . preg_quote( $find, '/' ) . '/';
 	}
-
-	return preg_replace( $find, $replace, $string, $occurrences );
+	if ( is_string( $string ) ) {
+		return preg_replace( $find, $replace, $string, $occurrences );
+	} else {
+		// Occasionally we will receive non string values (true, false, null).  Allow those to pass through
+		return $string;
+	}
 }
 
 /**

--- a/tests/phpunit/includes/Bugs/Test_5254.php
+++ b/tests/phpunit/includes/Bugs/Test_5254.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pods_Unit_tests\Bugs;
+
+/**
+ * @package Pods_Unit_Tests
+ * @group   pods_acceptance_tests
+ * @group   pods-issue-5254
+ */
+class Bug_5254 extends \Pods_Unit_Tests\Pods_UnitTestCase {
+
+	/*
+	 * This should probably get rolled into extensive includes/data.php coverage
+	 * but for now it is specific to at least Bug #5254
+	 */
+	public function test_pods_str_replace_false() {
+		$params = false;
+		$result = pods_str_replace( '@wp_', '{prefix}', $params );
+		$this->assertFalse( $result );
+
+		$params = array( 'bypass_helpers' => false );
+		$result = pods_str_replace( '@wp_', '{prefix}', $params );
+		$this->assertFalse( $result['bypass_helpers'] );
+
+		$params = array( 'nested' => array( 'bypass_helpers' => false ) );
+		$result = pods_str_replace( '@wp_', '{prefix}', $params );
+		$this->assertFalse( $result['nested']['bypass_helpers'] );
+
+	}
+}


### PR DESCRIPTION
## Description
The pods_str_replace() function can't handle values that are not strings.
Fixes #5254
<!-- use the terminology Fixes #issue -->

## How Has This Been Tested?
Test included in first commit, second commit will have actual fix

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## ChangeLog
Fix: Allow pods_str_replace() function to handle non-strings #5254 (@jamesgol)
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
