### PR TITLE
Fix Required checkbox field value

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -188,7 +188,7 @@
 
                             if ( $el.is( 'input[type=checkbox]' ) && !$el.is( ':checked' ) ) {
                                 if ( $el.is( '.pods-boolean' ) || $el.is( '.pods-form-ui-field-type-boolean') )
-                                    val = 0;
+                                    val = null;
                                 else
                                     return true; // This input isn't a boolean, continue the loop
                             }


### PR DESCRIPTION
## Description
the field is now filled with the same value inserted in the backend.
Fixes or at least mitigates #5481

This patch fixes the UI, but the same problem may arise again when the post request is performed manually via curl or whatever with user inserted data (See my last post in #5481)

 ## How Has This Been Tested?
By inspecting the data transmitted by the browser in both cases, and how the BE is managing null value with respect to the 0 value. 

