### PR TITLE
Add validate method to boolean field to fix #5481

### DIFF
--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -172,6 +172,25 @@ class PodsField_Boolean extends PodsField {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
+	
+		$errors = array();
+		$check  = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
+
+		if ( 1 === (int) pods_v( 'required', $options ) && 0 === $check ) {
+			$errors[] = __( 'This field is required.', 'pods' );
+		}
+
+		if ( ! empty( $errors ) ) {
+			return $errors;
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
 
 		$yes = strtolower( pods_v( static::$type . '_yes_label', $options, __( 'Yes', 'pods' ), true ) );


### PR DESCRIPTION
## Description

Fix #5481 by adding a validate() to the boolean field.

## How Has This Been Tested?

- Create a form with a required checkbox field
- Try to submit the form without ticking the box.

## Screenshots (jpeg or gifs if applicable):

## Types of changes

Bug fix

## ChangeLog

Fix: Cannot submit a form if required checkbox not ticked.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
