### PR TITLE
Sanitize meta values before passing to *_post_meta functions

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -310,7 +310,7 @@ class PodsAPI {
 		}
 
 		foreach ( $post_meta as $meta_key => $meta_value ) {
-			// WordPress's *_post_meta() functions expect to receive 'slashed' data
+			// The WordPress *_post_meta() functions expect to receive 'slashed' data.
 			$meta_value = pods_sanitize( $meta_value );
 
 			if ( null === $meta_value || ( $strict && '' === $post_meta[ $meta_key ] ) ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -312,6 +312,7 @@ class PodsAPI {
 		foreach ( $post_meta as $meta_key => $meta_value ) {
 			// WordPress's *_post_meta() functions expect to receive 'slashed' data
 			$meta_value = pods_sanitize( $meta_value );
+
 			if ( null === $meta_value || ( $strict && '' === $post_meta[ $meta_key ] ) ) {
 				$old_meta_value = '';
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -310,6 +310,8 @@ class PodsAPI {
 		}
 
 		foreach ( $post_meta as $meta_key => $meta_value ) {
+			// WordPress's *_post_meta() functions expect to receive 'slashed' data
+			$meta_value = pods_sanitize( $meta_value );
 			if ( null === $meta_value || ( $strict && '' === $post_meta[ $meta_key ] ) ) {
 				$old_meta_value = '';
 


### PR DESCRIPTION
WordPress expects slashed data

## Description
Fixes issue #5366 



## How Has This Been Tested?
I can't be sure if this is going to break anything else, hopefully the tests cover enough.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
