### PR TITLE
Unslash simple relationship values to support saving quoted values

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -3774,6 +3774,9 @@ class PodsAPI {
 
 						$custom = apply_filters( 'pods_form_ui_field_pick_custom_values', $custom, $field_data['name'], $value, array_merge( $field_data, $options ), $pod, $params->id );
 
+						// Input values are unslashed. Unslash database values as well to ensure correct comparison.
+						$custom = pods_unslash( $custom );
+
 						if ( empty( $value ) || empty( $custom ) ) {
 							$value = '';
 						} elseif ( ! empty( $custom ) ) {


### PR DESCRIPTION
Fixes: #2360
Fixes: #5479
Closes: #3616 (Sorry @jamesgol, I think this might be a better and simpler fix)
Closes: #1943 (Old related issue)

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
This PR makes sure simple custom relationship options are unslashed before comparing to input data.
This needs to be done because input data is unslashed as well. If we want to correctly compare input data to available options both sides need to be the same.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
