### PR TITLE
DateTime: Add onClose method to always parse any manual input data

### DIFF
--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -176,18 +176,21 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 		}
 
 		if ( ! podsCheckHtml5() ) {
-			args = altField( args, $element );
 			$element.val( '<?php echo esc_js( $formatted_value ); ?>' );
-			$element.<?php echo esc_js( $method ); ?>( args );
+			jQueryField( args, $element );
 		}
 		<?php
 		} else {
 		?>
-		args = altField( args, $element );
-		$element.<?php echo esc_js( $method ); ?>( args );
+		jQueryField( args, $element );
 		<?php
 		} //end if
 		?>
+		function jQueryField( args, $element ) {
+			args = altField( args, $element );
+			$element.<?php echo esc_js( $method ); ?>( args );
+		}
+
 		function altField( args, el ) {
 			var $el  = $( el ),
 				$alt = $el.clone();
@@ -202,6 +205,6 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 			args.altField = 'input#' + $alt.attr( 'id' );
 
 			return args;
-		};
+		}
 	} );
 </script>

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -59,6 +59,7 @@ if ( $use_time ) {
 	$args['timeFormat']    = PodsForm::field_method( $form_field_type, 'format_time', $options, true );
 	$args['altTimeFormat'] = PodsForm::field_method( $form_field_type, 'convert_format', $mysql_time_format, array( 'type' => 'time' ) );
 	$args['ampm']          = ( false !== stripos( $args['timeFormat'], 'tt' ) );
+	$args['parse']         = 'loose';
 }
 
 $mysql_format = '';

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -155,12 +155,8 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 	jQuery( function ( $ ) {
 		var $container = $( '<div>' ).appendTo( 'body' ).addClass( 'pods-compat-container' ),
 			$element   = $( 'input#<?php echo esc_js( $attributes['id'] ); ?>' ),
-			beforeShow = {
-				'beforeShow': function( textbox, instance) {
-					$( '#ui-datepicker-div' ).appendTo( $container );
-				}
-			},
-			args = $.extend( <?php echo json_encode( $args ); ?>, beforeShow );
+			$alt       = null,
+			args       = <?php echo json_encode( $args ); ?>;
 
 		<?php
 		if ( 'text' !== $type ) {
@@ -178,37 +174,37 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 
 		if ( ! podsCheckHtml5() ) {
 			$element.val( '<?php echo esc_js( $formatted_value ); ?>' );
-			jQueryField( args, $element );
+			jQueryField();
 		}
 		<?php
 		} else {
 		?>
-		jQueryField( args, $element );
+		jQueryField();
 		<?php
 		} //end if
 		?>
-		function jQueryField( args, $element ) {
-			args = altField( args, $element );
+		function jQueryField() {
+
+			// Create alt field.
+			$alt = $element.clone();
+			$alt.attr( 'type', 'hidden' );
+			$alt.val( '<?php echo esc_attr( $mysql_value ) ?>' );
+			$element.after( $alt );
+			$element.attr( 'name', $element.attr( 'name' ) + '__ui' );
+			$element.attr( 'id', $element.attr( 'id' ) + '__ui' );
+
+			// Add alt field option.
+			args.altField = 'input#' + $alt.attr( 'id' );
+			// Fix manual user input changes.
 			args.onClose = function() {
 				$element.<?php echo esc_js( $method ); ?>( 'setDate', $element.val() );
 			};
+			// Wrapper.
+			args.beforeShow = function( textbox, instance ) {
+				$( '#ui-datepicker-div' ).appendTo( $container );
+			};
+
 			$element.<?php echo esc_js( $method ); ?>( args );
-		}
-
-		function altField( args, el ) {
-			var $el  = $( el ),
-				$alt = $el.clone();
-
-			$alt.attr( 'type', 'hidden' );
-			$alt.val( '<?php echo esc_attr( $mysql_value ) ?>' );
-			$el.after( $alt );
-
-			$el.attr( 'name', $el.attr( 'name' ) + '__ui' );
-			$el.attr( 'id', $el.attr( 'id' ) + '__ui' );
-
-			args.altField = 'input#' + $alt.attr( 'id' );
-
-			return args;
 		}
 	} );
 </script>

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -188,6 +188,9 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 		?>
 		function jQueryField( args, $element ) {
 			args = altField( args, $element );
+			args.onClose = function() {
+				$element.<?php echo esc_js( $method ); ?>( 'setDate', $element.val() );
+			};
 			$element.<?php echo esc_js( $method ); ?>( args );
 		}
 

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -156,7 +156,7 @@ $attributes = PodsForm::merge_attributes( $attributes, $name, $form_field_type, 
 		var $container = $( '<div>' ).appendTo( 'body' ).addClass( 'pods-compat-container' ),
 			$element   = $( 'input#<?php echo esc_js( $attributes['id'] ); ?>' ),
 			$alt       = null,
-			args       = <?php echo json_encode( $args ); ?>;
+			args       = <?php echo wp_json_encode( $args ); ?>;
 
 		<?php
 		if ( 'text' !== $type ) {


### PR DESCRIPTION
Fixes: #5488 

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
The close/blur events from the date/time pickers aren't always picking up manual user input (keyboard). This PR fixes that and makes sure dates are parsed through the date/time picker at any time, even is the value is empty.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fixed: DateTime: Always parse any manual input data.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
