### PR TITLE
Add "full" to available image sizes

### DIFF
--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -711,6 +711,8 @@ class PodsField_File extends PodsField {
 			$data[ $image_size ] = ucwords( str_replace( '-', ' ', $image_size ) );
 		}
 
+		$data[ 'full' ] = __( 'Full Size' ); // Translated by WordPress core.
+
 		return apply_filters( 'pods_form_ui_field_pick_data_image_sizes', $data, $name, $value, $options, $pod, $id );
 
 	}

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -711,7 +711,7 @@ class PodsField_File extends PodsField {
 			$data[ $image_size ] = ucwords( str_replace( '-', ' ', $image_size ) );
 		}
 
-		$data[ 'full' ] = __( 'Full Size' ); // Translated by WordPress core.
+		$data['full'] = __( 'Full Size' ); // Translated by WordPress core.
 
 		return apply_filters( 'pods_form_ui_field_pick_data_image_sizes', $data, $name, $value, $options, $pod, $id );
 


### PR DESCRIPTION
Fixes: #5185 

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
- Enhancement: Add "full" to available image sizes in file fields.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
