### PR TITLE
DateTime: Use is_empty() to centralize validation

### DIFF
--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -308,13 +308,7 @@ class PodsField_DateTime extends PodsField {
 	 */
 	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
 
-		if ( ! empty( $value ) && ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) || ! in_array(
-			$value, array(
-				'0000-00-00',
-				'0000-00-00 00:00:00',
-				'00:00:00',
-			), true
-		) ) ) {
+		if ( ! $this->is_empty( $value ) ) {
 			$js = true;
 
 			if ( 'custom' !== pods_v( static::$type . '_type', $options, 'format' ) ) {
@@ -331,10 +325,9 @@ class PodsField_DateTime extends PodsField {
 
 				return sprintf( esc_html__( '%1$s was not provided in a recognizable format: "%2$s"', 'pods' ), $label, $value );
 			}
-		}//end if
+		}
 
 		return true;
-
 	}
 
 	/**
@@ -345,15 +338,9 @@ class PodsField_DateTime extends PodsField {
 		// Value should always be passed as storage format since 2.7.15.
 		$format = static::$storage_format;
 
-		if ( ! empty( $value ) && ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) || ! in_array(
-			$value, array(
-				'0000-00-00',
-				'0000-00-00 00:00:00',
-				'00:00:00',
-			), true
-		) ) ) {
+		if ( ! $this->is_empty( $value ) ) {
 			$value = $this->convert_date( $value, static::$storage_format, $format );
-		} elseif ( 1 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
+		} elseif ( pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
 			$value = static::$empty_value;
 		} else {
 			$value = date_i18n( static::$storage_format );
@@ -369,13 +356,7 @@ class PodsField_DateTime extends PodsField {
 
 		$value = $this->display( $value, $name, $options, $pod, $id );
 
-		if ( 1 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) && ( empty( $value ) || in_array(
-			$value, array(
-				'0000-00-00',
-				'0000-00-00 00:00:00',
-				'00:00:00',
-			), true
-		) ) ) {
+		if ( $this->is_empty( $value ) && pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
 			$value = false;
 		}
 
@@ -396,7 +377,7 @@ class PodsField_DateTime extends PodsField {
 
 		$format = $this->format_display( $options, $js );
 
-		if ( ! empty( $value ) && ! in_array( $value, array( '0000-00-00', '0000-00-00 00:00:00', '00:00:00' ), true ) ) {
+		if ( ! $this->is_empty( $value ) ) {
 			// Try default storage format.
 			$date = $this->createFromFormat( static::$storage_format, (string) $value );
 
@@ -416,7 +397,7 @@ class PodsField_DateTime extends PodsField {
 			}
 
 			$value = date_i18n( $format, $timestamp );
-		} elseif ( 0 === (int) pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
+		} elseif ( ! pods_v( static::$type . '_allow_empty', $options, 1 ) ) {
 			$value = date_i18n( $format );
 		} else {
 			$value = '';

--- a/ui/fields/datetime.php
+++ b/ui/fields/datetime.php
@@ -101,16 +101,9 @@ $date_default = PodsForm::field_method( $form_field_type, 'createFromFormat', $m
 $formatted_value = PodsForm::field_method( $form_field_type, 'format_value_display', $value, $options, true );
 $mysql_value     = $value;
 
-$empty_values = array(
-	'',
-	'0000-00-00',
-	'0000-00-00 00:00:00',
-	'00:00:00',
-);
-
 if (
 	pods_v( $form_field_type . '_allow_empty', $options, true )
-	&& in_array( $value, $empty_values, true )
+	&& PodsForm::field_method( $form_field_type, 'is_empty', $value )
 ) {
 	$formatted_value = '';
 	$value           = '';


### PR DESCRIPTION
Fixes: #5534 (verified by user)
Fixes: #5544

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
See issue.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Everywhere we check for empty date values I've replace the array search with the is_empty() method. This centralizes the empty validation checks.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
