### PR TITLE
Fix compare 9'999.99 format

### DIFF
--- a/classes/fields/number.php
+++ b/classes/fields/number.php
@@ -366,30 +366,40 @@ class PodsField_Number extends PodsField {
 	 */
 	public function get_number_format_args( $options ) {
 
-		global $wp_locale;
+		$format = pods_v( static::$type . '_format', $options );
+		$format = pods_unslash( $format );
 
-		if ( '9.999,99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = '.';
-			$dot       = ',';
-		} elseif ( '9,999.99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = ',';
-			$dot       = '.';
-		} elseif ( '9\'999.99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = '\'';
-			$dot       = '.';
-		} elseif ( '9 999,99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = ' ';
-			$dot       = ',';
-		} elseif ( '9999.99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot       = '.';
-		} elseif ( '9999,99' === pods_v( static::$type . '_format', $options ) ) {
-			$thousands = '';
-			$dot       = ',';
-		} else {
-			$thousands = $wp_locale->number_format['thousands_sep'];
-			$dot       = $wp_locale->number_format['decimal_point'];
-		}//end if
+		switch ( $format ) {
+			case '9.999,99':
+				$thousands = '.';
+				$dot       = ',';
+				break;
+			case '9,999.99':
+				$thousands = ',';
+				$dot       = '.';
+				break;
+			case '9\'999.99':
+				$thousands = '\'';
+				$dot       = '.';
+				break;
+			case '9 999,99':
+				$thousands = ' ';
+				$dot       = ',';
+				break;
+			case '9999.99':
+				$thousands = '';
+				$dot       = '.';
+				break;
+			case '9999,99':
+				$thousands = '';
+				$dot       = ',';
+				break;
+			default:
+				global $wp_locale;
+				$thousands = $wp_locale->number_format['thousands_sep'];
+				$dot       = $wp_locale->number_format['decimal_point'];
+				break;
+		}
 
 		$decimals = $this->get_max_decimals( $options );
 


### PR DESCRIPTION
Fixes: #5559 #5597
Apply unslash on format before comparing + refactor to switch statement for readability.

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
- Fixed: Parsing error for number format 9'999.99.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
