### PR TITLE
Add `not_found` tag for shortcodes

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -834,6 +834,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		'fields'     => null,
 		'label'      => null,
 		'thank_you'  => null,
+		'not_found'  => null,
 		'view'       => null,
 		'cache_mode' => 'none',
 		'expires'    => 0,
@@ -1083,7 +1084,13 @@ function pods_shortcode_run( $tags, $content = null ) {
 		echo $pod->pagination( $tags['pagination_label'] );
 	}
 
-	echo $pod->template( $tags['template'], $content );
+	$content = $pod->template( $tags['template'], $content );
+
+	if ( empty( $content ) && ! empty( $tags['not_found'] ) ) {
+		echo $pod->do_magic_tags( $tags['not_found'] );
+	} else {
+		echo $content;
+	}
 
 	if ( ! $is_singular && 0 < $found && true === $tags['pagination'] && in_array(
 		$tags['pagination_location'], array(

--- a/includes/general.php
+++ b/includes/general.php
@@ -1098,6 +1098,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		$content = $pod->do_magic_tags( $tags['not_found'] );
 	}
 
+	// phpcs:ignore
 	echo $content;
 
 	if ( ! $is_singular && 0 < $found && true === $tags['pagination'] && in_array(

--- a/includes/general.php
+++ b/includes/general.php
@@ -1085,6 +1085,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}
 
 	$content = $pod->template( $tags['template'], $content );
+	$content = trim( $content );
 
 	if ( empty( $content ) && ! empty( $tags['not_found'] ) ) {
 		echo $pod->do_magic_tags( $tags['not_found'] );

--- a/includes/general.php
+++ b/includes/general.php
@@ -1088,10 +1088,10 @@ function pods_shortcode_run( $tags, $content = null ) {
 	$content = trim( $content );
 
 	if ( empty( $content ) && ! empty( $tags['not_found'] ) ) {
-		echo $pod->do_magic_tags( $tags['not_found'] );
-	} else {
-		echo $content;
+		$content = $pod->do_magic_tags( $tags['not_found'] );
 	}
+
+	echo $content;
 
 	if ( ! $is_singular && 0 < $found && true === $tags['pagination'] && in_array(
 		$tags['pagination_location'], array(


### PR DESCRIPTION
## Description
Fixes: #5580 

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Enhancement: Add `not_found` tag to the Pods shortcode to return default string if no output is empty.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
