### PR TITLE
Fix PHP 7.4 deprecation

### DIFF
--- a/components/Markdown.php
+++ b/components/Markdown.php
@@ -1101,7 +1101,7 @@ if ( ! function_exists( 'Markdown' ) ) :
 				return $matches[0];
 			}
 
-			$level = $matches[2]{0} == '=' ? 1 : 2;
+			$level = $matches[2][0] == '=' ? 1 : 2;
 			$block = "<h$level>" . $this->runSpanGamut( $matches[1] ) . "</h$level>";
 
 			return "\n" . $this->hashBlock( $block ) . "\n\n";
@@ -1449,7 +1449,7 @@ if ( ! function_exists( 'Markdown' ) ) :
 					} else {
 						// Other closing marker: close one em or strong and
 						// change current token state to match the other
-						$token_stack[0] = str_repeat( $token{0}, 3 - $token_len );
+						$token_stack[0] = str_repeat( $token[0], 3 - $token_len );
 						$tag            = $token_len == 2 ? 'strong' : 'em';
 						$span           = $text_stack[0];
 						$span           = $this->runSpanGamut( $span );
@@ -1476,7 +1476,7 @@ if ( ! function_exists( 'Markdown' ) ) :
 					} else {
 						// Reached opening three-char emphasis marker. Push on token
 						// stack; will be handled by the special condition above.
-						$em     = $token{0};
+						$em     = $token[0];
 						$strong = "$em$em";
 						array_unshift( $token_stack, $token );
 						array_unshift( $text_stack, '' );
@@ -1902,9 +1902,9 @@ if ( ! function_exists( 'Markdown' ) ) :
 			// Handle $token provided by parseSpan by determining its nature and
 			// returning the corresponding value that should replace it.
 			//
-			switch ( $token{0} ) {
+			switch ( $token[0] ) {
 				case '\\':
-					return $this->hashPart( '&#' . ord( $token{1} ) . ';' );
+					return $this->hashPart( '&#' . ord( $token[1] ) . ';' );
 				case '`':
 					// Search for end marker in remaining text.
 					if ( preg_match( '/^(.*?[^`])' . preg_quote( $token ) . '(?!`)(.*)$/sm', $str, $matches ) ) {


### PR DESCRIPTION
Fixes: #5582

Deprecated: Array and string offset access syntax with curly braces is deprecated

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* Fix: PHP 7.4: Array and string offset access syntax with curly braces is deprecated.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
