### PR TITLE
Shortcode: Automatically revert to use_current

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -876,13 +876,20 @@ function pods_shortcode_run( $tags, $content = null ) {
 	if ( ! $tags['use_current'] && empty( $tags['name'] ) ) {
 		$has_query_tags = array_intersect_key( array_diff( $tags, $defaults ), $default_query_tags );
 
-		if ( ( in_the_loop() || is_singular() ) && ! $has_query_tags ) {
-			$pod = pods( get_post_type(), get_the_ID(), false );
+		// Only allow revert to current object if there are no query tags.
+		if ( ! $has_query_tags ) {
 
-			if ( ! empty( $pod ) ) {
-				$tags['name'] = get_post_type();
-				$id           = get_the_ID();
-				$tags['id']   = get_the_ID();
+			// Archives, Post type archives, singular posts.
+			if ( in_the_loop() ) {
+				$pod = pods( get_post_type(), get_the_ID(), false );
+
+				if ( ! empty( $pod ) ) {
+					$id           = get_the_ID();
+					$tags['id']   = $id;
+					$tags['name'] = get_post_type();
+				}
+			} else {
+				$tags['use_current'] = true;
 			}
 		}
 


### PR DESCRIPTION
If there are no query tags and no object info is supplied.

Fixes: #5598 

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
Currently the shortcode automatically reverts to the current post if it's in the loop.
While there is a use_current parameter it might be a nice feature to support simple shortcodes for users and taxonomies as well ([pods field="name"]).

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
