### PR TITLE
WP 5.4 Compatibility: Add user Pod fields to privacy export data

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1887,14 +1887,18 @@ class PodsInit {
 	 */
 	public function filter_wp_privacy_additional_user_profile_data( $additional_user_profile_data, $user, $reserved_names ) {
 		$pod = pods( 'user', $user->ID );
-		if ( $pod->valid() ) {
-			foreach ( $pod->fields as $name => $field ) {
-				$additional_user_profile_data[] = array(
-					'name'  => apply_filters( 'pods_form_ui_label_text', $field['label'], $name, '', $field ),
-					'value' => $pod->display( $name ),
-				);
-			}
+
+		if ( ! $pod->valid() ) {
+			return $additional_user_profile_data;
 		}
+
+		foreach ( $pod->fields as $name => $field ) {
+			$additional_user_profile_data[] = array(
+				'name'  => apply_filters( 'pods_form_ui_label_text', $field['label'], $name, '', $field ),
+				'value' => $pod->display( $name ),
+			);
+		}
+
 		return $additional_user_profile_data;
 	}
 

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1883,7 +1883,7 @@ class PodsInit {
 		if ( $pod->valid() ) {
 			foreach ( $pod->fields as $name => $field ) {
 				$additional_profile_data[] = array(
-					'name'  => $field['label'],
+					'name'  => apply_filters( 'pods_form_ui_label_text', $field['label'], $name, '', $field ),
 					'value' => $pod->display( $name ),
 				);
 			}

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1883,7 +1883,7 @@ class PodsInit {
 	 *                                 `$additional_user_data` that uses one of these
 	 *                                 for it's `name` will not be included in the export.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public function filter_wp_privacy_additional_user_profile_data( $additional_profile_data, $user, $reserved_names ) {
 		$pod = pods( 'user', $user->ID );

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1872,30 +1872,30 @@ class PodsInit {
 	 *
 	 * @since 2.7.17
 	 *
-	 * @param array    $additional_user_profile_data {
+	 * @param array   $additional_user_profile_data {
 	 *     An array of name-value pairs of additional user data items.  Default: the empty array.
 	 *
 	 *     @type string $name  The user-facing name of an item name-value pair, e.g. 'IP Address'.
 	 *     @type string $value The user-facing value of an item data pair, e.g. '50.60.70.0'.
 	 * }
-	 * @param WP_User  $user           The user whose data is being exported.
-	 * @param array    $reserved_names An array of reserved names.  Any item in
+	 * @param WP_User $user           The user whose data is being exported.
+	 * @param array   $reserved_names An array of reserved names.  Any item in
 	 *                                 `$additional_user_data` that uses one of these
 	 *                                 for it's `name` will not be included in the export.
 	 *
 	 * @return array
 	 */
-	public function filter_wp_privacy_additional_user_profile_data( $additional_profile_data, $user, $reserved_names ) {
+	public function filter_wp_privacy_additional_user_profile_data( $additional_user_profile_data, $user, $reserved_names ) {
 		$pod = pods( 'user', $user->ID );
 		if ( $pod->valid() ) {
 			foreach ( $pod->fields as $name => $field ) {
-				$additional_profile_data[] = array(
+				$additional_user_profile_data[] = array(
 					'name'  => apply_filters( 'pods_form_ui_label_text', $field['label'], $name, '', $field ),
 					'value' => $pod->display( $name ),
 				);
 			}
 		}
-		return $additional_profile_data;
+		return $additional_user_profile_data;
 	}
 
 	/**

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1665,6 +1665,9 @@ class PodsInit {
 		// Show admin bar links
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_links' ), 81 );
 
+		// Compatibility with WP 5.4 privacy export.
+		add_filter( 'wp_privacy_additional_user_profile_data', array( $this, 'filter_wp_privacy_additional_user_profile_data' ), 10, 3 );
+
 		// Compatibility for Query Monitor conditionals
 		add_filter( 'query_monitor_conditionals', array( $this, 'filter_query_monitor_conditionals' ) );
 
@@ -1861,6 +1864,31 @@ class PodsInit {
 			}
 		}
 
+	}
+
+	/**
+	 * Add Pod fields to user export.
+	 * Requires WordPress 5.4+
+	 *
+	 * @since 2.7.17
+	 *
+	 * @param array   $additional_profile_data
+	 * @param WP_User $user
+	 * @param array   $reserved_names
+	 *
+	 * @return mixed
+	 */
+	public function filter_wp_privacy_additional_user_profile_data( $additional_profile_data, $user, $reserved_names ) {
+		$pod = pods( 'user', $user->ID );
+		if ( $pod->valid() ) {
+			foreach ( $pod->fields as $name => $field ) {
+				$additional_profile_data[] = array(
+					'name'  => $field['label'],
+					'value' => $pod->display( $name ),
+				);
+			}
+		}
+		return $additional_profile_data;
 	}
 
 	/**

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1872,9 +1872,16 @@ class PodsInit {
 	 *
 	 * @since 2.7.17
 	 *
-	 * @param array   $additional_profile_data
-	 * @param WP_User $user
-	 * @param array   $reserved_names
+	 * @param array    $additional_user_profile_data {
+	 *     An array of name-value pairs of additional user data items.  Default: the empty array.
+	 *
+	 *     @type string $name  The user-facing name of an item name-value pair, e.g. 'IP Address'.
+	 *     @type string $value The user-facing value of an item data pair, e.g. '50.60.70.0'.
+	 * }
+	 * @param WP_User  $user           The user whose data is being exported.
+	 * @param array    $reserved_names An array of reserved names.  Any item in
+	 *                                 `$additional_user_data` that uses one of these
+	 *                                 for it's `name` will not be included in the export.
 	 *
 	 * @return mixed
 	 */


### PR DESCRIPTION
Fixes: #5606

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
* WP 5.4 Compatibility: Add user Pod fields to privacy export data

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
