### PR TITLE
Add poststuff class for wp5.4 compatibility

### DIFF
--- a/components/Roles/ui/edit.php
+++ b/components/Roles/ui/edit.php
@@ -30,7 +30,7 @@
 
 			<p><?php _e( 'Choose below which Capabilities you would like this existing user role to have.', 'pods' ); ?></p>
 
-			<div id="poststuff">
+			<div id="poststuff" class="poststuff">
 				<div id="post-body" class="metabox-holder columns-2">
 
 					<div id="postbox-container-1" class="postbox-container">

--- a/ui/admin/form.php
+++ b/ui/admin/form.php
@@ -179,7 +179,7 @@ if ( 0 < $pod->id() ) {
 		 */
 		do_action( 'pods_meta_box_pre', $pod, $obj );
 		?>
-		<div id="poststuff" class="metabox-holder has-right-sidebar"> <!-- class "has-right-sidebar" preps for a sidebar... always present? -->
+		<div id="poststuff" class="poststuff metabox-holder has-right-sidebar"> <!-- class "has-right-sidebar" preps for a sidebar... always present? -->
 			<div id="side-info-column" class="inner-sidebar">
 				<?php
 				/**

--- a/ui/admin/setup-edit.php
+++ b/ui/admin/setup-edit.php
@@ -250,7 +250,7 @@ if ( isset( $_GET[ 'do' ] ) ) {
 }
 ?>
 
-<div id="poststuff">
+<div id="poststuff" class="poststuff">
 <img src="<?php echo esc_url( PODS_URL ); ?>ui/images/pods-logo-notext-rgb-transparent.png" class="pods-leaf-watermark-right" />
 <!-- /inner-sidebar -->
 <div id="post-body" class="meta-box-holder columns-2">

--- a/ui/admin/view.php
+++ b/ui/admin/view.php
@@ -8,7 +8,7 @@ wp_enqueue_style( 'pods-form' );
 ?>
 
 <div class="pods-submittable-fields">
-	<div id="poststuff" class="metabox-holder has-right-sidebar"> <!-- class "has-right-sidebar" preps for a sidebar... always present? -->
+	<div id="poststuff" class="poststuff metabox-holder has-right-sidebar"> <!-- class "has-right-sidebar" preps for a sidebar... always present? -->
 		<div id="side-info-column" class="inner-sidebar">
 			<div id="side-sortables" class="meta-box-sortables ui-sortable">
 				<!-- BEGIN PUBLISH DIV -->


### PR DESCRIPTION
## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
WP 5.4 switched from the `poststuff` ID to a class. This PR adds the class and leaved the ID for backwards compatibility.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
- WP 5.4 admin style compatibility

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
