### PR TITLE
Fix dbx_post_advanced deprecated notices and error on page

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -105,6 +105,7 @@ class PodsField_Pick extends PodsField {
 		add_action( 'edit_category_form', array( $this, 'admin_modal_input' ) );
 		add_action( 'edit_link_category_form', array( $this, 'admin_modal_input' ) );
 		add_action( 'edit_tag_form', array( $this, 'admin_modal_input' ) );
+		// @todo add_tag_form is deprecated, replace our hook usage.
 		add_action( 'add_tag_form', array( $this, 'admin_modal_input' ) );
 		add_action( 'pods_meta_box_pre', array( $this, 'admin_modal_input' ) );
 

--- a/components/Helpers.php
+++ b/components/Helpers.php
@@ -72,7 +72,7 @@ class Pods_Helpers extends PodsComponent {
 		if ( is_admin() ) {
 			add_filter( 'post_updated_messages', array( $this, 'setup_updated_messages' ), 10, 1 );
 
-			add_action( 'dbx_post_advanced', array( $this, 'edit_page_form' ) );
+			add_action( 'add_meta_boxes_' . $this->object_type, array( $this, 'edit_page_form' ) );
 
 			add_action( 'pods_meta_groups', array( $this, 'add_meta_boxes' ) );
 			add_filter( 'get_post_metadata', array( $this, 'get_meta' ), 10, 4 );

--- a/components/Pages.php
+++ b/components/Pages.php
@@ -105,7 +105,7 @@ class Pods_Pages extends PodsComponent {
 		} else {
 			add_filter( 'post_updated_messages', array( $this, 'setup_updated_messages' ), 10, 1 );
 
-			add_action( 'dbx_post_advanced', array( $this, 'edit_page_form' ) );
+			add_action( 'add_meta_boxes_' . $this->object_type, array( $this, 'edit_page_form' ) );
 
 			add_action( 'pods_meta_groups', array( $this, 'add_meta_boxes' ) );
 			add_filter( 'get_post_metadata', array( $this, 'get_meta' ), 10, 4 );
@@ -373,13 +373,6 @@ class Pods_Pages extends PodsComponent {
 	 * @since 2.0.0
 	 */
 	public function edit_page_form() {
-
-		global $post_type;
-
-		if ( $this->object_type != $post_type ) {
-			return;
-		}
-
 		add_filter( 'enter_title_here', array( $this, 'set_title_text' ), 10, 2 );
 	}
 

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -99,7 +99,7 @@ class Pods_Templates extends PodsComponent {
 		if ( is_admin() ) {
 			add_filter( 'post_updated_messages', array( $this, 'setup_updated_messages' ), 10, 1 );
 
-			add_action( 'dbx_post_advanced', array( $this, 'edit_page_form' ) );
+			add_action( 'add_meta_boxes_' . $this->object_type, array( $this, 'edit_page_form' ) );
 
 			add_action( 'pods_meta_groups', array( $this, 'add_meta_boxes' ) );
 

--- a/components/Templates/class-pods_templates.php
+++ b/components/Templates/class-pods_templates.php
@@ -164,7 +164,7 @@ class Pods_Templates_Frontier {
 	 */
 	public function activate_metaboxes() {
 
-		add_action( 'add_meta_boxes', array( $this, 'add_metaboxes' ), 5, 4 );
+		add_action( 'add_meta_boxes__pods_template', array( $this, 'add_metaboxes' ), 5, 2 );
 		add_action( 'save_post', array( $this, 'save_post_metaboxes' ), 1, 2 );
 
 	}
@@ -172,25 +172,28 @@ class Pods_Templates_Frontier {
 	/**
 	 * setup meta boxes.
 	 *
-	 * @param      $slug
 	 * @param bool $post
 	 *
 	 * @return null
 	 */
-	public function add_metaboxes( $slug, $post = false ) {
+	public function add_metaboxes( $post = false ) {
 
 		if ( ! empty( $post ) ) {
 			if ( ! in_array( $post->post_type, array( '_pods_template' ), true ) ) {
 				return;
 			}
+
+			$slug = $post->post_type;
 		} else {
 			$screen = get_current_screen();
 			if ( ! in_array( $screen->base, array( '_pods_template' ), true ) ) {
 				return;
 			}
+
+			$slug = $screen->base;
 		}
 
-		$this->plugin_screen_hook_suffix[ $slug ] = $slug;
+		$this->plugin_screen_hook_suffix[ $slug ] = $post->post_type;
 
 		// Required Styles for metabox
 		wp_enqueue_style( $this->plugin_slug . '-view_template-styles', $this->get_url( 'assets/css/styles-view_template.css', __FILE__ ), array(), self::VERSION );

--- a/components/Templates/includes/functions-pod_reference.php
+++ b/components/Templates/includes/functions-pod_reference.php
@@ -45,7 +45,13 @@ function pq_recurse_pod_fields( $pod_name, $prefix = '', &$pods_visited = array(
 	if ( empty( $pod_name ) ) {
 		return $fields;
 	}
-	$pod           = pods( $pod_name );
+
+	$pod = pods( $pod_name );
+
+	if ( empty( $pod ) || ! $pod->valid() ) {
+		return $fields;
+	}
+
 	$recurse_queue = array();
 
 	foreach ( $pod->pod_data['object_fields'] as $name => $field ) {


### PR DESCRIPTION
## Description
Admin area shows deprecated notices when using Pods templates/helpers/pages components. Also sometimes bad pod configurations can fatal.

## ChangeLog
Fixed: Replaced hook used for meta boxes in admin for custom component integrations to avoid deprecated notices from WordPress.
Fixed: Prevented potential fatal errors on Pod Template editor screen when pod configuration is broken.