### PR TITLE
Fix getting the post thumb by correct ID

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1061,7 +1061,8 @@ class Pods implements Iterator {
 						$attachment_id = 0;
 						switch ( $image_field ) {
 							case 'post_thumbnail':
-								$attachment_id = get_post_thumbnail_id();
+								// Pods will auto-get the thumbnail ID if this isn't an attachment.
+								$attachment_id = get_post_thumbnail_id( $this->id() );
 								break;
 							case 'image_attachment':
 								if ( isset( $traverse_names[0] ) ) {

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1061,7 +1061,6 @@ class Pods implements Iterator {
 						$attachment_id = 0;
 						switch ( $image_field ) {
 							case 'post_thumbnail':
-								// Pods will auto-get the thumbnail ID if this isn't an attachment.
 								$attachment_id = get_post_thumbnail_id( $this->id() );
 								break;
 							case 'image_attachment':
@@ -1095,6 +1094,7 @@ class Pods implements Iterator {
 							}
 
 							if ( $size ) {
+								// Pods will auto-get the thumbnail ID if this isn't an attachment.
 								$value = pods_image( $attachment_id, $size, 0, null, true );
 
 								$object_field_found = true;


### PR DESCRIPTION
Fixes #5610 bug I missed in getting the correct thumbnail from an each loop.
Bug found by @jimtrue 

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
