### PR TITLE
Fix pick display serial comma

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -176,8 +176,9 @@ class PodsField_Pick extends PodsField {
 				'default'    => 'default',
 				'type'       => 'pick',
 				'data'       => array(
-					'default' => __( 'Item 1, Item 2, and Item 3', 'pods' ),
-					'custom'  => __( 'Custom separator (with no "and")', 'pods' ),
+					'default'    => __( 'Item 1, Item 2, and Item 3', 'pods' ),
+					'non_serial' => __( 'Item 1, Item 2 and Item 3', 'pods' ),
+					'custom'     => __( 'Custom separator (without "and")', 'pods' ),
 				),
 				'dependency' => true,
 			),
@@ -747,7 +748,13 @@ class PodsField_Pick extends PodsField {
 			'fields' => $fields,
 		);
 
-		if ( 'custom' === pods_v( static::$type . '_display_format_multi', $options, 'default' ) ) {
+		$display_format = pods_v( static::$type . '_display_format_multi', $options, 'default' );
+
+		if ( 'non_serial' === $display_format ) {
+			$args['serial'] = false;
+		}
+
+		if ( 'custom' === $display_format ) {
 			$args['serial'] = false;
 
 			$separator = pods_v( static::$type . '_display_format_separator', $options, ', ' );

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -748,8 +748,9 @@ class PodsField_Pick extends PodsField {
 		);
 
 		if ( 'custom' === pods_v( static::$type . '_display_format_multi', $options, 'default' ) ) {
-			$separator = pods_v( static::$type . '_display_format_separator', $options, ', ' );
+			$args['serial'] = false;
 
+			$separator = pods_v( static::$type . '_display_format_separator', $options, ', ' );
 			if ( ! empty( $separator ) ) {
 				$args['separator'] = $separator;
 

--- a/tests/phpunit/includes/tests-pods-data.php
+++ b/tests/phpunit/includes/tests-pods-data.php
@@ -244,7 +244,53 @@ class Test_PodsData extends Pods_UnitTestCase {
 
 	public function test_pods_serial_comma() {
 
-		$this->markTestIncomplete( 'not yet implemented' );
+		$values = array(
+			'test1',
+			'test2',
+			'test3',
+		);
+
+		$result = 'test1, test2, and test3';
+
+		$this->assertEquals( $result, pods_serial_comma( $values ) );
+
+		$args = array(
+			'serial' => false,
+		);
+
+		$result = 'test1, test2 and test3';
+
+		$this->assertEquals( $result, pods_serial_comma( $values, $args ) );
+
+		$args = array(
+			'separator' => ' | ',
+			'serial'    => false,
+		);
+
+		$result = 'test1 | test2 and test3';
+
+		$this->assertEquals( $result, pods_serial_comma( $values, $args ) );
+
+		$args = array(
+			'and'       => ' & ',
+			'serial'    => false,
+		);
+
+		$result = 'test1, test2 & test3';
+
+		$this->assertEquals( $result, pods_serial_comma( $values, $args ) );
+
+		$args = array(
+			'separator' => ' | ',
+			'and'       => ' | ',
+			'serial'    => false,
+		);
+
+		$result = 'test1 | test2 | test3';
+
+		$this->assertEquals( $result, pods_serial_comma( $values, $args ) );
+
+		//$this->markTestIncomplete( 'not yet implemented' );
 	}
 
 	public function test_pods_var_user() {

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -4,7 +4,7 @@ namespace Pods_Unit_Tests;
 
 use PodsField_Boolean;
 
-require PODS_TEST_PLUGIN_DIR . '/classes/fields/boolean.php';
+require_once PODS_TEST_PLUGIN_DIR . '/classes/fields/boolean.php';
 
 /**
  * Class Test_PodsField_Boolean

--- a/tests/phpunit/includes/tests-pods-field-currency.php
+++ b/tests/phpunit/includes/tests-pods-field-currency.php
@@ -3,7 +3,7 @@ namespace Pods_Unit_Tests;
 
 use PodsField_Currency;
 
-require PODS_TEST_PLUGIN_DIR . '/classes/fields/currency.php';
+require_once PODS_TEST_PLUGIN_DIR . '/classes/fields/currency.php';
 
 /**
  * Class Test_PodsField_Boolean

--- a/tests/phpunit/includes/tests-pods-field-pick.php
+++ b/tests/phpunit/includes/tests-pods-field-pick.php
@@ -38,7 +38,7 @@ class Test_PodsField_Pick extends Pods_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider formatDefaultsProvider
+	 * Single values.
 	 */
 	public function test_format_defaults() {
 		$options = $this->defaultOptions;

--- a/tests/phpunit/includes/tests-pods-field-pick.php
+++ b/tests/phpunit/includes/tests-pods-field-pick.php
@@ -3,7 +3,7 @@ namespace Pods_Unit_Tests;
 
 use PodsField_Pick;
 
-require PODS_TEST_PLUGIN_DIR . '/classes/fields/pick.php';
+require_once PODS_TEST_PLUGIN_DIR . '/classes/fields/pick.php';
 
 /**
  * Class Test_PodsField_Boolean

--- a/tests/phpunit/includes/tests-pods-field-pick.php
+++ b/tests/phpunit/includes/tests-pods-field-pick.php
@@ -1,0 +1,103 @@
+<?php
+namespace Pods_Unit_Tests;
+
+use PodsField_Pick;
+
+require PODS_TEST_PLUGIN_DIR . '/classes/fields/pick.php';
+
+/**
+ * Class Test_PodsField_Boolean
+ *
+ * @package            Pods_Unit_Tests
+ * @group              pods-field
+ * @coversDefaultClass PodsField_Pick
+ */
+class Test_PodsField_Pick extends Pods_UnitTestCase {
+
+	/**
+	 * @var PodsField_Pick
+	 */
+	private $field;
+
+	public $defaultOptions = array(
+		"pick_format_type"              => "single",
+		"pick_format_single"            => "dropdown",
+		"pick_format_multi"             => "checkbox",
+		"pick_display_format_multi"     => "default",
+		"pick_display_format_separator" => ", ",
+	);
+
+	public function setUp() {
+
+		$this->field = new PodsField_Pick();
+	}
+
+	public function tearDown() {
+
+		unset( $this->field );
+	}
+
+	/**
+	 * @dataProvider formatDefaultsProvider
+	 */
+	public function test_format_defaults() {
+		$options = $this->defaultOptions;
+
+		$value = array(
+			'item1',
+		);
+
+		$expected = 'item1';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+	}
+
+	/**
+	 * Multiple values and display formats.
+	 */
+	public function test_display_format_multi_simple() {
+		$options = $this->defaultOptions;
+		$options[ 'pick_format_type' ] = 'multi';
+
+		$value = array(
+			'item1',
+			'item2',
+			'item3',
+		);
+
+		$expected = 'item1, item2, and item3';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+
+		// no_serial display format.
+		$options[ 'pick_display_format_multi' ] = 'no_serial';
+
+		$expected = 'item1, item2 and item3';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+
+		// custom display format.
+		$options[ 'pick_display_format_multi' ] = 'custom';
+
+		$expected = 'item1, item2, item3';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+
+		// custom display format separator.
+		$options[ 'pick_display_format_multi' ]     = 'custom';
+		$options[ 'pick_display_format_separator' ] = ' | ';
+
+		$expected = 'item1 | item2 | item3';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+	}
+
+	/**
+	 * @todo Cover display tests with actual relationship values.
+	 */
+	public function test_display_format_multi_relationship() {
+
+		$this->markTestIncomplete( 'not yet implemented' );
+	}
+
+}

--- a/tests/phpunit/includes/tests-pods-field-pick.php
+++ b/tests/phpunit/includes/tests-pods-field-pick.php
@@ -70,7 +70,7 @@ class Test_PodsField_Pick extends Pods_UnitTestCase {
 		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
 
 		// no_serial display format.
-		$options[ 'pick_display_format_multi' ] = 'no_serial';
+		$options[ 'pick_display_format_multi' ] = 'non_serial';
 
 		$expected = 'item1, item2 and item3';
 


### PR DESCRIPTION
Fixes: #5637

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
This PR makes the serial comma optionally and disables it for the custom separator format.

I also added some simple unit tests for `pods_serial_comma()`

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
- Fixed: Double comma in custom pick display formats.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
