### PR TITLE
Shortcodes auto use_current fix

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -895,7 +895,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		}
 
 		if ( empty( $tags['name'] ) ) {
-			return '<p>Please provide a Pod name</p>';
+			return '<p>' . __( 'Please provide a Pod name', 'pods' ) . '</p>';
 		}
 	}
 
@@ -912,7 +912,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}
 
 	if ( empty( $content ) && empty( $tags['pods_page'] ) && empty( $tags['template'] ) && empty( $tags['field'] ) && empty( $tags['form'] ) ) {
-		return '<p>Please provide either a template or field name</p>';
+		return '<p>' . __( 'Please provide either a template or field name', 'pods' ) . '</p>';
 	}
 
 	if ( ! $tags['use_current'] && ! isset( $id ) ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -894,7 +894,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 			}
 		}
 
-		if ( empty( $tags['name'] ) ) {
+		if ( ! $tags['use_current'] && empty( $tags['name'] ) ) {
 			return '<p>' . __( 'Please provide a Pod name', 'pods' ) . '</p>';
 		}
 	}

--- a/includes/general.php
+++ b/includes/general.php
@@ -950,7 +950,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}
 
 	if ( empty( $pod ) || ! $pod->valid() ) {
-		return '<p>Pod not found</p>';
+		return '<p>' . __( 'Pod not found', 'pods' ) . '</p>';
 	}
 
 	$found = 0;


### PR DESCRIPTION
Fixes: #5636 

Since in nearly all occasions themes start a loop, even for singular pages, this bug wasn't noticed.

I tested this fix by adding `[pods]{@post_status}[/pods]` in the `wp_body_open` hook, outside the posts loop and can confirm this works.

## ChangeLog
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->
- Fixed: auto `use_current` not working correctly

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
