### PR TITLE
Fix [if][else] magic tags for boolean fields

### DIFF
--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -199,7 +199,7 @@ class PodsField_Boolean extends PodsField {
 	}
 
 	/**
-	 * Replicates filter_var with FILTER_VALIDATE_BOOLEAN and adds custom input for yes/no values.
+	 * Replicates filter_var() with `FILTER_VALIDATE_BOOLEAN` and adds custom input for yes/no values.
 	 *
 	 * {@inheritdoc}
 	 */

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -79,6 +79,7 @@ class PodsField_Boolean extends PodsField {
 
 		$is_empty = false;
 
+		// is_empty() is used for if/else statements. Value should be true to pass.
 		$value = $this->pre_save( $value );
 
 		if ( ! $value ) {

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -215,7 +215,7 @@ class PodsField_Boolean extends PodsField {
 		if ( $yes === $value ) {
 			$value = 1;
 		} else {
-			// Validate: 1", "true", "on", and "yes" as 1, all others are 0.
+			// Validate: 1, "1", true, "true", "on", and "yes" as 1, all others are 0.
 			$value = (int) filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 		}
 

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -212,18 +212,11 @@ class PodsField_Boolean extends PodsField {
 			$value = strtolower( $value );
 		}
 
-		$yes_values = array( 'yes', 'true', 'on', '1', $yes );
-		$no_values  = array( 'no', 'false', 'off', '0', $no );
-
-		// Only allow 0 / 1
-		if ( in_array( $value, $yes_values, true ) ) {
-			$value = 1;
-		} elseif ( in_array( $value, $no_values, true ) ) {
-			$value = 0;
-		} elseif ( 0 !== (int) $value ) {
+		if ( $yes === $value ) {
 			$value = 1;
 		} else {
-			$value = 0;
+			// Validate: 1", "true", "on", and "yes" as 1, all others are 0.
+			$value = (int) filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 		}
 
 		return $value;

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -75,22 +75,6 @@ class PodsField_Boolean extends PodsField {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function is_empty( $value = null ) {
-
-		$is_empty = false;
-
-		// Boolean false and integer 0 are non-empty values.
-		if ( ! is_bool( $value ) && ! is_int( $value ) && '0' !== $value ) {
-			$is_empty = empty( $value );
-		}
-
-		return $is_empty;
-
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
 		$yesno = array(

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -75,6 +75,23 @@ class PodsField_Boolean extends PodsField {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function is_empty( $value = null ) {
+
+		$is_empty = false;
+
+		$value = $this->pre_save( $value );
+
+		if ( ! $value ) {
+			$is_empty = true;
+		}
+
+		return $is_empty;
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
 
 		$yesno = array(
@@ -181,6 +198,8 @@ class PodsField_Boolean extends PodsField {
 	}
 
 	/**
+	 * Replicates filter_var with FILTER_VALIDATE_BOOLEAN and adds custom input for yes/no values.
+	 *
 	 * {@inheritdoc}
 	 */
 	public function pre_save( $value, $id = null, $name = null, $options = null, $fields = null, $pod = null, $params = null ) {
@@ -188,14 +207,13 @@ class PodsField_Boolean extends PodsField {
 		$yes = strtolower( pods_v( static::$type . '_yes_label', $options, __( 'Yes', 'pods' ), true ) );
 		$no  = strtolower( pods_v( static::$type . '_no_label', $options, __( 'No', 'pods' ), true ) );
 
+		$yes_values = array( 'yes', 'true', 'on', '1', $yes );
+		$no_values  = array( 'no', 'false', 'off', '0', $no );
+
 		// Only allow 0 / 1
-		if ( 'yes' === strtolower( $value ) || '1' === (string) $value ) {
+		if ( in_array( strtolower( $value ), $yes_values, true ) ) {
 			$value = 1;
-		} elseif ( 'no' === strtolower( $value ) || '0' === (string) $value ) {
-			$value = 0;
-		} elseif ( strtolower( $value ) === $yes ) {
-			$value = 1;
-		} elseif ( strtolower( $value ) === $no ) {
+		} elseif ( in_array( strtolower( $value ), $no_values, true ) ) {
 			$value = 0;
 		} elseif ( 0 !== (int) $value ) {
 			$value = 1;

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -208,13 +208,17 @@ class PodsField_Boolean extends PodsField {
 		$yes = strtolower( pods_v( static::$type . '_yes_label', $options, __( 'Yes', 'pods' ), true ) );
 		$no  = strtolower( pods_v( static::$type . '_no_label', $options, __( 'No', 'pods' ), true ) );
 
+		if ( is_string( $value ) ) {
+			$value = strtolower( $value );
+		}
+
 		$yes_values = array( 'yes', 'true', 'on', '1', $yes );
 		$no_values  = array( 'no', 'false', 'off', '0', $no );
 
 		// Only allow 0 / 1
-		if ( in_array( strtolower( $value ), $yes_values, true ) ) {
+		if ( in_array( $value, $yes_values, true ) ) {
 			$value = 1;
-		} elseif ( in_array( strtolower( $value ), $no_values, true ) ) {
+		} elseif ( in_array( $value, $no_values, true ) ) {
 			$value = 0;
 		} elseif ( 0 !== (int) $value ) {
 			$value = 1;

--- a/classes/fields/boolean.php
+++ b/classes/fields/boolean.php
@@ -173,21 +173,20 @@ class PodsField_Boolean extends PodsField {
 	 */
 	public function validate( $value, $name = null, $options = null, $fields = null, $pod = null, $id = null, $params = null ) {
 
+		$required = (int) pods_v( 'required', $options, 0 );
+
+		if ( ! $required ) {
+			// Any value can be parsed to boolean.
+			return true;
+		}
+
 		$errors = array();
 		$check  = $this->pre_save( $value, $id, $name, $options, $fields, $pod, $params );
 
 		$yes_required = ( 'checkbox' === pods_v( static::$type . '_format_type', $options ) );
 
-		$required = (int) pods_v( 'required', $options );
-
-		if ( 1 === $required ) {
-			if ( $yes_required ) {
-				if ( 0 === $check ) {
-					$errors[] = __( 'This field is required.', 'pods' );
-				}
-			} elseif ( $this->is_empty( $value ) ) {
-				$errors[] = __( 'This field is required.', 'pods' );
-			}
+		if ( $yes_required && ! $check ) {
+			$errors[] = __( 'This field is required.', 'pods' );
 		}
 
 		if ( ! empty( $errors ) ) {

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -263,8 +263,8 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
 
 		// Other
-		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 
 		$options = array(
 			'boolean_format_type' => 'radio',
@@ -288,8 +288,8 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
 
 		// Other
-		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 
 		$options = array(
 			'boolean_format_type' => 'checkbox',
@@ -313,8 +313,8 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
 
 		// Other
-		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
 
 
 		/**
@@ -344,8 +344,8 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 		$this->assertFalse( $this->field->validate( 'False', null, $options ) );
 
 		// Other
-		$this->assertFalse( $this->field->validate( '', null, $options ) ); // Parses to 0.
-		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) ); // Parses to 1.
+		$this->assertNotTrue( $this->field->validate( '', null, $options ) ); // Parses to 0.
+		$this->assertNotTrue( $this->field->validate( 'Foobar', null, $options ) ); // Parses to 0.
 	}
 
 	/**
@@ -371,7 +371,7 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 
 		// Other
 		$this->assertTrue( $this->field->is_empty( '' ) ); // Parses to 0.
-		$this->assertFalse( $this->field->is_empty( 'Foobar' ) ); // Parses to 1.
+		$this->assertTrue( $this->field->is_empty( 'Foobar' ) ); // Parses to 0.
 	}
 
 	/**

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -239,7 +239,73 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 	 */
 	public function test_method_validate() {
 
-		$this->assertTrue( $this->field->validate( 'foo' ) );
+		$options = array(
+			'boolean_format_type' => 'radio',
+			'boolean_required'    => false,
+		);
+
+		// All values are valid as they are parsed to integers (1 or 0).
+		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( false, null, $options ) );
+
+		$options = array(
+			'boolean_format_type' => 'radio',
+			'boolean_required'    => true,
+		);
+
+		// All values are valid as they are parsed to integers (1 or 0).
+		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( false, null, $options ) );
+
+		$options = array(
+			'boolean_format_type' => 'checkbox',
+			'boolean_required'    => false,
+		);
+
+		// All values are valid as they are parsed to integers (1 or 0).
+		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( false, null, $options ) );
+
+		$options = array(
+			'boolean_format_type' => 'checkbox',
+			'boolean_required'    => true,
+		);
+
+		// Only non_empty values are valid since a required checkbox only has one value.
+		$this->assertTrue( $this->field->validate( 'foo', null, $options ) ); // Parses to 1.
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertFalse( $this->field->validate( 'No', null, $options ) ); // Parses to 0.
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertFalse( $this->field->validate( '0', null, $options ) );
+		$this->assertFalse( $this->field->validate( '', null, $options ) );
+		$this->assertFalse( $this->field->validate( 1, null, $options ) );
+		$this->assertFalse( $this->field->validate( 0, null, $options ) );
+		$this->assertFalse( $this->field->validate( true, null, $options ) );
+		$this->assertFalse( $this->field->validate( false, null, $options ) );
 	}
 
 	/**

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -239,73 +239,139 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 	 */
 	public function test_method_validate() {
 
+		// All values are valid as they are parsed to integers (1 or 0).
+
 		$options = array(
 			'boolean_format_type' => 'radio',
 			'boolean_required'    => false,
 		);
 
-		// All values are valid as they are parsed to integers (1 or 0).
-		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
-		$this->assertTrue( $this->field->validate( '1', null, $options ) );
-		$this->assertTrue( $this->field->validate( '0', null, $options ) );
-		$this->assertTrue( $this->field->validate( '', null, $options ) );
-		$this->assertTrue( $this->field->validate( 1, null, $options ) );
-		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		// Empty values.
 		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'On', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'True', null, $options ) );
+
+		// Non empty values.
 		$this->assertTrue( $this->field->validate( false, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Off', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
+
+		// Other
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
 
 		$options = array(
 			'boolean_format_type' => 'radio',
 			'boolean_required'    => true,
 		);
 
-		// All values are valid as they are parsed to integers (1 or 0).
-		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
-		$this->assertTrue( $this->field->validate( '1', null, $options ) );
-		$this->assertTrue( $this->field->validate( '0', null, $options ) );
-		$this->assertTrue( $this->field->validate( '', null, $options ) );
-		$this->assertTrue( $this->field->validate( 1, null, $options ) );
-		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		// Empty values.
 		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'On', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'True', null, $options ) );
+
+		// Non empty values.
 		$this->assertTrue( $this->field->validate( false, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Off', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
+
+		// Other
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
 
 		$options = array(
 			'boolean_format_type' => 'checkbox',
 			'boolean_required'    => false,
 		);
 
-		// All values are valid as they are parsed to integers (1 or 0).
-		$this->assertTrue( $this->field->validate( 'foo', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
-		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
-		$this->assertTrue( $this->field->validate( '1', null, $options ) );
-		$this->assertTrue( $this->field->validate( '0', null, $options ) );
-		$this->assertTrue( $this->field->validate( '', null, $options ) );
-		$this->assertTrue( $this->field->validate( 1, null, $options ) );
-		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		// Empty values.
 		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
+		$this->assertTrue( $this->field->validate( '1', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'On', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'True', null, $options ) );
+
+		// Non empty values.
 		$this->assertTrue( $this->field->validate( false, null, $options ) );
+		$this->assertTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Off', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'False', null, $options ) );
+
+		// Other
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) );
+		$this->assertTrue( $this->field->validate( '', null, $options ) );
+
+
+		/**
+		 * Required checkbox.
+		 * Only non_empty values are valid since a required checkbox only has one value.
+		 */
 
 		$options = array(
 			'boolean_format_type' => 'checkbox',
 			'boolean_required'    => true,
 		);
 
-		// Only non_empty values are valid since a required checkbox only has one value.
-		$this->assertTrue( $this->field->validate( 'foo', null, $options ) ); // Parses to 1.
-		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
-		$this->assertFalse( $this->field->validate( 'No', null, $options ) ); // Parses to 0.
+		// Empty values.
+		$this->assertTrue( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( 1, null, $options ) );
 		$this->assertTrue( $this->field->validate( '1', null, $options ) );
-		$this->assertFalse( $this->field->validate( '0', null, $options ) );
-		$this->assertFalse( $this->field->validate( '', null, $options ) );
-		$this->assertFalse( $this->field->validate( 1, null, $options ) );
-		$this->assertFalse( $this->field->validate( 0, null, $options ) );
-		$this->assertFalse( $this->field->validate( true, null, $options ) );
+		$this->assertTrue( $this->field->validate( 'Yes', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'On', null, $options ) );
+		$this->assertTrue( $this->field->validate( 'True', null, $options ) );
+
+		// Non empty values.
 		$this->assertFalse( $this->field->validate( false, null, $options ) );
+		$this->assertFalse( $this->field->validate( 0, null, $options ) );
+		$this->assertFalse( $this->field->validate( '0', null, $options ) );
+		$this->assertFalse( $this->field->validate( 'No', null, $options ) );
+		$this->assertFalse( $this->field->validate( 'Off', null, $options ) );
+		$this->assertFalse( $this->field->validate( 'False', null, $options ) );
+
+		// Other
+		$this->assertFalse( $this->field->validate( '', null, $options ) ); // Parses to 0.
+		$this->assertTrue( $this->field->validate( 'Foobar', null, $options ) ); // Parses to 1.
+	}
+
+	/**
+	 * @covers  ::is_empty
+	 */
+	public function test_method_is_empty() {
+
+		// Empty values.
+		$this->assertTrue( $this->field->is_empty( false ) );
+		$this->assertTrue( $this->field->is_empty( 0 ) );
+		$this->assertTrue( $this->field->is_empty( '0' ) );
+		$this->assertTrue( $this->field->is_empty( 'No' ) );
+		$this->assertTrue( $this->field->is_empty( 'Off' ) );
+		$this->assertTrue( $this->field->is_empty( 'False' ) );
+
+		// Non empty values.
+		$this->assertFalse( $this->field->is_empty( true ) );
+		$this->assertFalse( $this->field->is_empty( 1 ) );
+		$this->assertFalse( $this->field->is_empty( '1' ) );
+		$this->assertFalse( $this->field->is_empty( 'Yes' ) );
+		$this->assertFalse( $this->field->is_empty( 'On' ) );
+		$this->assertFalse( $this->field->is_empty( 'True' ) );
+
+		// Other
+		$this->assertTrue( $this->field->is_empty( '' ) ); // Parses to 0.
+		$this->assertFalse( $this->field->is_empty( 'Foobar' ) ); // Parses to 1.
 	}
 
 	/**

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -336,12 +336,12 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 		$this->assertTrue( $this->field->validate( 'True', null, $options ) );
 
 		// Non empty values.
-		$this->assertFalse( $this->field->validate( false, null, $options ) );
-		$this->assertFalse( $this->field->validate( 0, null, $options ) );
-		$this->assertFalse( $this->field->validate( '0', null, $options ) );
-		$this->assertFalse( $this->field->validate( 'No', null, $options ) );
-		$this->assertFalse( $this->field->validate( 'Off', null, $options ) );
-		$this->assertFalse( $this->field->validate( 'False', null, $options ) );
+		$this->assertNotTrue( $this->field->validate( false, null, $options ) );
+		$this->assertNotTrue( $this->field->validate( 0, null, $options ) );
+		$this->assertNotTrue( $this->field->validate( '0', null, $options ) );
+		$this->assertNotTrue( $this->field->validate( 'No', null, $options ) );
+		$this->assertNotTrue( $this->field->validate( 'Off', null, $options ) );
+		$this->assertNotTrue( $this->field->validate( 'False', null, $options ) );
 
 		// Other
 		$this->assertNotTrue( $this->field->validate( '', null, $options ) ); // Parses to 0.

--- a/tests/phpunit/includes/tests-pods-field-boolean.php
+++ b/tests/phpunit/includes/tests-pods-field-boolean.php
@@ -243,7 +243,7 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 
 		$options = array(
 			'boolean_format_type' => 'radio',
-			'boolean_required'    => false,
+			'required'            => false,
 		);
 
 		// Empty values.
@@ -268,7 +268,7 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 
 		$options = array(
 			'boolean_format_type' => 'radio',
-			'boolean_required'    => true,
+			'required'            => true,
 		);
 
 		// Empty values.
@@ -293,7 +293,7 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 
 		$options = array(
 			'boolean_format_type' => 'checkbox',
-			'boolean_required'    => false,
+			'required'            => false,
 		);
 
 		// Empty values.
@@ -324,7 +324,7 @@ class Test_PodsField_Boolean extends Pods_UnitTestCase {
 
 		$options = array(
 			'boolean_format_type' => 'checkbox',
-			'boolean_required'    => true,
+			'required'            => true,
 		);
 
 		// Empty values.


### PR DESCRIPTION
Fixes: #5643 (confirmed by user)
Fixes: #5649

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->
PR #5550 introduces fixes for validation boolean fields from a API stand of view. This however created an issue with Pods if/else tags.
This PR fixes that and adds unit tests to make sure this won't happen again.

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [x] My code includes PHP Unit Tests (if applicable)
