### PR TITLE
Fix whitespace trimming for templates

### DIFF
--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -582,8 +582,6 @@ class Pods_Templates extends PodsComponent {
 			return '';
 		}
 
-		$code = trim( $code );
-
 		if ( false !== strpos( $code, '<?' ) && ( ! defined( 'PODS_DISABLE_EVAL' ) || ! PODS_DISABLE_EVAL ) ) {
 			pods_deprecated( 'Pod Template PHP code has been deprecated, please use WP Templates instead of embedding PHP.', '2.3' );
 
@@ -599,6 +597,11 @@ class Pods_Templates extends PodsComponent {
 		}
 
 		$out = $obj->do_magic_tags( $out );
+
+		// Prevent blank whitespace from being output if nothing came through.
+		if ( '' === trim( $out ) ) {
+			$out = '';
+		}
 
 		return apply_filters( 'pods_templates_do_template', $out, $code, $obj );
 	}

--- a/includes/general.php
+++ b/includes/general.php
@@ -1092,7 +1092,6 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}
 
 	$content = $pod->template( $tags['template'], $content );
-	$content = trim( $content );
 
 	if ( empty( $content ) && ! empty( $tags['not_found'] ) ) {
 		$content = $pod->do_magic_tags( $tags['not_found'] );


### PR DESCRIPTION
## Description
Fixes #5668

Backwards compatibility fix -- This now only trims the template after running, to prevent blank whitespace from being output. It will keep whitespace as is if there is any content being output.

## Changelog text for these changes
Only trim template whitespace after running magic tag replacement if there was no content to output.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] My code includes PHP Unit Tests (if applicable)