### PR TITLE
Nested relationship fields should render as array of objects

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5025,7 +5025,13 @@ class PodsAPI {
 
 								$related_item = $this->export_pod_item_level( $related_pod, $related_params );
 
-								$related_data[] = $this->do_hook( 'export_pod_item_level', $related_item, $related_pod->pod, $related_pod->id(), $related_pod, $related_fields, $depth, $flatten, ( $current_depth + 1 ), $params );
+								$related_item_data = $this->do_hook( 'export_pod_item_level', $related_item, $related_pod->pod, $related_pod->id(), $related_pod, $related_fields, $depth, $flatten, ( $current_depth + 1 ), $params );
+
+								if ( function_exists( 'wp_is_json_request' ) && wp_is_json_request() ) {
+									$related_data[] = $related_item_data;
+								} else {
+									$related_data[ $related_id ] = $related_item_data;
+								}
 							}
 						}
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5028,6 +5028,7 @@ class PodsAPI {
 								$related_item_data = $this->do_hook( 'export_pod_item_level', $related_item, $related_pod->pod, $related_pod->id(), $related_pod, $related_fields, $depth, $flatten, ( $current_depth + 1 ), $params );
 
 								if ( function_exists( 'wp_is_json_request' ) && wp_is_json_request() ) {
+									// Don't pass IDs as keys for REST API context to ensure arrays of data are returned.
 									$related_data[] = $related_item_data;
 								} else {
 									$related_data[ $related_id ] = $related_item_data;

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5025,7 +5025,7 @@ class PodsAPI {
 
 								$related_item = $this->export_pod_item_level( $related_pod, $related_params );
 
-								$related_data[ $related_id ] = $this->do_hook( 'export_pod_item_level', $related_item, $related_pod->pod, $related_pod->id(), $related_pod, $related_fields, $depth, $flatten, ( $current_depth + 1 ), $params );
+								$related_data[] = $this->do_hook( 'export_pod_item_level', $related_item, $related_pod->pod, $related_pod->id(), $related_pod, $related_fields, $depth, $flatten, ( $current_depth + 1 ), $params );
 							}
 						}
 


### PR DESCRIPTION
## Description

In REST context, multi-level Relationship field Pods renders first level
response correctly, as an array of objects.

```
"steps": [
  {},
  {},
  ...
]
```

But further relationship fields go through `$related_pod->export()` and get
rendered as keyed object list.

```
"steps": [
  {
    "actions": {
      "299": {
      },
      ...
    }
  },
  {},
  ...
]
```

To maintain uniform structure across the response, `$pod->export()` should
join anonymous array members camp.

```
"steps": [
  {
    "actions": [
      {},
      {},
      ...
    ]
  },
  {},
  ...
]
```

## How Has This Been Tested?
REST API requests.

## Checklist:
- [ ] My code is tested.

Couldn't find instructions on how to make PHPUnit 8 run here.

```
$ [git:master+] phpunit
PHP Notice:  Undefined variable: test_root in /home/warmpress/wp-content/plugins/pods.git/tests/phpunit/bootstrap.php on line 21
PHP Warning:  require(/includes/functions.php): failed to open stream: No such file or directory in /home/warmpress/wp-content/plugins/pods.git/tests/phpunit/bootstrap.php on line 21
PHP Fatal error:  require(): Failed opening required '/includes/functions.php' (include_path='.:/usr/share/php7:/usr/share/php') in /home/warmpress/wp-content/plugins/pods.git/tests/phpunit/bootstrap.php on line 21
```