### PR TITLE
Only check `delete_users` for single installations

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -328,6 +328,7 @@ function pods_is_admin( $cap = null ) {
 		}
 
 		$pods_admin_capabilities = array();
+
 		if ( ! is_multisite() ) {
 			// Default is_super_admin() checks against this capability.
 			$pods_admin_capabilities[] = 'delete_users';

--- a/includes/general.php
+++ b/includes/general.php
@@ -322,16 +322,18 @@ function pods_is_debug_display() {
 function pods_is_admin( $cap = null ) {
 
 	if ( is_user_logged_in() ) {
-		// Default is_super_admin() checks against this.
-		$pods_admin_capabilities = array(
-			'delete_users',
-		);
-
-		$pods_admin_capabilities = apply_filters( 'pods_admin_capabilities', $pods_admin_capabilities, $cap );
 
 		if ( is_multisite() && is_super_admin() ) {
 			return apply_filters( 'pods_is_admin', true, $cap, '_super_admin' );
 		}
+
+		$pods_admin_capabilities = array();
+		if ( ! is_multisite() ) {
+			// Default is_super_admin() checks against this capability.
+			$pods_admin_capabilities[] = 'delete_users';
+		}
+
+		$pods_admin_capabilities = apply_filters( 'pods_admin_capabilities', $pods_admin_capabilities, $cap );
 
 		if ( empty( $cap ) ) {
 			$cap = array();


### PR DESCRIPTION
Related: #2311
Related: #3985
Related: #4815

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->

This PR will enhance the network check for Pods access.
Currently Pods validates the `delete_users`, just like WordPress core.
However, this is not entirely correct.

For multisite installations this check isn't valid as only actual super admins should always have access.
This PR only adds the `delete_users` cap if it's a single installation. Multisites do not check this cap.

Doing so improves the way we validate capabilities and makes it behave more similar to WP core.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
