### PR TITLE
REST field options: Only display depth for array response type

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -3707,11 +3707,11 @@ class PodsAdmin {
 					'type'       => 'pick',
 					'default'    => 'array',
 					'depends-on' => array( 'type' => 'pick' ),
+					'dependency' => true,
 					'data'       => array(
 						'array' => __( 'Full', 'pods' ),
 						'id'    => __( 'ID only', 'pods' ),
 						'name'  => __( 'Name', 'pods' ),
-
 					),
 				),
 				'rest_pick_depth'    => array(
@@ -3719,8 +3719,10 @@ class PodsAdmin {
 					'help'       => __( 'How far to traverse relationships in response', 'pods' ),
 					'type'       => 'number',
 					'default'    => '2',
-					'depends-on' => array( 'type' => 'pick' ),
-
+					'depends-on' => array(
+						'type'               => 'pick',
+						'rest_pick_response' => 'array',
+					),
 				),
 
 			);


### PR DESCRIPTION
Fixes: #5705 

Hide the "Depth" option for single response types.

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
