### PR TITLE
Fix factory in pods testcase

### DIFF
--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -370,10 +370,25 @@ class Pods_UnitTestCase extends \WP_UnitTestCase {
 		 */
 	);
 
+	/**
+	 * Fetches the factory object for generating WordPress & Pods fixtures.
+	 *
+	 * @return Pods_UnitTest_Factory The fixture factory.
+	 */
+	protected static function factory() {
+		static $factory = null;
+		if ( ! $factory ) {
+			$factory = new Pods_UnitTest_Factory();
+		}
+		return $factory;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public function setUp() {
 
 		parent::setUp();
-		$this->factory = new Pods_UnitTest_Factory();
 
 		pods_require_component( 'table-storage' );
 		pods_require_component( 'advanced-relationships' );

--- a/tests/phpunit/includes/tests-pods-data.php
+++ b/tests/phpunit/includes/tests-pods-data.php
@@ -368,7 +368,7 @@ class Test_PodsData extends Pods_UnitTestCase {
 		);
 
 		// First log in the user.
-		$user_id = $this->factory->user->create();
+		$user_id = $this->factory()->user->create();
 		wp_set_current_user( $user_id );
 		$this->assertEquals(
 			get_current_user_id(),


### PR DESCRIPTION
The way we assign the factory to a property isn't the same as WordPress core testcase does.
This PR fixes that.

The factory is still accessible through the property since the WordPress core testcase utilizes a `__get()` method for this.

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
