### PR TITLE
Support `get_query_var` in pods_v (and thus special magic tags)

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -363,6 +363,9 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 					$output = pods_unslash( $_REQUEST[ $var ] );
 				}
 				break;
+			case 'query':
+				$output = get_query_var( $var, $default );
+				break;
 			case 'url':
 			case 'uri':
 				$url = parse_url( pods_current_url() );


### PR DESCRIPTION
Fixes: #5719 
Related: https://wordpress.org/support/topic/issue-trying-to-use-shortcodes-with-pods-shortcode/

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
~~- My code includes PHP Unit Tests (if applicable)~~
