### PR TITLE
Downgrade Jest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "grunt-git": "^1.0.13",
     "grunt-text-replace": "^0.4.0",
     "install": "^0.10.2",
-    "jest": "^26.0.1",
+    "jest": "^25.0.0",
     "jquery": "^3.5.1",
     "jsdom": "^16.2.2",
     "jsdom-global": "3.0.2",


### PR DESCRIPTION
Downgrade Jest version to version supported by @wordpress/jest-preset-default

## Description
@wordpress/jest-preset-default uses a deprecated function that was removed in Jest 26, switch to Jest 25 for now.

## How Has This Been Tested?
Jest tests now pass.

## Types of changes
Bug fix

## Changelog text for these changes
Downgrade Jest

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows has proper inline documentation.
- [ ] My code includes PHP Unit Tests (if applicable)
