### PR TITLE
Add is_empty() method to validate numeric pick values

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -727,6 +727,34 @@ class PodsField_Pick extends PodsField {
 	}
 
 	/**
+	 * @todo 2.8 Centralize the usage of this method. See PR #5540.
+	 * {@inheritdoc}
+	 */
+	public function is_empty( $value = null ) {
+
+		$is_empty = false;
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $val ) {
+				if ( $this->is_empty( $val ) ) {
+					unset( $value[ $key ] );
+				}
+			}
+		}
+
+		/**
+		 * @todo Find a way to check for relationship type before comparing to `0` as this is still empty for posts/terms/users etc.
+		 *       Currently not possible since this method doesn't get any options passed as parameters.
+		 */
+		if ( empty( $value ) && '0' !== (string) $value ) {
+			$is_empty = true;
+		}
+
+		return $is_empty;
+
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {


### PR DESCRIPTION
0 could be valid for weekdays and custom simple relationships.

Fixes: #1854

- [ ] NEEDS TESTING WITH `[if]` TAGS

## Description
<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology Fixes #issue -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Changelog text for these changes
<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list all of them. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
- [ ] My code includes PHP Unit Tests (if applicable)
