### PR TITLE
Pods 2.8: WP doesn't use border radius

### DIFF
--- a/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
+++ b/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
@@ -1,4 +1,4 @@
-$border-radius: 0;
+$border-radius: 2px;
 
 $color--grey: #82878c;
 $color--light-grey: #ccd0d4;

--- a/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
+++ b/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
@@ -8,6 +8,6 @@ $color--zebra-grey: #f9f9f9;
 $color--wp-blue: #007CBA;
 $color--wp-blue-light: #00a0d2;
 
-$color--green: #95BF3B;
+$color--green: #95bf3b;
 $color--red: #a00;
 $color--red-dark: #a02222;

--- a/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
+++ b/ui/js/dfv/src/admin/edit-pod/_edit-pod-variables.scss
@@ -1,4 +1,4 @@
-$border-radius: 9px;
+$border-radius: 0;
 
 $color--grey: #82878c;
 $color--light-grey: #ccd0d4;

--- a/ui/js/dfv/src/admin/edit-pod/main-tabs/field-groups.scss
+++ b/ui/js/dfv/src/admin/edit-pod/main-tabs/field-groups.scss
@@ -9,15 +9,14 @@
 
 .pods-field-group-wrapper {
 	margin-bottom: 10px;
-	border-radius: $border-radius;
 	border: 1px solid $color--light-grey;
 	background-color: #fff;
 	position: relative;
-    transition: border 200ms ease-in-out;
+	transition: border 200ms ease-in-out;
 
 	&.pods-unsaved-data  {
-        border-left-color: #95BF3B;
-        border-left-width: 5px;
+		border-left-color: #95BF3B;
+		border-left-width: 5px;
 	}
 
 	&>.pods-field_wrapper {
@@ -71,7 +70,6 @@
 	border: 2px dashed $color--light-grey;
 	background: none;
 	width: 100%;
-	border-radius: $border-radius;
 	padding: .7em 1em;
 	transition: 300ms ease background-color;
 }

--- a/ui/js/dfv/src/admin/edit-pod/main-tabs/field-list-item.scss
+++ b/ui/js/dfv/src/admin/edit-pod/main-tabs/field-list-item.scss
@@ -147,7 +147,6 @@
 
 .pods-field_wrapper-items {
 	border: 1px solid $color--light-grey;
-	border-radius: $border-radius;
 	margin: 1em 0;
 	overflow: hidden;
 }
@@ -180,10 +179,10 @@
 }
 
 .pods-field_button.pods-field_delete {
-    color: $color--red;
+	color: $color--red;
 
-    &:hover {
-        color: $color--red-dark;
+	&:hover {
+		color: $color--red-dark;
 	}
 
 	&::after {


### PR DESCRIPTION
The 9px border radios isn't in line with the WP and Pods UI.