### PR TITLE
Add Primary Branch header for GitHub Updater

### DIFF
--- a/init.php
+++ b/init.php
@@ -8,6 +8,7 @@ Author: Pods Framework Team
 Author URI: https://pods.io/about/
 Text Domain: pods
 GitHub Plugin URI: https://github.com/pods-framework/pods
+Primary Branch: main
 
 Copyright 2009-2019  Pods Foundation, Inc  (email : contact@podsfoundation.org)
 


### PR DESCRIPTION
## Description

Since Pods' primary branch is now `main` in order for GitHub Updater to properly work the `Primary Branch` header needs to be added.

https://github.com/afragen/github-updater/wiki/Settings#primary-branch

Unfortunately users may need to use the branch switching to reinstall or use a webhook to force a branch switch. Otherwise they may not _see_ an update.