### PR TITLE
Do not limit users by user_status=0 anymore

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -9390,9 +9390,7 @@ class PodsAPI {
 			$info['meta_field_index'] = 'meta_key';
 			$info['meta_field_value'] = 'meta_value';
 
-			$info['where'] = array(
-				'user_status' => '`t`.`user_status` = 0'
-			);
+			$info['where'] = [];
 
 			$info['object_fields'] = $this->get_wp_object_fields( $object_type, $info['pod'] );
 		} elseif ( 'comment' === $object_type || 'comment' === pods_v( 'type', $info['pod'] ) ) {


### PR DESCRIPTION
## Description

WordPress core does not do this kind of limitation on WP User queries and the column has seen total disuse over the years since WordPress has been developed. Plugins are using this column for their own purposes which causes unexpected conflicts with how Pods relationships and lists using `Pods::find()` queries for users.

## How Has This Been Tested?

Tested on client site and confirmed as working.

## Changelog text for these changes

* Fixed: Stop limiting users being queried using the deprecated `user_status` column in the WP Users table to prevent conflicts from other plugin usage of the disused column. #5677

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.