### PR TITLE
Fix selected query for autocomplete relationships

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -2334,6 +2334,10 @@ class PodsField_Pick extends PodsField {
 							$ids = wp_list_pluck( $ids, $search_data->field_id );
 						}
 
+						if ( $params['limit'] < count( $ids ) ) {
+							$params['limit'] = count( $ids );
+						}
+
 						if ( is_array( $ids ) ) {
 							$ids = implode( ', ', $ids );
 						}
@@ -2342,7 +2346,7 @@ class PodsField_Pick extends PodsField {
 							$params['where'] = implode( ' AND ', $params['where'] );
 						}
 						if ( ! empty( $params['where'] ) ) {
-							$params['where'] .= ' AND ';
+							$params['where'] = '(' . $params['where'] . ') AND ';
 						}
 
 						$params['where'] .= "`t`.`{$search_data->field_id}` IN ( {$ids} )";


### PR DESCRIPTION
Fixes #5542 

The `IN ( $ids )` query wasn't added correctly resulting in an `OR` statement where it should be `AND`.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly. #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list each unique issue as separate changelog items. -->

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
