### PR TITLE
Fix PDF src in each loop.

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1124,6 +1124,7 @@ class Pods implements Iterator {
 					}
 
 					if ( $attachment_id ) {
+						$is_image = wp_attachment_is_image( $attachment_id );
 
 						$size = 'thumbnail';
 						if ( isset( $traverse_params[0] ) ) {
@@ -1135,11 +1136,18 @@ class Pods implements Iterator {
 							if ( ! in_array( $size, $sizes, true ) ) {
 								// No valid image size found.
 								$size = false;
+							} else {
+								// Force image request since a valid size parameter is passed.
+								$is_image = true;
 							}
 						}
 
 						if ( $url ) {
-							$value = pods_image_url( $attachment_id, $size, 0, true );
+							if ( $is_image ) {
+								$value = pods_image_url( $attachment_id, $size, 0, true );
+							} else {
+								$value = wp_get_attachment_url( $attachment_id );
+							}
 						} elseif ( $size ) {
 							// Pods will auto-get the thumbnail ID if this isn't an attachment.
 							$value = pods_image( $attachment_id, $size, 0, null, true );

--- a/includes/media.php
+++ b/includes/media.php
@@ -122,7 +122,8 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
  *
  * @param array|int|string $image   The image field array, ID, or guid
  * @param string|array     $size    Image size to use
- * @param int              $default Default image to show if image not found, can be field array, ID, or guid
+ * @param int              $default Default image to show if image not found, can be field array, ID, or guid.
+ *                                  Passing `-1` prevents default filter.
  * @param boolean          $force   Force generation of image (if custom size array provided)
  *
  * @return string Image URL or empty if image not found
@@ -131,8 +132,20 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
  */
 function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = false ) {
 
-	$url = '';
+	if ( ! $default && -1 !== $default ) {
+		/**
+		 * Filter for default value
+		 *
+		 * Use to set a fallback image to be used when the image passed to pods_image can not be found. Will only take effect if $default is not set.
+		 *
+		 * @since 2.7.23
+		 *
+		 * @param array|int|string $default Default image to show if image not found, can be field array, ID, or guid
+		 */
+		$default = apply_filters( 'pods_image_url_default', $default );
+	}
 
+	$url     = '';
 	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
 
@@ -161,7 +174,7 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
 	}//end if
 
 	if ( empty( $url ) && 0 < $default ) {
-		$url = pods_image_url( $default, $size, 0, $force );
+		$url = pods_image_url( $default, $size, -1, $force );
 	}//end if
 
 	return $url;

--- a/includes/media.php
+++ b/includes/media.php
@@ -161,27 +161,7 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
 	}//end if
 
 	if ( empty( $url ) && 0 < $default ) {
-		if ( $force ) {
-			$full = wp_get_attachment_image_src( $default, 'full' );
-			$src  = wp_get_attachment_image_src( $default, $size );
-
-			if ( 'full' !== $size && $full[0] == $src[0] ) {
-				pods_image_resize( $default, $size );
-			}
-		}
-
-		$src = wp_get_attachment_image_src( $default, $size );
-
-		if ( ! empty( $src ) ) {
-			$url = $src[0];
-		} else {
-			// Handle non-images
-			$attachment = get_post( $default );
-
-			if ( ! preg_match( '!^image/!', get_post_mime_type( $attachment ) ) ) {
-				$url = wp_get_attachment_url( $default );
-			}
-		}
+		$url = pods_image_url( $default, $size, 0, $force );
 	}//end if
 
 	return $url;

--- a/includes/media.php
+++ b/includes/media.php
@@ -60,6 +60,7 @@ function pods_image_id_from_field( $image ) {
  * @param array|int|string $image      The image field array, ID, or guid
  * @param string|array     $size       Image size to use
  * @param int              $default    Default image to show if image not found, can be field array, ID, or guid
+ *                                     Passing `-1` prevents default filter.
  * @param string|array     $attributes <img> Attributes array or string (passed to wp_get_attachment_image
  * @param boolean          $force      Force generation of image (if custom size array provided)
  *
@@ -69,11 +70,7 @@ function pods_image_id_from_field( $image ) {
  */
 function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = '', $force = false ) {
 
-	$html = '';
-
-	$id = pods_image_id_from_field( $image );
-
-	if ( 0 == $default ) {
+	if ( ! $default && -1 !== $default ) {
 		/**
 		 * Filter for default value
 		 *
@@ -86,6 +83,8 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
 		$default = apply_filters( 'pods_image_default', $default );
 	}
 
+	$html    = '';
+	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
 
 	if ( 0 < $id ) {
@@ -102,16 +101,7 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
 	}
 
 	if ( empty( $html ) && 0 < $default ) {
-		if ( $force ) {
-			$full = wp_get_attachment_image_src( $default, 'full' );
-			$src  = wp_get_attachment_image_src( $default, $size );
-
-			if ( 'full' !== $size && $full[0] == $src[0] ) {
-				pods_image_resize( $default, $size );
-			}
-		}
-
-		$html = wp_get_attachment_image( $default, $size, true, $attributes );
+		$html = pods_image( $default, $size, -1, $attributes, $force );
 	}
 
 	return $html;

--- a/tests/phpunit/includes/tests-media.php
+++ b/tests/phpunit/includes/tests-media.php
@@ -28,7 +28,7 @@ class Test_Media extends Pods_UnitTestCase {
 		// Default.
 		$this->assertNotEmpty( pods_image( null, 'thumbnail', self::$images[0] ) );
 
-		// Default (make sure it does not loop.
+		// Default (make sure it does not loop).
 		$this->assertEmpty( pods_image( null, 'thumbnail', 123456789 ) );
 	}
 
@@ -39,7 +39,7 @@ class Test_Media extends Pods_UnitTestCase {
 		// Default.
 		$this->assertNotEmpty( pods_image_url( null, 'thumbnail', self::$images[0] ) );
 
-		// Default (make sure it does not loop.
+		// Default (make sure it does not loop).
 		$this->assertEmpty( pods_image_url( null, 'thumbnail', 123456789 ) );
 	}
 

--- a/tests/phpunit/includes/tests-media.php
+++ b/tests/phpunit/includes/tests-media.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Pods_Unit_Tests;
+
+/**
+ * @group pods_acceptance_tests
+ */
+class Test_Media extends Pods_UnitTestCase {
+
+	/** @var array */
+	public static $images = array();
+
+	public function setUp() {
+		self::$images[] = $this->factory()->attachment->create();
+		self::$images[] = $this->factory()->attachment->create();
+		self::$images[] = $this->factory()->attachment->create();
+		//parent::setUp();
+	}
+
+	public function tearDown() {
+		//parent::tearDown();
+	}
+
+	public function test_pods_image() {
+		// Simple fetch.
+		$this->assertNotEmpty( pods_image( self::$images[0] ) );
+
+		// Default.
+		$this->assertNotEmpty( pods_image( null, 'thumbnail', self::$images[0] ) );
+
+		// Default (make sure it does not loop.
+		$this->assertEmpty( pods_image( null, 'thumbnail', 123456789 ) );
+	}
+
+	public function test_pods_image_url() {
+		// Simple fetch.
+		$this->assertNotEmpty( pods_image_url( self::$images[0] ) );
+
+		// Default.
+		$this->assertNotEmpty( pods_image_url( null, 'thumbnail', self::$images[0] ) );
+
+		// Default (make sure it does not loop.
+		$this->assertEmpty( pods_image_url( null, 'thumbnail', 123456789 ) );
+	}
+
+}


### PR DESCRIPTION
Fixes #4040 

## Description

<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology "Fixes #issue" to ensure the related issue will auto-close when this code is release -->

PDF's tags like `{@id}` and `{@_src}` in each loops are converted to `{@image_attachment_url}` tags. This makes the PDF handled as an image.
I've chosen to fix this in the `field()` method instead of in frontier since a different solution would require an extra global tag like `pdf_attachment` or something which I didn't think was needed.
This makes sure if someone uses the `{@image_attachment_url}` tag the URL's get handled correctly.

Of course, if someone uses the `{@image_attachment}` tag this will always return an actual image (HTML).

This PR also removes duplicate code in `pods_image_url` for default value handling.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly. #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list each unique issue as separate changelog items. -->

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
