### PR TITLE
Force avatar size + enhance support for custom sizes

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1140,17 +1140,13 @@ class Pods implements Iterator {
 
 						$size = 'thumbnail';
 						if ( isset( $traverse_params[0] ) ) {
-							$size  = $traverse_params[0];
-							$sizes = get_intermediate_image_sizes();
-							// Not shown by default.
-							$sizes[] = 'full';
-							$sizes[] = 'original';
-							if ( ! in_array( $size, $sizes, true ) ) {
-								// No valid image size found.
-								$size = false;
-							} else {
+							$size = $traverse_params[0];
+							if ( pods_is_image_size( $size ) ) {
 								// Force image request since a valid size parameter is passed.
 								$is_image = true;
+							} else {
+								// No valid image size found.
+								$size = false;
 							}
 						}
 

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1739,7 +1739,7 @@ class Pods implements Iterator {
 											// @todo Refactor the above condition statement.
 											$size = 'full';
 
-											if ( false === strpos( 'image', get_post_mime_type( $item_id ) ) ) {
+											if ( wp_attachment_is_image( $item_id ) ) {
 												// No default sizes for non-images.
 												// When a size is defined this will be overwritten.
 												$size = null;

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1141,6 +1141,7 @@ class Pods implements Iterator {
 						$size = 'thumbnail';
 						if ( isset( $traverse_params[0] ) ) {
 							$size = $traverse_params[0];
+
 							if ( pods_is_image_size( $size ) ) {
 								// Force image request since a valid size parameter is passed.
 								$is_image = true;
@@ -1735,7 +1736,7 @@ class Pods implements Iterator {
 											// @todo Refactor the above condition statement.
 											$size = 'full';
 
-											if ( wp_attachment_is_image( $item_id ) ) {
+											if ( ! wp_attachment_is_image( $item_id ) ) {
 												// No default sizes for non-images.
 												// When a size is defined this will be overwritten.
 												$size = null;

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1075,26 +1075,7 @@ class Pods implements Iterator {
 				}
 
 				// Handle special field tags.
-				if ( 'avatar' === $first_field && 'user' === $pod_type ) {
-					$object_field_found = true;
-					// User avatar.
-					$size = null;
-
-					if ( 0 === strpos( $params->name, 'avatar.' ) ) {
-						$field_names = explode( '.', $params->name );
-
-						if ( isset( $field_names[1] ) ) {
-							$size = (int) $field_names[1];
-						}
-					}
-
-					if ( 0 < $size ) {
-						$value = get_avatar( $this->id(), $size );
-					} else {
-						$value = get_avatar( $this->id() );
-					}
-
-				} elseif ( in_array( $first_field, $image_fields, true ) ) {
+				if ( in_array( $first_field, $image_fields, true ) ) {
 					// Default image field handlers.
 					$object_field_found = true;
 
@@ -1177,6 +1158,25 @@ class Pods implements Iterator {
 						}
 					}
 				}
+			} elseif ( 'avatar' === $first_field && 'user' === $pod_type ) {
+				$object_field_found = true;
+				// User avatar.
+				$size = null;
+
+				if ( 0 === strpos( $params->name, 'avatar.' ) ) {
+					$field_names = explode( '.', $params->name );
+
+					if ( isset( $field_names[1] ) ) {
+						$size = (int) $field_names[1];
+					}
+				}
+
+				if ( 0 < $size ) {
+					$value = get_avatar( $this->id(), $size );
+				} else {
+					$value = get_avatar( $this->id() );
+				}
+
 			}
 
 			// Continue regular field parsing.

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1062,6 +1062,25 @@ class Pods implements Iterator {
 				} else {
 					return null;
 				}
+			} elseif ( 'avatar' === $first_field && 'user' === $pod_type ) {
+				$object_field_found = true;
+				// User avatar.
+				$size = null;
+
+				if ( 0 === strpos( $params->name, 'avatar.' ) ) {
+					$field_names = explode( '.', $params->name );
+
+					if ( isset( $field_names[1] ) ) {
+						$size = (int) $field_names[1];
+					}
+				}
+
+				if ( 0 < $size ) {
+					$value = get_avatar( $this->id(), $size );
+				} else {
+					$value = get_avatar( $this->id() );
+				}
+
 			} elseif ( ! $is_field_set ) {
 
 				$image_fields = array(
@@ -1158,25 +1177,6 @@ class Pods implements Iterator {
 						}
 					}
 				}
-			} elseif ( 'avatar' === $first_field && 'user' === $pod_type ) {
-				$object_field_found = true;
-				// User avatar.
-				$size = null;
-
-				if ( 0 === strpos( $params->name, 'avatar.' ) ) {
-					$field_names = explode( '.', $params->name );
-
-					if ( isset( $field_names[1] ) ) {
-						$size = (int) $field_names[1];
-					}
-				}
-
-				if ( 0 < $size ) {
-					$value = get_avatar( $this->id(), $size );
-				} else {
-					$value = get_avatar( $this->id() );
-				}
-
 			}
 
 			// Continue regular field parsing.

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1754,7 +1754,7 @@ class Pods implements Iterator {
 											}
 
 											if ( $size ) {
-												$value_url = pods_image_url( $item_id, $size );
+												$value_url = pods_image_url( $item_id, $size, 0, true );
 											} else {
 												$value_url = wp_get_attachment_url( $item_id );
 											}
@@ -1786,7 +1786,7 @@ class Pods implements Iterator {
 												$size = substr( $full_field, 5 );
 											}
 
-											$value[] = pods_image( $item_id, $size );
+											$value[] = pods_image( $item_id, $size, 0, array(), true );
 
 											$params->raw_display = true;
 										} elseif ( in_array( $field, array(

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1062,23 +1062,35 @@ class Pods implements Iterator {
 				} else {
 					return null;
 				}
+
 			} elseif ( 'avatar' === $first_field && 'user' === $pod_type ) {
-				$object_field_found = true;
 				// User avatar.
-				$size = null;
+				$size       = null;
+				$get_avatar = true;
 
-				if ( 0 === strpos( $params->name, 'avatar.' ) ) {
-					$field_names = explode( '.', $params->name );
-
-					if ( isset( $field_names[1] ) ) {
-						$size = (int) $field_names[1];
+				if ( $is_traversal ) {
+					if ( $is_field_set ) {
+						// This is a registered field.
+						if ( isset( $traverse_fields[1] ) && is_numeric( $traverse_fields[1] ) ) {
+							$size = (int) $traverse_fields[1];
+						} else {
+							// Traverse through attachment post.
+							$get_avatar = false;
+						}
+					} else {
+						if ( isset( $traverse_fields[1] ) ) {
+							$size = (int) $traverse_fields[1];
+						}
 					}
 				}
 
-				if ( 0 < $size ) {
-					$value = get_avatar( $this->id(), $size );
-				} else {
-					$value = get_avatar( $this->id() );
+				if ( $get_avatar ) {
+					$object_field_found = true;
+					if ( 0 < $size ) {
+						$value = get_avatar( $this->id(), $size );
+					} else {
+						$value = get_avatar( $this->id() );
+					}
 				}
 
 			} elseif ( ! $is_field_set ) {

--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -145,7 +145,7 @@ class PodsField_Avatar extends PodsField_File {
 							$attributes['alt'] = $alt;
 						}
 
-						$user_avatar = pods_image( $user_avatar, array( $size, $size ), 0, $attributes, true );
+						$user_avatar = pods_image( $user_avatar, array( $size, $size, 1 ), 0, $attributes, true );
 
 						if ( ! empty( $user_avatar ) ) {
 							$avatar = $user_avatar;

--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -132,7 +132,8 @@ class PodsField_Avatar extends PodsField_File {
 				}
 
 				if ( ! empty( $avatar_field ) ) {
-					$user_avatar = get_user_meta( $user_id, $avatar_field . '.ID', true );
+					$user_meta   = get_user_meta( $user_id );
+					$user_avatar = ! empty( $user_meta[ $avatar_field ][0] ) ? $user_meta[ $avatar_field ][0] : false;
 
 					if ( ! empty( $user_avatar ) ) {
 						$attributes = array(

--- a/classes/fields/avatar.php
+++ b/classes/fields/avatar.php
@@ -145,7 +145,7 @@ class PodsField_Avatar extends PodsField_File {
 							$attributes['alt'] = $alt;
 						}
 
-						$user_avatar = pods_image( $user_avatar, array( $size, $size ), 0, $attributes );
+						$user_avatar = pods_image( $user_avatar, array( $size, $size ), 0, $attributes, true );
 
 						if ( ! empty( $user_avatar ) ) {
 							$avatar = $user_avatar;

--- a/includes/media.php
+++ b/includes/media.php
@@ -2,12 +2,13 @@
 /**
  * @package Pods\Global\Functions\Media
  */
+
 /**
- * Get the Attachment ID for a specific image field
+ * Get the Attachment ID for a specific image field.
  *
- * @param array|int|string $image The image field array, ID, or guid
+ * @param array|int|string $image The image field array, ID, or guid.
  *
- * @return int Attachment ID
+ * @return int Attachment ID.
  *
  * @since 2.0.5
  */

--- a/includes/media.php
+++ b/includes/media.php
@@ -78,6 +78,38 @@ function pods_image_size( $size ) {
 }
 
 /**
+ * Check if an image size exists or is a valid custom format for a size.
+ *
+ * @param string|int[] $size
+ *
+ * @return bool
+ *
+ * @since 2.7.23
+ */
+function pods_is_image_size( $size ) {
+	$valid = false;
+	if ( is_array( $size ) ) {
+		// Custom array size format.
+		$valid = ( 2 <= count( $size ) && is_numeric( $size[0] ) && is_numeric( $size[1] ) );
+	} elseif ( is_numeric( $size ) ) {
+		// Numeric (square) size format.
+		$valid = true;
+	} elseif ( preg_match( '/[0-9]+x[0-9]+/', $size ) || preg_match( '/[0-9]+x[0-9]+x[0-1]/', $size ) ) {
+		// Custom size format.
+		$valid = true;
+	} else {
+		$sizes = get_intermediate_image_sizes();
+		// Not shown by default.
+		$sizes[] = 'full';
+		$sizes[] = 'original';
+		if ( in_array( $size, $sizes, true ) ) {
+			$valid = true;
+		}
+	}
+	return $valid;
+}
+
+/**
  * Get the <img> HTML for a specific image field.
  *
  * @param array|int|string $image      The image field array, ID, or guid.

--- a/includes/media.php
+++ b/includes/media.php
@@ -74,6 +74,7 @@ function pods_parse_image_size( $size ) {
 		// Fix HTML entity for custom sizes.
 		$size = str_replace( '&#215;', 'x', $size );
 	}
+
 	return $size;
 }
 
@@ -87,8 +88,10 @@ function pods_parse_image_size( $size ) {
  * @since 2.7.23
  */
 function pods_is_image_size( $size ) {
+
 	$valid = false;
 	$size  = pods_parse_image_size( $size );
+
 	if ( is_array( $size ) ) {
 		// Custom array size format.
 		$valid = ( 2 <= count( $size ) && is_numeric( $size[0] ) && is_numeric( $size[1] ) );
@@ -107,6 +110,7 @@ function pods_is_image_size( $size ) {
 			$valid = true;
 		}
 	}
+
 	return $valid;
 }
 

--- a/includes/media.php
+++ b/includes/media.php
@@ -55,6 +55,28 @@ function pods_image_id_from_field( $image ) {
 }
 
 /**
+ * Parse image size parameter to support custom image sizes.
+ *
+ * @param string|int[] $size
+ *
+ * @return string|int[]
+ *
+ * @since 2.7.23
+ */
+function pods_image_size( $size ) {
+
+	if ( ! is_array( $size ) ) {
+		if ( is_numeric( $size ) && ! has_image_size( $size ) ) {
+			// Square sizes.
+			$size = $size . 'x' . $size;
+		}
+		// Fix HTML entity for custom sizes.
+		$size = str_replace( '&#215;', 'x', $size );
+	}
+	return $size;
+}
+
+/**
  * Get the <img> HTML for a specific image field.
  *
  * @param array|int|string $image      The image field array, ID, or guid.
@@ -86,6 +108,7 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
 	$html    = '';
 	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
+	$size    = pods_image_size( $size );
 
 	if ( 0 < $id ) {
 		if ( $force ) {
@@ -133,6 +156,7 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
 	$url     = '';
 	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
+	$size    = pods_image_size( $size );
 
 	if ( 0 < $id ) {
 		if ( $force ) {
@@ -251,6 +275,8 @@ function pods_maybe_image_resize( $attachment_id, $size ) {
 		$full = wp_get_attachment_image_src( $attachment_id, 'full' );
 
 		if ( ! empty( $full[0] ) ) {
+			$size = pods_image_size( $size );
+
 			$src = wp_get_attachment_image_src( $attachment_id, $size );
 
 			if ( empty( $src[0] ) || $full[0] == $src[0] ) {

--- a/includes/media.php
+++ b/includes/media.php
@@ -88,6 +88,7 @@ function pods_image_size( $size ) {
  */
 function pods_is_image_size( $size ) {
 	$valid = false;
+	$size  = pods_image_size( $size );
 	if ( is_array( $size ) ) {
 		// Custom array size format.
 		$valid = ( 2 <= count( $size ) && is_numeric( $size[0] ) && is_numeric( $size[1] ) );

--- a/includes/media.php
+++ b/includes/media.php
@@ -64,7 +64,7 @@ function pods_image_id_from_field( $image ) {
  *
  * @since 2.7.23
  */
-function pods_image_size( $size ) {
+function pods_parse_image_size( $size ) {
 
 	if ( ! is_array( $size ) ) {
 		if ( is_numeric( $size ) && ! has_image_size( $size ) ) {
@@ -88,7 +88,7 @@ function pods_image_size( $size ) {
  */
 function pods_is_image_size( $size ) {
 	$valid = false;
-	$size  = pods_image_size( $size );
+	$size  = pods_parse_image_size( $size );
 	if ( is_array( $size ) ) {
 		// Custom array size format.
 		$valid = ( 2 <= count( $size ) && is_numeric( $size[0] ) && is_numeric( $size[1] ) );
@@ -142,7 +142,7 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
 	$html    = '';
 	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
-	$size    = pods_image_size( $size );
+	$size    = pods_parse_image_size( $size );
 
 	if ( 0 < $id ) {
 		if ( $force ) {
@@ -190,7 +190,7 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
 	$url     = '';
 	$id      = pods_image_id_from_field( $image );
 	$default = pods_image_id_from_field( $default );
-	$size    = pods_image_size( $size );
+	$size    = pods_parse_image_size( $size );
 
 	if ( 0 < $id ) {
 		if ( $force ) {
@@ -309,7 +309,7 @@ function pods_maybe_image_resize( $attachment_id, $size ) {
 		$full = wp_get_attachment_image_src( $attachment_id, 'full' );
 
 		if ( ! empty( $full[0] ) ) {
-			$size = pods_image_size( $size );
+			$size = pods_parse_image_size( $size );
 
 			$src = wp_get_attachment_image_src( $attachment_id, $size );
 


### PR DESCRIPTION
Fixes #2738 

- Force the size of an avatar field if the parameter is provided (`{@avatar.32}`)
- Allow traversing through attachment object if the field name is registered as `avatar`. Supports the usage of `{@avatar._src}`
- Enhance support custom sizes in magic tags. Example: `{@image._src.300x750}` (creates new cropped image) and `{@image._src.60x60x0}` (creates new non-cropped image).

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly. #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list each unique issue as separate changelog items. -->

- Fixed: Avatar should always return a square image.
- Enhancement: Allow traversing in avatar attachment.
- Added: Support custom image sizes for all image field types in magic tags.

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
