### PR TITLE
Allow WP objects to be passed in `pods()`

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -303,6 +303,10 @@ class Pods implements Iterator {
 				// Post Type Archive.
 				$pod       = $pod->name;
 				$id_lookup = false;
+			} else {
+				// Unsupported pod object.
+				$pod       = null;
+				$id_lookup = false;
 			}
 
 			if ( null === $id && $id_lookup ) {

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -283,31 +283,31 @@ class Pods implements Iterator {
 	public function __construct( $pod = null, $id = null ) {
 
 		if ( null === $pod ) {
-			$queried_object = get_queried_object();
+			$pod = get_queried_object();
+		}
 
-			if ( $queried_object ) {
+		if ( $pod && ! is_string( $pod ) ) {
+			if ( $pod instanceof WP_Post ) {
+				// Post Type Singular.
+				$pod       = $pod->post_type;
 				$id_lookup = true;
+			} elseif ( $pod instanceof WP_Term ) {
+				// Term Archive.
+				$pod       = $pod->taxonomy;
+				$id_lookup = true;
+			} elseif ( $pod instanceof WP_User ) {
+				// Author Archive.
+				$pod       = 'user';
+				$id_lookup = true;
+			} elseif ( $pod instanceof WP_Post_Type ) {
+				// Post Type Archive.
+				$pod       = $pod->name;
+				$id_lookup = false;
+			}
 
-				if ( $queried_object instanceof WP_Post ) {
-					// Post Type Singular.
-					$pod = $queried_object->post_type;
-				} elseif ( $queried_object instanceof WP_Term ) {
-					// Term Archive.
-					$pod = $queried_object->taxonomy;
-				} elseif ( $queried_object instanceof WP_User ) {
-					// Author Archive.
-					$pod = 'user';
-				} elseif ( $queried_object instanceof WP_Post_Type ) {
-					// Post Type Archive.
-					$pod = $queried_object->name;
-
-					$id_lookup = false;
-				}
-
-				if ( null === $id && $id_lookup ) {
-					$id = get_queried_object_id();
-				}
-			}//end if
+			if ( null === $id && $id_lookup ) {
+				$id = get_queried_object_id();
+			}
 		}//end if
 
 		$this->api                 = pods_api( $pod );

--- a/readme.txt
+++ b/readme.txt
@@ -203,6 +203,7 @@ We are also available through our [Live Slack Chat](https://pods.io/chat/) to he
 * Enhancement: Allow traversing in avatar attachment. #5870 (@JoryHogeveen)
 * Enhancement: If the media Pod exists, use it's context to run media loops to support other fields and traversal. #5855 (@JoryHogeveen)
 * Enhancement: Implement PHP 5.4 `session_status()` function. #5840 (@JoryHogeveen)
+* Enhancement: Allow WP objects to be passed in `pods()`. #5845 (@JoryHogeveen)
 * Compatibility: Enqueue DFV scripts when editing the page with Beaver Builder to fully support the media window. #5799 (@JoryHogeveen)
 * Updated: Primary Branch header for GitHub Updater. #5847 (@afragen)
 


### PR DESCRIPTION
Fixes #5845 
While The issue in 5845 is in fact incorrect usage of `pods()` this PR might be a nice enhancement in loading Pods objects.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly. #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list each unique issue as separate changelog items. -->

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
