### PR TITLE
Custom no access message for templates

### DIFF
--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -404,7 +404,7 @@ class Pods_Templates extends PodsComponent {
 			),
 			array(
 				'name'                  => 'restrict_message',
-				'label'                 => __( 'No access message' ),
+				'label'                 => __( 'No access message', 'pods' ),
 				'type'                  => 'wysiwyg',
 				'default'               => __( 'You do not have access to view this content.', 'pods' ),
 				'wysiwyg_editor_height' => 200,

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -396,11 +396,21 @@ class Pods_Templates extends PodsComponent {
 				),
 			),
 			array(
+				'name'       => 'show_restrict_message',
+				'label'      => __( 'Show no access message?', 'pods' ),
+				'default'    => 1,
+				'type'       => 'boolean',
+				'dependency' => true,
+			),
+			array(
 				'name'                  => 'restrict_message',
 				'label'                 => __( 'No access message' ),
 				'type'                  => 'wysiwyg',
 				'default'               => __( 'You do not have access to view this content.', 'pods' ),
 				'wysiwyg_editor_height' => 200,
+				'depends-on'            => array(
+					'show_restrict_message' => true,
+				),
 			)
 		);
 
@@ -522,7 +532,7 @@ class Pods_Templates extends PodsComponent {
 
 				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
-				if ( ! $permission ) {
+				if ( ! $permission && pods_v( 'show_restrict_message', $options, true ) ) {
 					$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
 					return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
 				}

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -534,6 +534,7 @@ class Pods_Templates extends PodsComponent {
 
 				if ( ! $permission && pods_v( 'show_restrict_message', $options, true ) ) {
 					$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
+					$message = PodsForm::field_method( 'wysiwyg', 'display', $message, 'restrict_message', $options );
 					return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
 				}
 			}

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -533,7 +533,7 @@ class Pods_Templates extends PodsComponent {
 				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
 				if ( ! $permission ) {
-					if ( pods_v( 'show_restrict_message', $options, true ) ) {
+					if ( 1 === (int) pods_v( 'show_restrict_message', $options, 1 ) ) {
 						$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
 						$message = PodsForm::field_method( 'wysiwyg', 'display', $message, 'restrict_message', $options );
 						return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -411,7 +411,7 @@ class Pods_Templates extends PodsComponent {
 				'depends-on'            => array(
 					'show_restrict_message' => true,
 				),
-			)
+			),
 		);
 
 		pods_group_add( $pod, __( 'Restrict Access', 'pods' ), $fields, 'normal', 'high' );

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -395,6 +395,13 @@ class Pods_Templates extends PodsComponent {
 					'restrict_capability' => true,
 				),
 			),
+			array(
+				'name'                  => 'restrict_message',
+				'label'                 => __( 'No access message' ),
+				'type'                  => 'wysiwyg',
+				'default'               => __( 'You do not have access to view this content.', 'pods' ),
+				'wysiwyg_editor_height' => 200,
+			)
 		);
 
 		pods_group_add( $pod, __( 'Restrict Access', 'pods' ), $fields, 'normal', 'high' );
@@ -509,12 +516,15 @@ class Pods_Templates extends PodsComponent {
 					$code = $template['code'];
 				}
 
-				$permission = pods_permission( $template['options'] );
+				$options = pods_v( 'options', $template );
+
+				$permission = pods_permission( $options );
 
 				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
 				if ( ! $permission ) {
-					return apply_filters( 'pods_templates_permission_denied', __( 'You do not have access to view this content.', 'pods' ), $code, $template, $obj );
+					$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
+					return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
 				}
 			}
 		}

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -534,7 +534,7 @@ class Pods_Templates extends PodsComponent {
 
 				if ( ! $permission ) {
 					if ( 1 === (int) pods_v( 'show_restrict_message', $options, 1 ) ) {
-						$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
+						$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ), true );
 						$message = PodsForm::field_method( 'wysiwyg', 'display', $message, 'restrict_message', $options );
 						return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
 					}

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -532,10 +532,13 @@ class Pods_Templates extends PodsComponent {
 
 				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
-				if ( ! $permission && pods_v( 'show_restrict_message', $options, true ) ) {
-					$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
-					$message = PodsForm::field_method( 'wysiwyg', 'display', $message, 'restrict_message', $options );
-					return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
+				if ( ! $permission ) {
+					if ( pods_v( 'show_restrict_message', $options, true ) ) {
+						$message = pods_v( 'restrict_message', $options, __( 'You do not have access to view this content.', 'pods' ) );
+						$message = PodsForm::field_method( 'wysiwyg', 'display', $message, 'restrict_message', $options );
+						return apply_filters( 'pods_templates_permission_denied', $message, $code, $template, $obj );
+					}
+					return '';
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #5875 

## Description

<!-- Please describe your changes; if your change fixes an existing issue, -->
<!-- use the terminology "Fixes #issue" to ensure the related issue will auto-close when this code is release -->

This PR adds 2 new options to Pods Templates:
- Boolean: Show no-access message (default: true)
- Wysiwyg: No access message (overwrites default)

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for the Changelog -->
<!-- Examples: Fix: Updates changelog to be more friendly. #Issue (@your-GH-Handle) -->
<!-- If your fix addresses multiple issues, please list each unique issue as separate changelog items. -->

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
