### PR TITLE
Add pods_shortcode_detect_from_current_post filter for more flexibility

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -882,9 +882,18 @@ function pods_shortcode_run( $tags, $content = null ) {
 
 		// Only allow revert to current object if there are no query tags.
 		if ( ! $has_query_tags ) {
+			/**
+			 * Allow filtering whether to detect the pod name / item ID from the current post object.
+			 *
+			 * @since 2.7.26
+			 *
+			 * @param bool  $detect_from_current  Whether to detect the pod name / item ID from the current post object.
+			 * @param array $shortcode_attributes The list of attributes used for the shortcode.
+			 */
+			$detect_from_current = apply_filters( 'pods_shortcode_detect_from_current_post', in_the_loop(), $tags );
 
 			// Archives, Post type archives, singular posts.
-			if ( in_the_loop() ) {
+			if ( $detect_from_current ) {
 				$pod = pods( get_post_type(), get_the_ID(), false );
 
 				if ( ! empty( $pod ) ) {


### PR DESCRIPTION
## Description

This allows Pods to not rely as much on `in_the_loop()` so the shortcode can be used in more flexible ways. This is needed for https://github.com/pods-framework/pods-beaver-builder-themer-add-on/pull/112

## Changelog text for these changes

* Added: New filter `pods_shortcode_detect_from_current_post` allows you to override whether a shortcode should detect the post object outside of the loop (default is only when `in_the_loop()`).

## PR Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
