### PR TITLE
Remove check for /post-new.php when populating custom fields

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1113,7 +1113,7 @@ class PodsMeta {
 
 		$id = null;
 
-		if ( is_object( $post ) && false === strpos( $_SERVER['REQUEST_URI'], '/post-new.php' ) ) {
+		if ( is_object( $post ) ) {
 			$id = $post->ID;
 		}
 


### PR DESCRIPTION
## Description

Fixes #5879

If a **new post** is pre-filled with custom fields, the custom fields values are not populated in the custom fields metabox.
This PR removes the check for `/post-new.php` in order to populate the fields eve for new posts.

## How Has This Been Tested?

Manual test, following the steps described in the issue #5879.

## Types of changes

Bug fix

## Changelog text for these changes

Fix custom fields values not prefilled when creating a post translation with Polylang.

## PR Checklist

- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
