### PR TITLE
Add WP 5.7 `filter_by_item` and `filter_by_date` labels

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -1672,18 +1672,18 @@ class PodsAdmin {
 					'object_type' => array( 'post_type' ),
 				),
 				'filter_by_date'                   => array(
-						'label'       => __( 'Filter by date', 'pods' ),
-						'help'        => __( 'help', 'pods' ),
-						'type'        => 'text',
-						'default'     => '',
-						'object_type' => array( 'post_type' ),
+					'label'       => __( 'Filter by date', 'pods' ),
+					'help'        => __( 'help', 'pods' ),
+					'type'        => 'text',
+					'default'     => '',
+					'object_type' => array( 'post_type' ),
 				),
 				'filter_by_item'                   => array(
-						'label'       => __( 'Filter by <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ),
-						'help'        => __( 'help', 'pods' ),
-						'type'        => 'text',
-						'default'     => '',
-						'object_type' => array( 'taxonomy' ),
+					'label'       => __( 'Filter by <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ),
+					'help'        => __( 'help', 'pods' ),
+					'type'        => 'text',
+					'default'     => '',
+					'object_type' => array( 'taxonomy' ),
 				),
 			);
 

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -1671,6 +1671,13 @@ class PodsAdmin {
 					'default'     => '',
 					'object_type' => array( 'post_type' ),
 				),
+				'filter_by_date'                   => array(
+						'label'       => __( 'Filter by date', 'pods' ),
+						'help'        => __( 'help', 'pods' ),
+						'type'        => 'text',
+						'default'     => '',
+						'object_type' => array( 'post_type' ),
+				),
 			);
 
 			$options['labels'] = array();

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -1678,6 +1678,13 @@ class PodsAdmin {
 						'default'     => '',
 						'object_type' => array( 'post_type' ),
 				),
+				'filter_by_item'                   => array(
+						'label'       => __( 'Filter by <span class="pods-slugged" data-sluggable="label_singular">Item</span>', 'pods' ),
+						'help'        => __( 'help', 'pods' ),
+						'type'        => 'text',
+						'default'     => '',
+						'object_type' => array( 'taxonomy' ),
+				),
 			);
 
 			$options['labels'] = array();

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -895,6 +895,7 @@ class PodsInit {
 				$cpt_labels['item_reverted_to_draft']   = pods_v( 'label_item_reverted_to_draft', $post_type, '', true );
 				$cpt_labels['item_scheduled']           = pods_v( 'label_item_scheduled', $post_type, '', true );
 				$cpt_labels['item_updated']             = pods_v( 'label_item_updated', $post_type, '', true );
+				$cpt_labels['filter_by_date']           = pods_v( 'label_filter_by_date', $post_type, '', true );
 
 				// Supported
 				$cpt_supported = array(
@@ -1617,6 +1618,7 @@ class PodsInit {
 			$labels['item_reverted_to_draft']   = pods_v( 'item_reverted_to_draft', $labels, sprintf( __( '%s reverted to draft', 'pods'), $singular_label ), true );
 			$labels['item_scheduled']           = pods_v( 'item_scheduled', $labels, sprintf( __( '%s scheduled', 'pods' ), $singular_label ), true );
 			$labels['item_updated']             = pods_v( 'item_updated', $labels, sprintf( __( '%s updated', 'pods' ), $singular_label ), true );
+			$labels['filter_by_date']           = pods_v( 'filter_by_date', $labels, sprintf( __( 'Filter by date', 'pods' ), $label ), true );
 		} elseif ( 'taxonomy' === $type ) {
 			$labels['menu_name']                  = pods_v( 'menu_name', $labels, $label, true );
 			$labels['search_items']               = pods_v( 'search_items', $labels, sprintf( __( 'Search %s', 'pods' ), $label ), true );

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1119,6 +1119,7 @@ class PodsInit {
 				$ct_labels['no_terms']                   = pods_v( 'label_no_terms', $taxonomy, '', true );
 				$ct_labels['items_list']                 = pods_v( 'label_items_list', $taxonomy, '', true );
 				$ct_labels['items_list_navigation']      = pods_v( 'label_items_list_navigation', $taxonomy, '', true );
+				$ct_labels['filter_by_item']             = pods_v( 'label_filter_by_item', $taxonomy, '', true );
 
 				// Rewrite
 				$ct_rewrite       = (boolean) pods_v( 'rewrite', $taxonomy, true );
@@ -1638,6 +1639,7 @@ class PodsInit {
 			$labels['no_terms']                   = pods_v( 'no_terms', $labels, sprintf( __( 'No %s', 'pods' ), $label ), true );
 			$labels['items_list_navigation']      = pods_v( 'items_list_navigation', $labels, sprintf( __( '%s navigation', 'pods' ), $label ), true );
 			$labels['items_list']                 = pods_v( 'items_list', $labels, sprintf( __( '%s list', 'pods' ), $label ), true );
+			$labels['filter_by_item']             = pods_v( 'filter_by_item', $labels, sprintf( __( 'Filter by %s', 'pods' ), $label ), true );
 		}//end if
 
 		$args['labels'] = $labels;

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -482,6 +482,7 @@ class Pods_Component_I18n extends PodsComponent {
 			'add_or_remove_items'        => 'label_add_or_remove_items',
 			'choose_from_most_used'      => 'label_choose_from_the_most_used', // Different.
 			'no_terms'                   => 'label_no_terms',
+			'filter_by_item'             => 'label_filter_by_item', // WP 5.7
 		);
 
 		if ( ! isset( $options['labels'] ) || ! is_array( $options['labels'] ) ) {

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -471,6 +471,7 @@ class Pods_Component_I18n extends PodsComponent {
 			'item_reverted_to_draft'     => 'label_item_reverted_to_draft',
 			'item_scheduled'             => 'label_item_scheduled',
 			'item_updated'               => 'label_item_updated',
+			'filter_by_date'             => 'label_filter_by_date', // WP 5.7
 
 			// Taxonomies
 			'update_item'                => 'label_update_item',


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->

## Related GitHub issue(s)

Fixes #5959

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
