### PR TITLE
Force export as ID's for rel fields to fix changed field compare 

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5007,10 +5007,16 @@ class PodsAPI {
 		$data = array();
 
 		foreach ( $export_fields as $field ) {
-			// Return IDs (or guid for files) if only one level deep
+			$field_type = pods_v( 'type', $field );
+
 			if ( 1 == $depth ) {
-				$data[ $field['name'] ] = $pod->field( array( 'name' => $field['lookup_name'], 'output' => 'arrays' ) );
-			} elseif ( ( - 1 == $depth || $current_depth < $depth ) && 'pick' === $field['type'] && ! in_array( pods_var( 'pick_object', $field ), $simple_tableless_objects ) ) {
+				// Return IDs (or guid for files) if only one level deep.
+				$output = 'arrays';
+				if ( 'pick' === $field_type ) {
+					$output = 'ids';
+				}
+				$data[ $field['name'] ] = $pod->field( array( 'name' => $field['lookup_name'], 'output' => $output ) );
+			} elseif ( ( - 1 == $depth || $current_depth < $depth ) && 'pick' === $field_type && ! in_array( pods_v( 'pick_object', $field ), $simple_tableless_objects ) ) {
 				// Recurse depth levels for pick fields if $depth allows
 				$related_data = array();
 

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5029,7 +5029,7 @@ class PodsAPI {
 
 					$related_pod = pods( pods_var_raw( 'pick_val', $field ), null, false );
 
-					// If this isn't a Pod, return data exactly as Pods does normally
+					// If this isn't a Pod, return data exactly as Pods does normally.
 					if ( empty( $related_pod ) || ( 'pod' !== $pick_object && $pick_object !== $related_pod->pod_data['type'] ) || $related_pod->pod == $pod->pod ) {
 						$related_data = $pod->field( array( 'name' => $field['name'], 'output' => 'arrays' ) );
 					} else {
@@ -5071,7 +5071,7 @@ class PodsAPI {
 
 				$data[ $field['name'] ] = $related_data;
 			} else {
-				// Return data exactly as Pods does normally
+				// Return data exactly as Pods does normally.
 				$data[ $field['name'] ] = $pod->field( array( 'name' => $field['name'], 'output' => 'arrays' ) );
 			}
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Inline documentation mention this should already happen but it wasn't implemented correctly.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #5957 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
