### PR TITLE
Add pagination type to shortcode params

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -1117,6 +1117,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 			'label' => pods_v( 'pagination_label', $tags, null ),
 			'type'  => pods_v( 'pagination_type', $tags, null ),
 		);
+
 		// Remove empty params.
 		$pagination = array_filter( $pagination );
 	}

--- a/includes/general.php
+++ b/includes/general.php
@@ -1128,7 +1128,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		echo $pod->filters( $tags['filters'], $tags['filters_label'] );
 	}
 
-	if ( $tags['pagination'] && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
+	if ( false !== $pagination && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
 		echo $pod->pagination( $pagination );
 	}
 
@@ -1141,7 +1141,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	// phpcs:ignore
 	echo $content;
 
-	if ( $tags['pagination'] && in_array( $tags['pagination_location'], array( 'after', 'both', ), true ) ) {
+	if ( false !== $pagination && in_array( $tags['pagination_location'], array( 'after', 'both', ), true ) ) {
 		echo $pod->pagination( $pagination );
 	}
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -1108,19 +1108,25 @@ function pods_shortcode_run( $tags, $content = null ) {
 		return $return;
 	}//end if
 
+	$pagination = false;
+	if ( ! $is_singular && 0 < $found && $tags['pagination'] ) {
+		$pagination = $tags['pagination_label'];
+		if ( is_string( $tags['pagination'] ) ) {
+			$pagination = array(
+					'label' => $pagination,
+					'type'  => $tags['pagination'],
+			);
+		}
+	}
+
 	ob_start();
 
 	if ( ! $is_singular && false !== $tags['filters'] && 'before' === $tags['filters_location'] ) {
 		echo $pod->filters( $tags['filters'], $tags['filters_label'] );
 	}
 
-	if ( ! $is_singular && 0 < $found && true === $tags['pagination'] && in_array(
-		$tags['pagination_location'], array(
-			'before',
-			'both',
-		), true
-	) ) {
-		echo $pod->pagination( $tags['pagination_label'] );
+	if ( $pagination && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
+		echo $pod->pagination( $pagination );
 	}
 
 	$content = $pod->template( $tags['template'], $content );
@@ -1132,13 +1138,8 @@ function pods_shortcode_run( $tags, $content = null ) {
 	// phpcs:ignore
 	echo $content;
 
-	if ( ! $is_singular && 0 < $found && true === $tags['pagination'] && in_array(
-		$tags['pagination_location'], array(
-			'after',
-			'both',
-		), true
-	) ) {
-		echo $pod->pagination( $tags['pagination_label'] );
+	if ( $pagination && in_array( $tags['pagination_location'], array( 'after', 'both', ), true ) ) {
+		echo $pod->pagination( $pagination );
 	}
 
 	if ( ! $is_singular && false !== $tags['filters'] && 'after' === $tags['filters_location'] ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -824,6 +824,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		'filters_label'       => null,
 		'filters_location'    => 'before',
 		'pagination_label'    => null,
+		'pagination_type'     => null,
 		'pagination_location' => 'after',
 	);
 
@@ -1110,13 +1111,12 @@ function pods_shortcode_run( $tags, $content = null ) {
 
 	$pagination = false;
 	if ( ! $is_singular && 0 < $found && $tags['pagination'] ) {
-		$pagination = $tags['pagination_label'];
-		if ( is_string( $tags['pagination'] ) ) {
-			$pagination = array(
-					'label' => $pagination,
-					'type'  => $tags['pagination'],
-			);
-		}
+		$pagination = array(
+			'label' => pods_v( 'pagination_label', $tags, null ),
+			'type'  => pods_v( 'pagination_type', $tags, null ),
+		);
+		// Remove empty params.
+		$pagination = array_filter( $pagination );
 	}
 
 	ob_start();
@@ -1125,7 +1125,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 		echo $pod->filters( $tags['filters'], $tags['filters_label'] );
 	}
 
-	if ( $pagination && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
+	if ( $tags['pagination'] && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
 		echo $pod->pagination( $pagination );
 	}
 
@@ -1138,7 +1138,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	// phpcs:ignore
 	echo $content;
 
-	if ( $pagination && in_array( $tags['pagination_location'], array( 'after', 'both', ), true ) ) {
+	if ( $tags['pagination'] && in_array( $tags['pagination_location'], array( 'after', 'both', ), true ) ) {
 		echo $pod->pagination( $pagination );
 	}
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -1110,6 +1110,8 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}//end if
 
 	$pagination = false;
+
+	// Only handle pagination on non-singular shortcodes where items were found.
 	if ( ! $is_singular && 0 < $found && $tags['pagination'] ) {
 		$pagination = array(
 			'label' => pods_v( 'pagination_label', $tags, null ),


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
~~Optionally parse the `pagination` parameter as the pagination type.~~
Added `pagination_type` param.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #5977

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
