### PR TITLE
Fix traversal display filters

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1927,18 +1927,34 @@ class Pods implements Iterator {
 				$filter = pods_v( 'display_filter', $field_data['options'] );
 
 				if ( 0 < strlen( $filter ) ) {
-					$args = array(
-						$filter,
-						$value,
-					);
 
-					$filter_args = pods_v( 'display_filter_args', $field_data['options'] );
-
-					if ( ! empty( $filter_args ) ) {
-						$args = array_merge( $args, compact( $filter_args ) );
+					if ( $params->single ) {
+						$value = array( $value );
 					}
 
-					$value = call_user_func_array( 'apply_filters', $args );
+					foreach ( $value as $key => $val ) {
+
+						$args = array(
+							$filter,
+							$val,
+						);
+
+						$filter_args = pods_v( 'display_filter_args', $field_data['options'] );
+
+						if ( ! empty( $filter_args ) ) {
+							$args = array_merge( $args, compact( $filter_args ) );
+						}
+
+						$val = call_user_func_array( 'apply_filters', $args );
+
+						$value[ $key ] = $val;
+
+					}
+
+					if ( $params->single ) {
+						$value = reset( $value );
+					}
+
 				} elseif ( 1 === (int) pods_v( 'display_process', $field_data['options'], 1 ) ) {
 					$value = PodsForm::display( $field_data['type'], $value, $params->name, array_merge( $field_data, $field_data['options'] ), $this->pod_data, $this->id() );
 				}


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Parse display filters for each value instead of the full array in case single is false.

If a Pod is extended and run through traversal the display filters are handled as single values while the actual value is an array since traversal always sets the `single` param to false.

@sc0ttkclark Maybe add an extra param for `display_filters` that sets the filter to run for multiple or a single instance?

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #5985 

Related: https://wordpress.org/support/topic/error-with-post_title-in-xampp-host/

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->
See issue.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
