### PR TITLE
Support taxonomy filters in Pods::find() and other object fields

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1236,14 +1236,16 @@ class PodsData {
 				$where  = array();
 				$having = array();
 
-				if ( ! isset( $params->fields[ $filter ] ) && ! isset( $params->object_fields[ $filter ] ) ) {
-					continue;
-				}
-
 				$attributes = pods_v( $filter, $params->fields, null );
 				if ( ! $attributes ) {
 					$attributes = pods_v( $filter, $params->object_fields, null );
 				}
+
+				if ( null === $attributes ) {
+					// Field not found.
+					continue;
+				}
+
 				$field = pods_v( 'name', $attributes, $filter, true );
 
 				$filterfield = '`' . $field . '`';

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1236,12 +1236,15 @@ class PodsData {
 				$where  = array();
 				$having = array();
 
-				if ( ! isset( $params->fields[ $filter ] ) ) {
+				if ( ! isset( $params->fields[ $filter ] ) && ! isset( $params->object_fields[ $filter ] ) ) {
 					continue;
 				}
 
-				$attributes = $params->fields[ $filter ];
-				$field      = pods_v( 'name', $attributes, $filter, true );
+				$attributes = pods_v( $filter, $params->fields, null );
+				if ( ! $attributes ) {
+					$attributes = pods_v( $filter, $params->object_fields, null );
+				}
+				$field = pods_v( 'name', $attributes, $filter, true );
 
 				$filterfield = '`' . $field . '`';
 

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1255,6 +1255,8 @@ class PodsData {
 					}
 
 					$filterfield = $filterfield . '.`' . $attributes['table_info']['field_index'] . '`';
+				} elseif ( 'taxonomy' === $attributes['type'] ) {
+					$filterfield = $filterfield . '.`term_id`';
 				} elseif ( in_array( $attributes['type'], $file_field_types, true ) ) {
 					$filterfield = $filterfield . '.`post_title`';
 				} elseif ( isset( $params->fields[ $field ] ) ) {

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -1236,7 +1236,10 @@ class PodsData {
 				$where  = array();
 				$having = array();
 
+				// Check if we have a matching field.
 				$attributes = pods_v( $filter, $params->fields, null );
+
+				// If we do not have a matching field, check for a matching object field.
 				if ( ! $attributes ) {
 					$attributes = pods_v( $filter, $params->object_fields, null );
 				}

--- a/includes/general.php
+++ b/includes/general.php
@@ -973,6 +973,7 @@ function pods_shortcode_run( $tags, $content = null ) {
 	}
 
 	$found = 0;
+	$filters = false;
 
 	$is_singular = ( ! empty( $id ) || $tags['use_current'] );
 
@@ -1017,6 +1018,11 @@ function pods_shortcode_run( $tags, $content = null ) {
 				$params['join'] = $tags['join'];
 			}
 		}//end if
+
+		// Load filters and return HTML for later use.
+		if ( false !== $tags['filters'] ) {
+			$filters = $pod->filters( $tags['filters'], $tags['filters_label'] );
+		}
 
 		// Forms require params set
 		if ( ! empty( $params ) || empty( $tags['form'] ) ) {
@@ -1124,8 +1130,8 @@ function pods_shortcode_run( $tags, $content = null ) {
 
 	ob_start();
 
-	if ( ! $is_singular && false !== $tags['filters'] && 'before' === $tags['filters_location'] ) {
-		echo $pod->filters( $tags['filters'], $tags['filters_label'] );
+	if ( $filters && 'before' === $tags['filters_location'] ) {
+		echo $filters;
 	}
 
 	if ( false !== $pagination && in_array( $tags['pagination_location'], array( 'before', 'both', ), true ) ) {
@@ -1145,8 +1151,8 @@ function pods_shortcode_run( $tags, $content = null ) {
 		echo $pod->pagination( $pagination );
 	}
 
-	if ( ! $is_singular && false !== $tags['filters'] && 'after' === $tags['filters_location'] ) {
-		echo $pod->filters( $tags['filters'], $tags['filters_label'] );
+	if ( $filters && 'after' === $tags['filters_location'] ) {
+		echo $filters;
 	}
 
 	$return = ob_get_clean();

--- a/ui/front/filters.php
+++ b/ui/front/filters.php
@@ -3,14 +3,17 @@
 
 	<?php
 	foreach ( $fields as $name => $field ) {
-		if ( 'pick' === $field['type'] && 'pick-custom' !== $field['pick_object'] && ! empty( $field['pick_object'] ) ) {
+		if ( in_array( $field['type'], array( 'pick', 'taxonomy' ), true ) && 'pick-custom' !== $field['pick_object'] && ! empty( $field['pick_object'] ) ) {
 			$field['options']['pick_format_type']   = 'single';
 			$field['options']['pick_format_single'] = 'dropdown';
 			$field['options']['pick_select_text']   = '-- ' . $field['label'] . ' --';
 
 			$filter = pods_var_raw( 'filter_' . $name, 'get', '' );
 
-			echo PodsForm::field( 'filter_' . $name, $filter, 'pick', $field, $pod->pod, $pod->id() );
+			// @todo Support other field types.
+			$field['type'] = 'pick';
+
+			echo PodsForm::field( 'filter_' . $name, $filter, $field['type'], $field, $pod->pod, $pod->id() );
 		}
 	}
 	?>


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Support taxonomies as filters in Pods::find()

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #5994 

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

- Create some posts with various categories
- Add the following shortcode anywhere: `[pods name="post" filters="category" field="title"]`
- It should add a selectbox with all available categories
- Select a category and only the posts related to that category should show.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
