### PR TITLE
Allow ID as parameter for audio and video

### DIFF
--- a/includes/media.php
+++ b/includes/media.php
@@ -410,20 +410,25 @@ function pods_image_resize( $attachment_id, $size ) {
  *
  * @since 2.5.0
  *
- * @param string|array $url  Can be a URL of the source file, or a Pods audio field.
- * @param bool|array   $args Optional. Additional arguments to pass to wp_audio_shortcode().
+ * @param string|array|int $url  Can be a URL of the source file, or a Pods audio field.
+ * @param bool|array       $args Optional. Additional arguments to pass to wp_audio_shortcode().
  *
  * @return string
  */
 function pods_audio( $url, $args = false ) {
 
-	if ( is_array( $url ) ) {
-		if ( ! is_null( pods_v( 'ID', $url ) ) ) {
-			$id  = pods_v( 'ID', $url );
-			$url = wp_get_attachment_url( $id );
-		} else {
-			return;
+	if ( ! is_string( $url ) ) {
+		$id = $url;
+		if ( is_array( $id ) ) {
+			$id = pods_v( 'ID', $url );
 		}
+		if ( is_numeric( $id ) ) {
+			$url = wp_get_attachment_url( $id );
+		}
+	}
+
+	if ( ! $url ) {
+		return '';
 	}
 
 	$audio_args = array( 'src' => $url );
@@ -443,20 +448,25 @@ function pods_audio( $url, $args = false ) {
  *
  * @since 2.5.0
  *
- * @param string|array $url  Can be a URL of the source file, or a Pods video field.
- * @param bool|array   $args Optional. Additional arguments to pass to wp_video_shortcode().
+ * @param string|array|int $url  Can be a URL of the source file, or a Pods video field.
+ * @param bool|array       $args Optional. Additional arguments to pass to wp_video_shortcode().
  *
  * @return string
  */
 function pods_video( $url, $args = false ) {
 
-	if ( is_array( $url ) ) {
-		if ( ! is_null( pods_v( 'ID', $url ) ) ) {
-			$id  = pods_v( 'ID', $url );
-			$url = wp_get_attachment_url( $id );
-		} else {
-			return;
+	if ( ! is_string( $url ) ) {
+		$id = $url;
+		if ( is_array( $id ) ) {
+			$id = pods_v( 'ID', $url );
 		}
+		if ( is_numeric( $id ) ) {
+			$url = wp_get_attachment_url( $id );
+		}
+	}
+
+	if ( ! $url ) {
+		return '';
 	}
 
 	$video_args = array( 'src' => $url );

--- a/includes/media.php
+++ b/includes/media.php
@@ -410,26 +410,30 @@ function pods_image_resize( $attachment_id, $size ) {
  *
  * @since 2.5.0
  *
- * @param string|array|int $url  Can be a URL of the source file, or a Pods audio field.
+ * @param string|array|int $url  The URL string, an array of post information, or an attachment ID.
  * @param bool|array       $args Optional. Additional arguments to pass to wp_audio_shortcode().
  *
  * @return string
  */
 function pods_audio( $url, $args = false ) {
 
-	if ( ! is_string( $url ) ) {
-		$id = $url;
-		if ( ! is_numeric( $id ) ) {
-			$id = pods_v( 'ID', $url );
-		}
-		$url = wp_get_attachment_url( $id );
+	// Support arrays.
+	if ( is_array( $url ) ) {
+		$url = pods_v( 'ID', $url );
 	}
 
-	if ( ! $url ) {
+	// Support IDs.
+	if ( false !== strpos( $url, '://' ) && is_numeric( $url ) ) {
+		$url = wp_get_attachment_url( $url );
+	}
+
+	if ( empty( $url ) || ! is_string( $url ) ) {
 		return '';
 	}
 
-	$audio_args = array( 'src' => $url );
+	$audio_args = array(
+		'src' => $url,
+	);
 
 	if ( is_array( $args ) ) {
 		$audio_args = array_merge( $audio_args, $args );
@@ -446,26 +450,30 @@ function pods_audio( $url, $args = false ) {
  *
  * @since 2.5.0
  *
- * @param string|array|int $url  Can be a URL of the source file, or a Pods video field.
+ * @param string|array|int $url  The URL string, an array of post information, or an attachment ID.
  * @param bool|array       $args Optional. Additional arguments to pass to wp_video_shortcode().
  *
  * @return string
  */
 function pods_video( $url, $args = false ) {
 
-	if ( ! is_string( $url ) ) {
-		$id = $url;
-		if ( ! is_numeric( $id ) ) {
-			$id = pods_v( 'ID', $url );
-		}
-		$url = wp_get_attachment_url( $id );
+	// Support arrays.
+	if ( is_array( $url ) ) {
+		$url = pods_v( 'ID', $url );
 	}
 
-	if ( ! $url ) {
+	// Support IDs.
+	if ( false !== strpos( $url, '://' ) && is_numeric( $url ) ) {
+		$url = wp_get_attachment_url( $url );
+	}
+
+	if ( empty( $url ) || ! is_string( $url ) ) {
 		return '';
 	}
 
-	$video_args = array( 'src' => $url );
+	$video_args = array(
+		'src' => $url,
+	);
 
 	if ( is_array( $args ) ) {
 		$video_args = array_merge( $video_args, $args );

--- a/includes/media.php
+++ b/includes/media.php
@@ -423,8 +423,8 @@ function pods_audio( $url, $args = false ) {
 	}
 
 	// Support IDs.
-	if ( false !== strpos( $url, '://' ) && is_numeric( $url ) ) {
-		$url = wp_get_attachment_url( $url );
+	if ( is_numeric( $url ) ) {
+		$url = wp_get_attachment_url( (int) $url );
 	}
 
 	if ( empty( $url ) || ! is_string( $url ) ) {
@@ -463,8 +463,8 @@ function pods_video( $url, $args = false ) {
 	}
 
 	// Support IDs.
-	if ( false !== strpos( $url, '://' ) && is_numeric( $url ) ) {
-		$url = wp_get_attachment_url( $url );
+	if ( is_numeric( $url ) ) {
+		$url = wp_get_attachment_url( (int) $url );
 	}
 
 	if ( empty( $url ) || ! is_string( $url ) ) {

--- a/includes/media.php
+++ b/includes/media.php
@@ -419,7 +419,7 @@ function pods_audio( $url, $args = false ) {
 
 	if ( ! is_string( $url ) ) {
 		$id = $url;
-		if ( is_array( $id ) ) {
+		if ( ! is_numeric( $id ) ) {
 			$id = pods_v( 'ID', $url );
 		}
 		$url = wp_get_attachment_url( $id );
@@ -455,7 +455,7 @@ function pods_video( $url, $args = false ) {
 
 	if ( ! is_string( $url ) ) {
 		$id = $url;
-		if ( is_array( $id ) ) {
+		if ( ! is_numeric( $id ) ) {
 			$id = pods_v( 'ID', $url );
 		}
 		$url = wp_get_attachment_url( $id );

--- a/includes/media.php
+++ b/includes/media.php
@@ -422,9 +422,7 @@ function pods_audio( $url, $args = false ) {
 		if ( is_array( $id ) ) {
 			$id = pods_v( 'ID', $url );
 		}
-		if ( is_numeric( $id ) ) {
-			$url = wp_get_attachment_url( $id );
-		}
+		$url = wp_get_attachment_url( $id );
 	}
 
 	if ( ! $url ) {
@@ -460,9 +458,7 @@ function pods_video( $url, $args = false ) {
 		if ( is_array( $id ) ) {
 			$id = pods_v( 'ID', $url );
 		}
-		if ( is_numeric( $id ) ) {
-			$url = wp_get_attachment_url( $id );
-		}
+		$url = wp_get_attachment_url( $id );
 	}
 
 	if ( ! $url ) {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Allow ID to be passed as param for `pods_audio` and `pods_video`

Will also enable the following magic tag usage:

```
[each videos]
{@ID,pods_video}
[/each]
```

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #5983 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
