### PR TITLE
Pass array values only to prevent PHP8 named parameters

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -1945,7 +1945,7 @@ class Pods implements Iterator {
 							$args = array_merge( $args, compact( $filter_args ) );
 						}
 
-						$val = call_user_func_array( 'apply_filters', $args );
+						$val = call_user_func_array( 'apply_filters', array_values( $args ) );
 
 						$value[ $key ] = $val;
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
https://wordpress.org/support/topic/php-8-debugging/

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6012

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
