### PR TITLE
Fix issue with datepicker being cut off

### DIFF
--- a/ui/js/dfv/pods-dfv.min.asset.json
+++ b/ui/js/dfv/pods-dfv.min.asset.json
@@ -1,1 +1,1 @@
-{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"49074d43540b067e3001a31895a3f7c1"}
+{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"88cd15c721141ff73ed80baae83ac486"}

--- a/ui/js/dfv/src/fields/datetime/datetime.scss
+++ b/ui/js/dfv/src/fields/datetime/datetime.scss
@@ -1,0 +1,3 @@
+.pods-react-datetime-fix .rdtPicker {
+	position: sticky !important;
+}

--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -16,6 +16,7 @@ import {
 import { FIELD_PROP_TYPE_SHAPE } from 'dfv/src/config/prop-types';
 
 import 'react-datetime/css/react-datetime.css';
+import './datetime.scss';
 
 const checkForHTML5BrowserSupport = ( fieldType ) => {
 	const input = document.createElement( 'input' );
@@ -182,6 +183,7 @@ const DateTime = ( props ) => {
 
 	return (
 		<Datetime
+			className="pods-react-datetime-fix"
 			initialValue={ value }
 			onClose={ handleChange }
 			dateFormat={ includeDateField && momentDateFormat }


### PR DESCRIPTION
## Description

Fixes issue with DatePicker fields being cut off. 

## Related GitHub issue(s)

#5965

## Testing instructions

1. Add a Datepicker field to the end of a group. 
2. Test that it is no longer cut off, and the group expands to fit it. 

## Changelog text for these changes

- Fixes issue where date pickers were cut off. 

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
