### PR TITLE
Fix issue where fields disappear after a group is renamed

### DIFF
--- a/ui/js/dfv/pods-dfv.min.asset.json
+++ b/ui/js/dfv/pods-dfv.min.asset.json
@@ -1,1 +1,1 @@
-{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"49074d43540b067e3001a31895a3f7c1"}
+{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"07d4a39e6440445b428eeb82f7437a07"}

--- a/ui/js/dfv/src/store/reducer.js
+++ b/ui/js/dfv/src/store/reducer.js
@@ -252,7 +252,7 @@ export const currentPod = ( state = {}, action = {} ) => {
 
 				return {
 					...action.result.group,
-					fields: result.group?.fields || [],
+					fields: result.group?.fields || group.fields || [],
 				};
 			} );
 


### PR DESCRIPTION
## Description

Fixes issue where fields disappear after a group is renamed.

## Related GitHub issue(s)

#5980

## Testing instructions

1. Rename a group with fields.
2. The fields will still be shown after the name change.

## Changelog text for these changes

- Fixes issue where fields disappear after a group is renamed.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
