### PR TITLE
Fixes for Boolean Groups

### DIFF
--- a/ui/js/dfv/pods-dfv.min.asset.json
+++ b/ui/js/dfv/pods-dfv.min.asset.json
@@ -1,1 +1,1 @@
-{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"8820a43e7ccd99126ca9a800305b61ab"}
+{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"b889769b90f066e9c8e2c7466fdbd875"}

--- a/ui/js/dfv/pods-dfv.min.asset.json
+++ b/ui/js/dfv/pods-dfv.min.asset.json
@@ -1,1 +1,1 @@
-{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"49074d43540b067e3001a31895a3f7c1"}
+{"dependencies":["moment","wp-api-fetch","wp-autop","wp-components","wp-compose","wp-data","wp-element","wp-i18n","wp-keycodes","wp-url"],"version":"8820a43e7ccd99126ca9a800305b61ab"}

--- a/ui/js/dfv/src/components/help-tooltip.scss
+++ b/ui/js/dfv/src/components/help-tooltip.scss
@@ -64,4 +64,8 @@
 			color: #ccd0d4;
 		}
 	}
+
+	.dashicon {
+		text-decoration: none;
+	}
 }

--- a/ui/js/dfv/src/config/prop-types.js
+++ b/ui/js/dfv/src/config/prop-types.js
@@ -154,7 +154,7 @@ export const FIELD_PROP_TYPE = {
 		PropTypes.shape( {
 			default: BOOLEAN_ALL_TYPES,
 			dependency: PropTypes.bool,
-			help: PropTypes.string,
+			help: PropTypes.oneOfType( [ PropTypes.string, PropTypes.arrayOf( PropTypes.string ) ] ),
 			label: PropTypes.string,
 			name: PropTypes.string,
 			type: PropTypes.string,

--- a/ui/js/dfv/src/fields/boolean-group/boolean-group-subfield.js
+++ b/ui/js/dfv/src/fields/boolean-group/boolean-group-subfield.js
@@ -25,7 +25,7 @@ const BooleanGroupSubfield = ( {
 } ) => {
 	const {
 		htmlAttr: htmlAttributes = {},
-		help,
+		help: helpText,
 		label,
 		name,
 		'depends-on': dependsOn,
@@ -44,6 +44,16 @@ const BooleanGroupSubfield = ( {
 	);
 
 	const idAttribute = !! htmlAttributes.id ? htmlAttributes.id : name;
+
+	// Sort out different shapes that we could get the help text in.
+	// It's possible to get an array of strings for the help text, but it
+	// will usually be a string.
+	const shouldShowHelpText = helpText && ( 'help' !== helpText );
+
+	const helpTextString = Array.isArray( helpText ) ? helpText[ 0 ] : helpText;
+	const helpLink = ( Array.isArray( helpText ) && !! helpText[ 1 ] )
+		? helpText[ 1 ]
+		: undefined;
 
 	if ( ! meetsDependencies ) {
 		return null;
@@ -67,11 +77,14 @@ const BooleanGroupSubfield = ( {
 					{ label }
 				</label>
 
-				{ help && (
-					<>
+				{ shouldShowHelpText && (
+					<span className="pods-field-label__tooltip-wrapper">
 						{ '\u00A0' /* &nbsp; */ }
-						<HelpTooltip helpText={ help } />
-					</>
+						<HelpTooltip
+							helpText={ helpTextString }
+							helpLink={ helpLink }
+						/>
+					</span>
 				) }
 			</div>
 		</li>

--- a/ui/js/dfv/src/fields/boolean-group/index.js
+++ b/ui/js/dfv/src/fields/boolean-group/index.js
@@ -28,7 +28,9 @@ const BooleanGroup = ( {
 		boolean_group: booleanGroup = [],
 	} = fieldConfig;
 
-	const toggleChange = ( name ) => () => setOptionValue( name, ! values[ name ] );
+	const toggleChange = ( name ) => () => {
+		setOptionValue( name, ! toBool( values[ name ] ) );
+	};
 
 	return (
 		<ul className="pods-boolean-group">


### PR DESCRIPTION
## Description

Fixes a few issues with Boolean Group fields.

## Testing instructions

1. Open an "Edit Field" modal, try the Boolean Group in the Kitchen Sink.

## Changelog text for these changes

- Fix: Fixes issue with boolean group checkboxes needing to be clicked twice in the "Edit Field" modals.
- Fix: Fixes tooltip links not displaying inside Boolean Groups. 

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
