### PR TITLE
Feature/add --ver argument support to grunt / npm run

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,5 @@
 /*jshint node: true */
-module.exports = function ( grunt ) {
+module.exports = function( grunt ) {
 	'use strict';
 
 	// load all grunt tasks in package.json matching the `grunt-*` pattern
@@ -8,25 +8,51 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-exec' );
 
 	const config = {
-		pkg : grunt.file.readJSON( 'package.json' ), replace : {
-			version_readme_txt  : {
-				src : ['readme.txt'], overwrite : true, replacements : [
+		pkg: grunt.file.readJSON( 'package.json' ),
+		replace: {
+			version_readme_txt: {
+				src: [ 'readme.txt' ],
+				overwrite: true,
+				replacements: [
 					{
-						from : /Stable tag: ([\.\d\w\-]*)/, to : "Stable tag: <%= pkg.version %>"
-					}
-				]
-			}, version_init_php : {
-				src : ['init.php'], overwrite : true, replacements : [
+						from: /Stable tag: ([\.\d\w\-]*)/,
+						to() {
+							return 'Stable tag: ' + grunt.option( 'ver' ) || pkg.version;
+						},
+					},
+				],
+			},
+			version_init_php: {
+				src: [ 'init.php' ],
+				overwrite: true,
+				replacements: [
 					{
-						from : /Version: ([\.\d\w\-]*)/, to : "Version: <%= pkg.version %>"
+						from: /Version: ([\.\d\w\-]*)/,
+						to() {
+							return 'Version: ' + grunt.option( 'ver' ) || pkg.version;
+						},
 					},
 					{
-						from : /define\( 'PODS_VERSION', '([\.\d\w\-]*)' \);/,
-						to   : "define( 'PODS_VERSION', '<%= pkg.version %>' );"
-					}
-				]
-			}
-		}
+						from: /define\( 'PODS_VERSION', '([\.\d\w\-]*)' \);/,
+						to() {
+							return "define( 'PODS_VERSION', '" + ( grunt.option( 'ver' ) || pkg.version ) + "' );";
+						},
+					},
+				],
+			},
+			version_package: {
+				src: [ 'package.json' ],
+				overwrite: true,
+				replacements: [
+					{
+						from: /"version": "([\.\d\w\-]*)"/,
+						to() {
+							return '"version": "' + ( grunt.option( 'ver' ) || pkg.version ) + '"';
+						},
+					},
+				],
+			},
+		},
 	};
 
 	// Project configuration.
@@ -34,7 +60,8 @@ module.exports = function ( grunt ) {
 
 	// dev tasks
 	grunt.registerTask( 'version_number', [
+		'replace:version_package',
 		'replace:version_readme_txt',
-		'replace:version_init_php'
+		'replace:version_init_php',
 	] );
 };

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -13,9 +13,7 @@ Next you'll install the packages for this repo using: `npm install`
 
 ## Version Changes
 
-* Set new version in `package.json` (it might be something like `1.2.3-a-1`, so set it to `1.2.3`)
-* Run the `version_number` task using `npm run version_number`
-* _TODO: Would be great if running `npm run version_number` would ask for the version number to save a step_
+* Run the `version_number` task using `npm run version_number -- --ver=1.2.3-a-1` or set it in `package.json` and run it without parameters.
 * Commit / merge changes into `release/x.x.x` branch
 
 ## Asset Build for Production


### PR DESCRIPTION
## Description

Add --ver argument support to npm run version_update or grunt version_update, like: `npm run version_number -- --ver=1.2.3-a-1` would update all versions in their respective files to 1.2.3-a-1, the old style of updating package.json first and running without parameters still works.

## Testing instructions

1. Run `npm run version_number -- --ver=1.2.3-a-1`
2. Modify package json and run `npm run version_number`