### PR TITLE
PHP Notice "Indirect modification of overloaded property PodsArray::$fields has no effect" on Custom Settings Page

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1134,9 +1134,11 @@ class PodsUI {
 
 		// Set up default manage field.
 		if ( empty( $options->fields['manage'] ) ) {
-			$options->fields['manage'][ $options->sql['field_index'] ] = [
-				'label' => __( 'Name', 'pods' ),
-			];
+			$fields = $options->fields; // make a local copy of the fields
+			$fields['manage'][ $options->sql['field_index'] ] = array(
+					'label' => __( 'Name', 'pods' ),
+			);
+			$options->fields = $fields;
 		}
 
 		$options->validate( 'export', $this->export, 'array_merge' );

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -1134,10 +1134,15 @@ class PodsUI {
 
 		// Set up default manage field.
 		if ( empty( $options->fields['manage'] ) ) {
-			$fields = $options->fields; // make a local copy of the fields
-			$fields['manage'][ $options->sql['field_index'] ] = array(
+			// Make a local copy of the fields.
+			$fields = $options->fields;
+
+			// Change the info.
+			$fields['manage'][ $options->sql['field_index'] ] = [
 					'label' => __( 'Name', 'pods' ),
-			);
+			];
+
+			// Set the object fields property.
 			$options->fields = $fields;
 		}
 


### PR DESCRIPTION
## Description

Update the way $options->fields is modified by first making a local copy then replacing the one in the object with the modified local variable.

The old method would only update the local copy of fields['manage'] and the object reference would remain untouched with an empty manage key.

## Related GitHub issue(s)

#6048

