### PR TITLE
Fix meta_user do_action not using the right object.

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1944,6 +1944,7 @@ class PodsMeta {
 		if ( is_object( $user_id ) ) {
 			$user_id = $user_id->ID;
 		}
+		$user = get_userdata($user_id);
 
 		$id  = $user_id;
 		$pod = null;
@@ -1995,12 +1996,12 @@ class PodsMeta {
 					return $value;
 				};
 
-				$pre_callback = static function( $field_name, $id, $field, $pod ) use ( $post ) {
-					do_action( "pods_meta_meta_user_pre_row_{$field_name}", $post, $field, $pod );
+				$pre_callback = static function( $field_name, $id, $field, $pod ) use ( $user ) {
+					do_action( "pods_meta_meta_user_pre_row_{$field_name}", $user, $field, $pod );
 				};
 
-				$post_callback = static function( $field_name, $id, $field, $pod ) use ( $post ) {
-					do_action( "pods_meta_meta_user_post_row_{$field_name}", $post, $field, $pod );
+				$post_callback = static function( $field_name, $id, $field, $pod ) use ( $user ) {
+					do_action( "pods_meta_meta_user_post_row_{$field_name}", $user, $field, $pod );
 				};
 
 				pods_view( PODS_DIR . 'ui/forms/table-rows.php', compact( array_keys( get_defined_vars() ) ) );

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1942,9 +1942,11 @@ class PodsMeta {
 		$groups = $this->groups_get( 'user', 'user' );
 
 		if ( is_object( $user_id ) ) {
+			$user    = $user_id;
 			$user_id = $user_id->ID;
+		} else {
+			$user = get_userdata( $user_id );
 		}
-		$user = get_userdata($user_id);
 
 		$id  = $user_id;
 		$pod = null;


### PR DESCRIPTION
## Description

Fix warnings on admin when editing a user with a custom pod for non-existent $post variable, do_action would also not pass the right object over to hooks.

## Related GitHub issue(s)

## Testing instructions

1. Create a user pod, add some fields to it.
2. Go to edit the user.

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
