### PR TITLE
Fix Export to CSV Additional Action limit issues

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -2606,6 +2606,8 @@ class PodsUI {
 			$action = $this->action;
 		}
 
+		$params = (array) $params;
+
 		$defaults = array(
 			'full'    => false,
 			'flatten' => true,
@@ -2613,7 +2615,7 @@ class PodsUI {
 			'type'    => '',
 		);
 
-		if ( ! empty( $params ) && is_array( $params ) ) {
+		if ( ! empty( $params ) ) {
 			$params = (object) array_merge( $defaults, $params );
 		} else {
 			$params = (object) $defaults;
@@ -2757,7 +2759,7 @@ class PodsUI {
 			$action = 'manage';
 		}
 
-		$find_params = $this->get_params( (array) $params, $action );
+		$find_params = $this->get_params( $params, $action );
 
 		if ( false !== $this->pod && is_object( $this->pod ) && ( 'Pods' == get_class( $this->pod ) || 'Pod' == get_class( $this->pod ) ) ) {
 			$this->pod->find( $find_params );

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -2757,7 +2757,7 @@ class PodsUI {
 			$action = 'manage';
 		}
 
-		$find_params = $this->get_params( $params, $action );
+		$find_params = $this->get_params( (array) $params, $action );
 
 		if ( false !== $this->pod && is_object( $this->pod ) && ( 'Pods' == get_class( $this->pod ) || 'Pod' == get_class( $this->pod ) ) ) {
 			$this->pod->find( $find_params );


### PR DESCRIPTION
## Description

Export function first converted $params to an object, then get_params only merged $params if it was an array causing $params->full to always be false.

## Related GitHub issue(s)

Fixes #3035

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Go to any pot that supports exports and has more than 25 fields
2. Export

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
