### PR TITLE
Resolve `strlen()` warning

### DIFF
--- a/classes/fields/text.php
+++ b/classes/fields/text.php
@@ -108,6 +108,21 @@ class PodsField_Text extends PodsField {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public function is_empty( $value ) {
+		$is_empty = false;
+
+		$value = (string) $value;
+
+		if ( '' === $value ) {
+			$is_empty = true;
+		}
+
+		return $is_empty;
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
@@ -165,7 +180,7 @@ class PodsField_Text extends PodsField {
 		if ( is_array( $check ) ) {
 			$errors = $check;
 		} else {
-			if ( 0 < strlen( (string) $value ) && '' === $check ) {
+			if ( $this->is_empty( $check ) ) {
 				if ( $this->is_required( $options ) ) {
 					$errors[] = __( 'This field is required.', 'pods' );
 				}

--- a/classes/fields/text.php
+++ b/classes/fields/text.php
@@ -108,21 +108,6 @@ class PodsField_Text extends PodsField {
 	}
 
 	/**
-	 * @inheritDoc
-	 */
-	public function is_empty( $value ) {
-		$is_empty = false;
-
-		$value = (string) $value;
-
-		if ( '' === $value ) {
-			$is_empty = true;
-		}
-
-		return $is_empty;
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function display( $value = null, $name = null, $options = null, $pod = null, $id = null ) {
@@ -180,7 +165,7 @@ class PodsField_Text extends PodsField {
 		if ( is_array( $check ) ) {
 			$errors = $check;
 		} else {
-			if ( $this->is_empty( $check ) ) {
+			if ( '' !== $value && '' === $check ) {
 				if ( $this->is_required( $options ) ) {
 					$errors[] = __( 'This field is required.', 'pods' );
 				}

--- a/classes/fields/text.php
+++ b/classes/fields/text.php
@@ -165,7 +165,7 @@ class PodsField_Text extends PodsField {
 		if ( is_array( $check ) ) {
 			$errors = $check;
 		} else {
-			if ( 0 < strlen( $value ) && '' === $check ) {
+			if ( 0 < strlen( (string) $value ) && '' === $check ) {
 				if ( $this->is_required( $options ) ) {
 					$errors[] = __( 'This field is required.', 'pods' );
 				}


### PR DESCRIPTION
## Description
Resolve `Warning: strlen() expects parameter 1 to be string, array given in wp-content/plugins/pods/classes/fields/text.php on line 168`

## Related GitHub issue(s)

None.

## Testing instructions

I was getting this error output. Casting the value to `(string)` resolves the Warning and still serves the purpose of the function.

## Screenshots / screencast

None.

## Changelog text for these changes

* Fix a PHP error output.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
