### PR TITLE
Freemius: Check _parent object for using method

### DIFF
--- a/vendor/freemius/wordpress-sdk/includes/class-freemius.php
+++ b/vendor/freemius/wordpress-sdk/includes/class-freemius.php
@@ -23429,6 +23429,7 @@
             if (
                 $this->is_addon() &&
                 ! $this->is_only_premium() &&
+		is_object( $this->_parent ) &&
                 $this->_parent->is_anonymous()
             ) {
                 return;


### PR DESCRIPTION
A proposed solution for an error reported in this [Slack thread](https://podswp.slack.com/archives/C02SVLHQF/p1631628235171000).

It appears that `$this->_parent` can contain either an object or a boolean.
This should resolve the error by checking that it's an object before attempting to use the method `->is_anonymous()`.

It looks like `$this->_parent` is used in other places in this class.
Unknown if the `boolean` vs. `object` detail effects any other functionality.

Error:
```
An error of type E_ERROR was caused in line 23432 of the file wp-content/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php. Error message: Uncaught Error: Call to a member function is_anonymous() on bool in wp-content/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php:23432
Stack trace:
#0 wp-content/plugins/pods/vendor/freemius/wordpress-sdk/includes/class-freemius.php(2051): Freemius->_add_tracking_links()
#1 wp-includes/class-wp-hook.php(303): Freemius->_hook_action_links_and_register_account_hooks('')
#2 wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#3 wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#4 wp-admin/admin.php(175): do_action('admin_init')
#5 wp-admin/plugins.php(10): require_once('/home/ekhulnac/...')
#6 {main}
```

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
