### PR TITLE
Pods 2.8: Enhance getting Pod WhatsIt translations

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1,6 +1,5 @@
 <?php
 
-use Pods\Whatsit\Group;
 use Pods\Whatsit\Pod;
 
 /**
@@ -937,23 +936,9 @@ class PodsMeta {
 					continue;
 				}
 
-				/**
-				 * Filter the title of the Pods Group used in the post editor.
-				 *
-				 * @since 2.8
-				 *
-				 * @param string    $title  The title to use, default is 'More Fields'.
-				 * @param obj|Group $group  Current Group Object.
-				 * @param obj|Pod   $pod    Current Pods Object.
-				 * @param array     $fields Array of fields that will go in the metabox.
-				 * @param string    $type   The type of Pod.
-				 * @param string    $name   Name of the Pod.
-				 */
-				$label = apply_filters( 'pods_meta_group_label', $group['label'], $group, $pod, $fields, $type, $name );
-
 				$groups[] = [
 					'pod'      => $pod,
-					'label'    => $label,
+					'label'    => $group['label'],
 					'fields'   => $group['fields'],
 					'context'  => pods_v( 'meta_box_context', $group, 'normal', true ),
 					'priority' => pods_v( 'meta_box_priority', $group, 'default', true ),

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pods\Whatsit\Group;
 use Pods\Whatsit\Pod;
 
 /**
@@ -936,9 +937,23 @@ class PodsMeta {
 					continue;
 				}
 
+				/**
+				 * Filter the title of the Pods Group used in the post editor.
+				 *
+				 * @since 2.8
+				 *
+				 * @param string    $title  The title to use, default is 'More Fields'.
+				 * @param obj|Group $group  Current Group Object.
+				 * @param obj|Pod   $pod    Current Pods Object.
+				 * @param array     $fields Array of fields that will go in the metabox.
+				 * @param string    $type   The type of Pod.
+				 * @param string    $name   Name of the Pod.
+				 */
+				$label = apply_filters( 'pods_meta_group_label', $group['label'], $group, $pod, $fields, $type, $name );
+
 				$groups[] = [
 					'pod'      => $pod,
-					'label'    => $group['label'],
+					'label'    => $label,
 					'fields'   => $group['fields'],
 					'context'  => pods_v( 'meta_box_context', $group, 'normal', true ),
 					'priority' => pods_v( 'meta_box_priority', $group, 'default', true ),

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -109,13 +109,13 @@ class Pods_Component_I18n extends PodsComponent {
 			 */
 
 			// WP Object filters (post_type and taxonomy)
-			add_filter( 'pods_register_post_type', array( $this, 'pods_register_wp_object_i18n' ), 10, 2 );
-			add_filter( 'pods_register_taxonomy', array( $this, 'pods_register_wp_object_i18n' ), 10, 2 );
+			add_filter( 'pods_register_post_type', array( $this, 'translate_register_wp_object' ), 10, 2 );
+			add_filter( 'pods_register_taxonomy', array( $this, 'translate_register_wp_object' ), 10, 2 );
 
 			// ACT's
 			add_filter(
 				'pods_advanced_content_type_pod_data',
-				array( $this, 'pods_filter_object_strings_i18n' ),
+				array( $this, 'translate_object_options' ),
 				10,
 				2
 			);
@@ -125,17 +125,17 @@ class Pods_Component_I18n extends PodsComponent {
 			 */
 
 			// Setting pages.
-			add_filter( 'pods_admin_menu_page_title', array( $this, 'admin_menu_page_title_i18n' ), 10, 2 );
-			add_filter( 'pods_admin_menu_label', array( $this, 'admin_menu_label_i18n' ), 10, 2 );
+			add_filter( 'pods_admin_menu_page_title', array( $this, 'translate_admin_menu_page_title' ), 10, 2 );
+			add_filter( 'pods_admin_menu_label', array( $this, 'translate_admin_menu_label' ), 10, 2 );
 
 			// Pod Objects.
-			add_filter( 'pods_whatsit_get_label', array( $this, 'pods_label_text_i18n' ), 10, 2 );
-			add_filter( 'pods_whatsit_get_description', array( $this, 'pods_description_text_i18n' ), 10, 2 );
+			add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );
+			add_filter( 'pods_whatsit_get_description', array( $this, 'translate_description' ), 10, 2 );
 
 			foreach ( pods_form()->field_types() as $type => $data ) {
 				add_filter(
 					'pods_form_ui_field_' . $type . '_options',
-					array( $this, 'form_ui_field_options_i18n' ),
+					array( $this, 'translate_field_options' ),
 					10,
 					5
 				);
@@ -291,7 +291,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return string
 	 */
-	public function admin_menu_page_title_i18n( $page_title, $pod ) {
+	public function translate_admin_menu_page_title( $page_title, $pod ) {
 
 		return (string) $this->get_value_translation( $page_title, 'label', $pod );
 	}
@@ -307,7 +307,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return string
 	 */
-	public function admin_menu_label_i18n( $menu_label, $pod ) {
+	public function translate_admin_menu_label( $menu_label, $pod ) {
 
 		return (string) $this->get_value_translation( $menu_label, 'menu_name', $pod );
 	}
@@ -323,7 +323,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return string
 	 */
-	public function pods_label_text_i18n( $label, $object ) {
+	public function translate_label( $label, $object ) {
 
 		return (string) $this->get_value_translation( $label, 'label', $object );
 	}
@@ -339,7 +339,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return string
 	 */
-	public function pods_description_text_i18n( $description, $object ) {
+	public function translate_description( $description, $object ) {
 
 		return (string) $this->get_value_translation( $description, 'description', $object );
 	}
@@ -359,7 +359,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return array
 	 */
-	public function field_pick_data_i18n( $data, $name, $value, $options, $pod, $id ) {
+	public function translate_field_pick_data( $data, $name, $value, $options, $pod, $id ) {
 
 		if ( isset( $data[''] ) && isset( $options['pick_select_text'] ) ) {
 			$locale = $this->locale;
@@ -385,7 +385,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return array
 	 */
-	public function form_ui_field_options_i18n( $options, $name, $value, $pod, $id ) {
+	public function translate_field_options( $options, $name, $value, $pod, $id ) {
 
 		foreach ( $this->get_translatable_fields() as $field ) {
 			$locale = $this->locale;
@@ -408,7 +408,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return array
 	 */
-	public function pods_register_wp_object_i18n( $options, $object ) {
+	public function translate_register_wp_object( $options, $object ) {
 
 		$locale = $this->locale;
 
@@ -508,7 +508,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return array
 	 */
-	public function pods_filter_object_strings_i18n( $options, $object ) {
+	public function translate_object_options( $options, $object ) {
 
 		/**
 		 * @todo allow labels to be set even if the default language isn't

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -278,9 +278,9 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Page title for setting pages.
 	 *
-	 * @since 0.1.0
-	 * @see    PodsAdmin.php >> admin_menu()
-	 * @see    PodsAdmin.php >> admin_content_settings()
+	 * @since 1.0.0
+	 * @see   PodsAdmin.php >> admin_menu()
+	 * @see   PodsAdmin.php >> admin_content_settings()
 	 *
 	 * @param  string $page_title Current page title
 	 * @param  array  $pod        Pod data
@@ -295,8 +295,8 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Menu title for setting pages.
 	 *
-	 * @since 0.1.0
-	 * @see    PodsAdmin.php >> admin_menu()
+	 * @since 1.0.0
+	 * @see   PodsAdmin.php >> admin_menu()
 	 *
 	 * @param  string $menu_label Current menu label
 	 * @param  array  $pod        Pod data
@@ -312,7 +312,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 * Returns the translated label if available.
 	 *
 	 * @since 1.0.0
-	 * @see    \Pods\Whatsit >> 'pods_whatsit_get_label' (filter)
+	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_label' (filter)
 	 *
 	 * @param  string       $label  The default label.
 	 * @param  Pods\Whatsit $object The Pod Object.
@@ -328,7 +328,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 * Returns the translated description if available.
 	 *
 	 * @since 1.0.0
-	 * @see    \Pods\Whatsit >> 'pods_whatsit_get_description' (filter)
+	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_description' (filter)
 	 *
 	 * @param  string       $description  The default description.
 	 * @param  Pods\Whatsit $object The Pod Object.
@@ -343,8 +343,8 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Replaces the default selected text with a translation if available.
 	 *
-	 * @since 0.1.0
-	 * @see    pick.php >> 'pods_field_pick_data' (filter)
+	 * @since 1.0.0
+	 * @see   pick.php >> 'pods_field_pick_data' (filter)
 	 *
 	 * @param  array  $data    The default data of the field
 	 * @param  string $name    The field name
@@ -370,8 +370,8 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Replaces the default values with a translation if available.
 	 *
-	 * @since 0.1.0
-	 * @see    PodsForm.php >> 'pods_form_ui_field_' . $type . '_options' (filter)
+	 * @since 1.0.0
+	 * @see   PodsForm.php >> 'pods_form_ui_field_' . $type . '_options' (filter)
 	 *
 	 * @param  array  $options The field options
 	 * @param  string $name    The field name
@@ -396,8 +396,8 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Filter hook function to overwrite the labels and description with translations (if available)
 	 *
-	 * @since 0.1.0
-	 * @see    PodsInit.php >> setup_content_types()
+	 * @since 1.0.0
+	 * @see   PodsInit.php >> setup_content_types()
 	 *
 	 * @param  array  $options The array of object options
 	 * @param  string $object  The object type name/slug
@@ -496,8 +496,8 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Filter hook function to overwrite the labels and description with translations (if available)
 	 *
-	 * @since 0.1.0
-	 * @see    PodsInit.php >> admin_menu()
+	 * @since 1.0.0
+	 * @see   PodsInit.php >> admin_menu()
 	 *
 	 * @param  array  $options The array of object options
 	 * @param  string $object  The object type name/slug

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -823,7 +823,7 @@ class Pods_Component_I18n extends PodsComponent {
 			return true;
 		}
 
-		if ( false === pods_v( $locale, $i18n, true ) ) {
+		if ( false === (bool) pods_v( $locale, $i18n, true ) ) {
 			return false;
 		}
 

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -265,14 +265,10 @@ class Pods_Component_I18n extends PodsComponent {
 			return $current;
 		}
 
-		if ( is_callable( array( $data, 'get_args' ) ) ) {
-			$data = $data->get_args();
-		}
-
-		if ( is_array( $data ) && $this->obj_is_language_enabled( $locale, $data ) ) {
-			// Check if the i18n option exists and isn't empty
-			if ( ! empty( $data[ $key . '_' . $locale ] ) ) {
-				return (string) $data[ $key . '_' . $locale ];
+		if ( $this->obj_is_language_enabled( $locale, $data ) ) {
+			$translation = pods_v( $key . '_' . $locale, $data, null );
+			if ( $translation ) {
+				return $translation;
 			}
 		}
 
@@ -819,10 +815,15 @@ class Pods_Component_I18n extends PodsComponent {
 		if ( ! array_key_exists( $locale, $this->languages ) ) {
 			return false;
 		}
-		$data    = (array) $data;
-		$options = ( isset( $data['options'] ) ) ? $data['options'] : $data;
-		// If it doesn't exist in the object data then use the default (enabled)
-		if ( isset( $options['enable_i18n'][ $locale ] ) && false === (bool) $options['enable_i18n'][ $locale ] ) {
+		$options = pods_v( 'options', $data, $data );
+
+		$i18n = pods_v( 'enable_i18n', $options, null );
+		if ( null === $i18n ) {
+			// If it doesn't exist in the object data then assume it's enabled.
+			return true;
+		}
+
+		if ( false === pods_v( $locale, $i18n, true ) ) {
 			return false;
 		}
 

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -124,16 +124,13 @@ class Pods_Component_I18n extends PodsComponent {
 			 * LABEL REPLACEMENT.
 			 */
 
-			// Setting pages
+			// Setting pages.
 			add_filter( 'pods_admin_menu_page_title', array( $this, 'admin_menu_page_title_i18n' ), 10, 2 );
 			add_filter( 'pods_admin_menu_label', array( $this, 'admin_menu_label_i18n' ), 10, 2 );
 
-			// Filters for Pod Groups.
-			add_filter( 'pods_meta_group_label', array( $this, 'groups_ui_label_text_i18n' ), 10, 2 );
-
-			// Default filters for all fields
-			add_filter( 'pods_form_ui_label_text', array( $this, 'fields_ui_label_text_i18n' ), 10, 4 );
-			add_filter( 'pods_form_ui_comment_text', array( $this, 'fields_ui_comment_text_i18n' ), 10, 3 );
+			// Pod Objects.
+			add_filter( 'pods_whatsit_get_label', array( $this, 'pods_label_text_i18n' ), 10, 2 );
+			add_filter( 'pods_whatsit_get_description', array( $this, 'pods_description_text_i18n' ), 10, 2 );
 
 			foreach ( pods_form()->field_types() as $type => $data ) {
 				add_filter(
@@ -257,7 +254,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @param  string $current Current value
 	 * @param  string $key     The key / opion name to search for
-	 * @param  array  $data    Pod data (can also be an options array of a pod or field)
+	 * @param  array|Pods\Whatsit  $data    Pod data (can also be an options array of a pod or field)
 	 *
 	 * @return string
 	 */
@@ -319,51 +316,32 @@ class Pods_Component_I18n extends PodsComponent {
 	 * Returns the translated label if available.
 	 *
 	 * @since 1.0.0
-	 * @see    PodsMeta.php >> 'pods_meta_group_label' (filter)
+	 * @see    \Pods\Whatsit >> 'pods_whatsit_get_label' (filter)
 	 *
-	 * @param  string             $label The default label
-	 * @param  Pods\Whatsit\Group $group The Pods Group
-	 *
-	 * @return string
-	 */
-	public function groups_ui_label_text_i18n( $label, $group ) {
-
-		return (string) $this->get_value_translation( $label, 'label', $group );
-	}
-
-	/**
-	 * Returns the translated label if available.
-	 *
-	 * @since 0.1.0
-	 * @see    PodsForm.php >> 'pods_form_ui_label_text' (filter)
-	 *
-	 * @param  string $label   The default label
-	 * @param  string $name    The field name
-	 * @param  string $help    The help text
-	 * @param  array  $options The field options
+	 * @param  string       $label  The default label.
+	 * @param  Pods\Whatsit $object The Pod Object.
 	 *
 	 * @return string
 	 */
-	public function fields_ui_label_text_i18n( $label, $name, $help, $options ) {
+	public function pods_label_text_i18n( $label, $object ) {
 
-		return (string) $this->get_value_translation( $label, 'label', $options );
+		return (string) $this->get_value_translation( $label, 'label', $object );
 	}
 
 	/**
 	 * Returns the translated description if available.
 	 *
-	 * @since 0.1.0
-	 * @see    PodsForm.php >> 'pods_form_ui_comment_text' (filter)
+	 * @since 1.0.0
+	 * @see    \Pods\Whatsit >> 'pods_whatsit_get_description' (filter)
 	 *
-	 * @param  string $message The default description
-	 * @param  string $name    The field name
-	 * @param  array  $options The field options
+	 * @param  string       $description  The default description.
+	 * @param  Pods\Whatsit $object The Pod Object.
 	 *
 	 * @return string
 	 */
-	public function fields_ui_comment_text_i18n( $message, $name, $options ) {
+	public function pods_description_text_i18n( $description, $object ) {
 
-		return (string) $this->get_value_translation( $message, 'description', $options );
+		return (string) $this->get_value_translation( $description, 'description', $object );
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -261,8 +261,15 @@ class Pods_Component_I18n extends PodsComponent {
 	public function get_value_translation( $current, $key, $data ) {
 
 		$locale = $this->locale;
-		// Validate locale and pod
-		if ( is_array( $data ) && array_key_exists( $locale, $this->languages ) && $this->obj_is_language_enabled( $locale, $data ) ) {
+		if ( ! array_key_exists( $locale, $this->languages ) ) {
+			return $current;
+		}
+
+		if ( is_callable( array( $data, 'get_args' ) ) ) {
+			$data = $data->get_args();
+		}
+
+		if ( is_array( $data ) && $this->obj_is_language_enabled( $locale, $data ) ) {
 			// Check if the i18n option exists and isn't empty
 			if ( ! empty( $data[ $key . '_' . $locale ] ) ) {
 				return (string) $data[ $key . '_' . $locale ];

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -6,7 +6,7 @@
  *
  * Description: Allow UI of Pods and fields to be translated.
  *
- * Version: 0.2
+ * Version: 1.0
  *
  * Category: I18n
  *
@@ -711,7 +711,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * The i18n option tab.
 	 *
-	 * @since 2.8.0
+	 * @since 1.0.0
 	 *
 	 * @param  array $tabs
 	 *
@@ -727,7 +727,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * The i18n options
 	 *
-	 * @since 2.8.0
+	 * @since 1.0.0
 	 *
 	 * @param  array $options
 	 *

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -128,6 +128,9 @@ class Pods_Component_I18n extends PodsComponent {
 			add_filter( 'pods_admin_menu_page_title', array( $this, 'admin_menu_page_title_i18n' ), 10, 2 );
 			add_filter( 'pods_admin_menu_label', array( $this, 'admin_menu_label_i18n' ), 10, 2 );
 
+			// Filters for Pod Groups.
+			add_filter( 'pods_meta_group_label', array( $this, 'groups_ui_label_text_i18n' ), 10, 2 );
+
 			// Default filters for all fields
 			add_filter( 'pods_form_ui_label_text', array( $this, 'fields_ui_label_text_i18n' ), 10, 4 );
 			add_filter( 'pods_form_ui_comment_text', array( $this, 'fields_ui_comment_text_i18n' ), 10, 3 );
@@ -310,6 +313,22 @@ class Pods_Component_I18n extends PodsComponent {
 	public function admin_menu_label_i18n( $menu_label, $pod ) {
 
 		return (string) $this->get_value_translation( $menu_label, 'menu_name', $pod );
+	}
+
+	/**
+	 * Returns the translated label if available.
+	 *
+	 * @since 1.0.0
+	 * @see    PodsMeta.php >> 'pods_meta_group_label' (filter)
+	 *
+	 * @param  string             $label The default label
+	 * @param  Pods\Whatsit\Group $group The Pods Group
+	 *
+	 * @return string
+	 */
+	public function groups_ui_label_text_i18n( $label, $group ) {
+
+		return (string) $this->get_value_translation( $label, 'label', $group );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Also modify group labels with the i18n component.

@sc0ttkclark Please check filter name. There are now some PodsForm, PodsAdmin and PodsMeta filters.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes: #6148

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- ~My code includes automated tests for PHP and/or JS (if applicable).~
