### PR TITLE
Pods 2.8 i18n integration classes

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -904,24 +904,15 @@ class Pods implements Iterator {
 					}
 
 					if ( $use_meta_fallback ) {
-						$id = $this->id();
-
 						$metadata_type = $pod_type;
 
 						if ( in_array( $metadata_type, array( 'post_type', 'media' ), true ) ) {
 							$metadata_type = 'post';
-
-							// Support for WPML 'duplicated' translation handling.
-							if ( did_action( 'wpml_loaded' ) && apply_filters( 'wpml_is_translated_post_type', false, $this->pod_data['name'] ) ) {
-								$master_post_id = (int) apply_filters( 'wpml_master_post_from_duplicate', $id );
-
-								if ( $master_post_id ) {
-									$id = $master_post_id;
-								}
-							}
 						} elseif ( 'taxonomy' === $metadata_type ) {
 							$metadata_type = 'term';
 						}
+
+						$id = apply_filters( 'pods_pods_field_get_metadata_object_id', $this->id(), $metadata_type, $params, $this );
 
 						$value = get_metadata( $metadata_type, $id, $params->name, $params->single );
 
@@ -1475,18 +1466,11 @@ class Pods implements Iterator {
 
 											$metadata_type = $object_type;
 
-											if ( 'post' === $object_type ) {
-												// Support for WPML 'duplicated' translation handling.
-												if ( did_action( 'wpml_loaded' ) && apply_filters( 'wpml_is_translated_post_type', false, $object ) ) {
-													$master_post_id = (int) apply_filters( 'wpml_master_post_from_duplicate', $metadata_object_id );
-
-													if ( 0 < $master_post_id ) {
-														$metadata_object_id = $master_post_id;
-													}
-												}
-											} elseif ( 'taxonomy' === $object_type ) {
+											if ( 'taxonomy' === $object_type ) {
 												$metadata_type = 'term';
 											}
+
+											$metadata_object_id = apply_filters( 'pods_pods_field_get_metadata_object_id', $metadata_object_id, $metadata_type, $params, $this );
 
 											$meta_value = get_metadata( $metadata_type, $metadata_object_id, $field, true );
 

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -3183,12 +3183,7 @@ class PodsData {
 
 		$field = $traverse_recurse['fields'][ $traverse_recurse['depth'] ];
 
-		$ignore_aliases = array(
-			'wpml_languages',
-			'polylang_languages',
-		);
-
-		$ignore_aliases = apply_filters( 'pods_data_traverse_recurse_ignore_aliases', $ignore_aliases, $field, $traverse_recurse, $this );
+		$ignore_aliases = apply_filters( 'pods_data_traverse_recurse_ignore_aliases', [], $field, $traverse_recurse, $this );
 
 		if ( in_array( $field, $ignore_aliases, true ) ) {
 			return $joins;

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -37,9 +37,6 @@ final class PodsI18n {
 
 		// Hook all enqueue scripts actions
 		add_action( 'pods_before_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-
-		// Polylang
-		add_filter( 'pll_get_post_types', array( $this, 'pll_get_post_types' ), 10, 2 );
 	}
 
 	/**
@@ -495,25 +492,6 @@ final class PodsI18n {
 
 		return $lang_data;
 
-	}
-
-	/**
-	 * Add Pods templates to possible i18n enabled post-types (polylang settings).
-	 *
-	 * @since 2.7.0
-	 *
-	 * @param  array $post_types
-	 * @param  bool  $is_settings
-	 *
-	 * @return array  mixed
-	 */
-	public function pll_get_post_types( $post_types, $is_settings = false ) {
-
-		if ( $is_settings ) {
-			$post_types['_pods_template'] = '_pods_template';
-		}
-
-		return $post_types;
 	}
 
 }

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -229,11 +229,7 @@ class PodsMeta {
 
 		add_action( 'init', array( $this, 'enqueue' ), 9 );
 
-		if ( function_exists( 'pll_current_language' ) ) {
-			add_action( 'init', array( $this, 'cache_pods' ), 101, 0 );
-		}
-
-		do_action( 'pods_meta_init' );
+		do_action( 'pods_meta_init', $this );
 
 		return $this;
 	}

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Pods\Integrations;
+
+/**
+ * Class Polylang
+ *
+ * @since 2.8.0
+ */
+class Polylang {
+}

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -17,6 +17,7 @@ class Polylang {
 	public function hook() {
 		add_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
 		add_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10, 2 );
+		add_filter( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
 	}
 
 	/**
@@ -27,6 +28,7 @@ class Polylang {
 	public function unhook() {
 		remove_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
 		remove_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10 );
+		remove_action( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
 	}
 
 	/**
@@ -59,4 +61,68 @@ class Polylang {
 		}
 
 		return $post_types;
+	}
+
+	/**
+	 * Filter table info data.
+	 *
+	 * @param $info
+	 * @param $object_type
+	 * @param $object
+	 * @param $name
+	 * @param $pod
+	 * @param $field
+	 * @param $pods_api
+	 *
+	 * @since 2.8.0
+	 */
+	public function pods_api_get_table_info( $info, $object_type, $object, $name, $pod, $field, $pods_api ) {
+		global $wpdb;
+		$object_name = pods_sanitize( ( empty( $object ) ? $name : $object ) );
+
+		// Get current language data
+		$lang_data = pods_i18n()->get_current_language_data();
+
+		$current_language_tt_id    = 0;
+		$current_language_tl_tt_id = 0;
+
+		if ( $lang_data ) {
+			if ( ! empty( $lang_data['tt_id'] ) ) {
+				$current_language_tt_id = $lang_data['tt_id'];
+			}
+			if ( ! empty( $lang_data['tl_tt_id'] ) ) {
+				$current_language_tl_tt_id = $lang_data['tl_tt_id'];
+			}
+		}
+
+		switch ( $object_type ) {
+
+			case 'post':
+			case 'post_type':
+				if ( function_exists( 'pll_is_translated_post_type' ) && pll_is_translated_post_type( $object_name ) ) {
+					$info['join']['polylang_languages'] = "
+						LEFT JOIN `{$wpdb->term_relationships}` AS `polylang_languages`
+							ON `polylang_languages`.`object_id` = `t`.`ID`
+								AND `polylang_languages`.`term_taxonomy_id` = {$current_language_tt_id}
+					";
+
+					$info['where']['polylang_languages'] = "`polylang_languages`.`object_id` IS NOT NULL";
+				}
+				break;
+
+			case 'taxonomy':
+				if ( function_exists( 'pll_is_translated_taxonomy' ) && pll_is_translated_taxonomy( $object_name ) ) {
+					$info['join']['polylang_languages'] = "
+					LEFT JOIN `{$wpdb->term_relationships}` AS `polylang_languages`
+						ON `polylang_languages`.`object_id` = `t`.`term_id`
+							AND `polylang_languages`.`term_taxonomy_id` = {$current_language_tl_tt_id}
+					";
+
+					$info['where']['polylang_languages'] = "`polylang_languages`.`object_id` IS NOT NULL";
+				}
+				break;
+		}
+
+		return $info;
+	}
 }

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -8,4 +8,20 @@ namespace Pods\Integrations;
  * @since 2.8.0
  */
 class Polylang {
+
+	/**
+	 * Add the class hooks.
+	 *
+	 * @since 2.8.0
+	 */
+	public function hook() {
+	}
+
+	/**
+	 * Remove the class hooks.
+	 *
+	 * @since 2.8.0
+	 */
+	public function unhook() {
+	}
 }

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -18,6 +18,7 @@ class Polylang {
 		add_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
 		add_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10, 2 );
 		add_filter( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
+		add_filter( 'pods_data_traverse_recurse_ignore_aliases', [ $this, 'pods_data_traverse_recurse_ignore_aliases' ], 10 );
 	}
 
 	/**
@@ -29,6 +30,7 @@ class Polylang {
 		remove_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
 		remove_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10 );
 		remove_action( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
+		remove_action( 'pods_data_traverse_recurse_ignore_aliases', [ $this, 'pods_data_traverse_recurse_ignore_aliases' ], 10 );
 	}
 
 	/**
@@ -41,6 +43,15 @@ class Polylang {
 		if ( function_exists( 'pll_current_language' ) ) {
 			add_action( 'init', array( $pods_meta, 'cache_pods' ), 101, 0 );
 		}
+	}
+
+	/**
+	 * @param array $ignore_aliases
+	 * @return array
+	 */
+	public function pods_data_traverse_recurse_ignore_aliases( $ignore_aliases ) {
+		$ignore_aliases[] = 'polylang_languages';
+		return $ignore_aliases;
 	}
 
 	/**

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -16,6 +16,7 @@ class Polylang {
 	 */
 	public function hook() {
 		add_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
+		add_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10, 2 );
 	}
 
 	/**
@@ -25,6 +26,7 @@ class Polylang {
 	 */
 	public function unhook() {
 		remove_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
+		remove_action( 'pll_get_post_types', [ $this, 'pll_get_post_types' ], 10 );
 	}
 
 	/**
@@ -38,4 +40,23 @@ class Polylang {
 			add_action( 'init', array( $pods_meta, 'cache_pods' ), 101, 0 );
 		}
 	}
+
+	/**
+	 * Add Pods templates to possible i18n enabled post-types (polylang settings).
+	 *
+	 * @since 2.7.0
+	 * @since 2.8.0 Moved from PodsI18n class.
+	 *
+	 * @param  array $post_types
+	 * @param  bool  $is_settings
+	 *
+	 * @return array  mixed
+	 */
+	public function pll_get_post_types( $post_types, $is_settings = false ) {
+
+		if ( $is_settings ) {
+			$post_types['_pods_template'] = '_pods_template';
+		}
+
+		return $post_types;
 }

--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -15,6 +15,7 @@ class Polylang {
 	 * @since 2.8.0
 	 */
 	public function hook() {
+		add_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
 	}
 
 	/**
@@ -23,5 +24,18 @@ class Polylang {
 	 * @since 2.8.0
 	 */
 	public function unhook() {
+		remove_action( 'pods_meta_init', [ $this, 'pods_meta_init' ] );
+	}
+
+	/**
+	 * @param \PodsMeta $pods_meta
+	 *
+	 * @since 2.8.0
+	 */
+	public function pods_meta_init( $pods_meta ) {
+
+		if ( function_exists( 'pll_current_language' ) ) {
+			add_action( 'init', array( $pods_meta, 'cache_pods' ), 101, 0 );
+		}
 	}
 }

--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -16,6 +16,7 @@ class WPML {
 	 */
 	public function hook() {
 		add_filter( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
+		add_filter( 'pods_data_traverse_recurse_ignore_aliases', [ $this, 'pods_data_traverse_recurse_ignore_aliases' ], 10 );
 	}
 
 	/**
@@ -25,6 +26,16 @@ class WPML {
 	 */
 	public function unhook() {
 		remove_action( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
+		remove_action( 'pods_data_traverse_recurse_ignore_aliases', [ $this, 'pods_data_traverse_recurse_ignore_aliases' ], 10 );
+	}
+
+	/**
+	 * @param array $ignore_aliases
+	 * @return array
+	 */
+	public function pods_data_traverse_recurse_ignore_aliases( $ignore_aliases ) {
+		$ignore_aliases[] = 'wpml_languages';
+		return $ignore_aliases;
 	}
 
 	/**

--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Pods\Integrations;
+
+/**
+ * Class WPML
+ *
+ * @since 2.8.0
+ */
+class WPML {
+}

--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -8,4 +8,20 @@ namespace Pods\Integrations;
  * @since 2.8.0
  */
 class WPML {
+
+	/**
+	 * Add the class hooks.
+	 *
+	 * @since 2.8.0
+	 */
+	public function hook() {
+	}
+
+	/**
+	 * Remove the class hooks.
+	 *
+	 * @since 2.8.0
+	 */
+	public function unhook() {
+	}
 }

--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -56,7 +56,7 @@ class WPML {
 
 			case 'post':
 			case 'post_type':
-				if ( did_action( 'wpml_loaded' ) && apply_filters( 'wpml_is_translated_post_type', false, $object_name ) ) {
+				if ( $this->is_translated_post_type( $object_name ) ) {
 					$info['join']['wpml_translations'] = "
 						LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
 							ON `wpml_translations`.`element_id` = `t`.`ID`
@@ -74,7 +74,7 @@ class WPML {
 				break;
 
 			case 'taxonomy':
-				if ( is_object( $sitepress ) && $sitepress->is_translated_taxonomy( $object_name ) ) {
+				if ( $this->is_translated_taxonomy( $object_name ) ) {
 					$info['join']['wpml_translations'] = "
 						LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
 							ON `wpml_translations`.`element_id` = `tt`.`term_taxonomy_id`
@@ -93,5 +93,43 @@ class WPML {
 		}
 
 		return $info;
+	}
+
+	/**
+	 * Helper method for backwards compatibility.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $object_name
+	 *
+	 * @return false|mixed|void
+	 */
+	public function is_translated_post_type( $object_name ) {
+		global $sitepress;
+		if ( has_filter( 'wpml_is_translated_post_type' ) ) {
+			return apply_filters( 'wpml_is_translated_post_type', false, $object_name );
+		} elseif ( is_callable( [ $sitepress, 'is_translated_post_type' ] ) ) {
+			return $sitepress->is_translated_post_type( $object_name );
+		}
+		return false;
+	}
+
+	/**
+	 * Helper method for backwards compatibility.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $object_name
+	 *
+	 * @return false|mixed|void
+	 */
+	public function is_translated_taxonomy( $object_name ) {
+		global $sitepress;
+		if ( has_filter( 'wpml_is_translated_taxonomy' ) ) {
+			return apply_filters( 'wpml_is_translated_taxonomy', false, $object_name );
+		} elseif ( is_callable( [ $sitepress, 'is_translated_taxonomy' ] ) ) {
+			return $sitepress->is_translated_taxonomy( $object_name );
+		}
+		return false;
 	}
 }

--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -15,6 +15,7 @@ class WPML {
 	 * @since 2.8.0
 	 */
 	public function hook() {
+		add_filter( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
 	}
 
 	/**
@@ -23,5 +24,74 @@ class WPML {
 	 * @since 2.8.0
 	 */
 	public function unhook() {
+		remove_action( 'pods_api_get_table_info', [ $this, 'pods_api_get_table_info' ], 10, 7 );
+	}
+
+	/**
+	 * Filter table info data.
+	 *
+	 * @param $info
+	 * @param $object_type
+	 * @param $object
+	 * @param $name
+	 * @param $pod
+	 * @param $field
+	 * @param $pods_api
+	 *
+	 * @since 2.8.0
+	 */
+	public function pods_api_get_table_info( $info, $object_type, $object, $name, $pod, $field, $pods_api ) {
+		global $wpdb, $sitepress;
+
+		if ( ! apply_filters( 'wpml_setting', true, 'auto_adjust_ids' ) ) {
+			return $info;
+		}
+
+		$object_name = pods_sanitize( ( empty( $object ) ? $name : $object ) );
+
+		// Get current language
+		$current_language = pods_i18n()->get_current_language();
+
+		switch ( $object_type ) {
+
+			case 'post':
+			case 'post_type':
+				if ( did_action( 'wpml_loaded' ) && apply_filters( 'wpml_is_translated_post_type', false, $object_name ) ) {
+					$info['join']['wpml_translations'] = "
+						LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
+							ON `wpml_translations`.`element_id` = `t`.`ID`
+								AND `wpml_translations`.`element_type` = 'post_" . pods_sanitize( $object_name ) . "'
+								AND `wpml_translations`.`language_code` = '" . pods_sanitize( $current_language ) . "'
+					";
+
+					$info['join']['wpml_languages'] = "
+						LEFT JOIN `{$wpdb->prefix}icl_languages` AS `wpml_languages`
+							ON `wpml_languages`.`code` = `wpml_translations`.`language_code` AND `wpml_languages`.`active` = 1
+					";
+
+					$info['where']['wpml_languages'] = "`wpml_languages`.`code` IS NOT NULL";
+				}
+				break;
+
+			case 'taxonomy':
+				if ( is_object( $sitepress ) && $sitepress->is_translated_taxonomy( $object_name ) ) {
+					$info['join']['wpml_translations'] = "
+						LEFT JOIN `{$wpdb->prefix}icl_translations` AS `wpml_translations`
+							ON `wpml_translations`.`element_id` = `tt`.`term_taxonomy_id`
+								AND `wpml_translations`.`element_type` = 'tax_" . pods_sanitize( $object_name ) . "'
+								AND `wpml_translations`.`language_code` = '" . pods_sanitize( $current_language ) . "'
+					";
+
+					$info['join']['wpml_languages'] = "
+						LEFT JOIN `{$wpdb->prefix}icl_languages` AS `wpml_languages`
+							ON `wpml_languages`.`code` = `wpml_translations`.`language_code` AND `wpml_languages`.`active` = 1
+					";
+
+					$info['where']['wpml_languages'] = "`wpml_languages`.`code` IS NOT NULL";
+				}
+				break;
+		}
+
+		return $info;
 	}
 }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR moved all i18n compatibility for third party plugins (WPML and Polylang) to dedicated integration classes.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Related: #5029 

TODO:
- [ ] Fix #5945 
- [ ] Fix #5968 

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

TODO

1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See '....'

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
