### PR TITLE
Ensure last_table_info is an object and not boolean

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -3548,7 +3548,7 @@ class PodsData {
 				'pod'             => $this->pod,
 				'fields'          => (array) $field,
 				'params'          => $params,
-				'last_table_info' => $this->pod_data || $this->table_info,
+				'last_table_info' => isset( $this->pod_data ) ? $this->pod_data : $this->table_info,
 				'joined_id'       => $this->field_id,
 				'joined_index'    => $this->field_index,
 			];


### PR DESCRIPTION
## Description

Ensure last_table_info is an object and not boolean

[This commit](https://github.com/pods-framework/pods/commit/6efb7139fbf3cec383538397eb0104dc755d8c00) broke some traversals.  Must not be all of them or more people would have noticed.  My setup I was testing against had a 'custom-simple' relationship field.
