### PR TITLE
Make sure fields are displayed properly with 'Admin Columns' plugin

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -601,7 +601,7 @@ class PodsMeta {
 				$meta = $podterms->field( $field );
 			}
 
-			$meta = PodsForm::field_method( $pod['fields'][ $field ]['type'], 'ui', $id, $meta, $field, $pod['fields'][ $field ] );
+			$meta = PodsForm::field_method( $pod['fields'][ $field ]['type'], 'ui', $id, $meta, $field, $pod['fields'][ $field ], $pod['fields'], $pod );
 		}
 
 		return $meta;


### PR DESCRIPTION

## Description

Previous commit (https://github.com/pods-framework/pods/commit/4f65fcd843ce2fa282c89671310d471a2d4e05c5) broke this feature.  For relationship fields the 'Admin Column' displayed would be a pods_serial_comma() list of the Pods meta data instead of the title or whatever the default is supposed to be.

