### PR TITLE
Allow Auto Template cache to be refreshed on save

### DIFF
--- a/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Settings.php
+++ b/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Settings.php
@@ -56,8 +56,8 @@ class Pods_Templates_Auto_Template_Settings {
 		// Include and init front-end class
 		add_action( 'init', array( $this, 'front_end' ), 25 );
 
-		// Delete transients when Pods settings are updated.
-		add_action( 'update_option', array( $this, 'reset' ), 21, 3 );
+		// Delete transients when Pods cache is flushed.
+		add_action( 'pods_cache_flushed', array( $this, 'reseter' ) );
 
 		// admin notice for archives without archives
 		add_action( 'admin_notices', array( $this, 'archive_warning' ) );
@@ -359,32 +359,13 @@ class Pods_Templates_Auto_Template_Settings {
 	}
 
 	/**
-	 * Reset the transients for front-end class when Pods are saved.
-	 *
-	 * @uses  update_option hook
-	 *
-	 * @param string $option
-	 * @param mixed  $old_value
-	 * @param mixed  $value
-	 *
-	 * @since 2.5.5
-	 */
-	public function reset( $option, $old_value, $value ) {
-
-		if ( $option === '_transient_pods_flush_rewrites' ) {
-			$this->reseter();
-		}
-
-	}
-
-	/**
 	 * Delete transients that stores the settings.
 	 *
 	 * @since 2.5.5
 	 */
 	public function reseter() {
 
-		$keys = array( 'pods_pfat_the_pods', 'pods_pfat_auto_pods', 'pods_pfat_archive_test' );
+		$keys = array( '_pods_pfat_the_pods', 'pods_pfat_the_pods', 'pods_pfat_auto_pods', 'pods_pfat_archive_test' );
 		foreach ( $keys as $key ) {
 			pods_transient_clear( $key );
 		}


### PR DESCRIPTION
Using the 'update_option' action and checking for a specific option to be set has too many assumptions and wasn't working on my test.  This switches to the 'pods_cache_flushed' action.

Additionally, if the reset attempt did ever get made the actual transient name was wrong.  The additional transients that get cleared probably aren't necessary anymore but do not hurt anything.

## Description

I was talking to a user on slack about auto templates and I couldn't get it to work until I manually cleared the transients.  I'm not sure if this ever worked properly.

