### PR TITLE
Revert "WPML Add compat for auto templates"

### DIFF
--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -23,7 +23,6 @@ class WPML extends Integration {
 			'pods_pods_field_get_metadata_object_id' => [ 'pods_pods_field_get_metadata_object_id', 10, 4 ],
 			'pods_component_i18n_admin_data' => [ 'pods_component_i18n_admin_data' ],
 			'pods_component_i18n_admin_ui_fields' => [ 'pods_component_i18n_admin_ui_fields', 10, 2 ],
-			'pods_auto_template_template_name' => [ 'pods_auto_template_template_name' ],
 			'pods_var_post_id' => [ 'pods_var_post_id' ],
 		],
 	];
@@ -58,34 +57,6 @@ class WPML extends Integration {
 		$ignore_aliases[] = 'wpml_languages';
 
 		return $ignore_aliases;
-	}
-
-	/**
-	 * Check for translated object ID for template.
-	 *
-	 * @since 2.8.2
-	 *
-	 * @param string $template_name The template name.
-	 *
-	 * @return string The template name for the translated template if set, or original template name.
-	 */
-	public function pods_auto_template_template_name( $template_name ) {
-
-		$obj = pods_by_title( $template_name );
-
-		if ( $obj ) {
-			$id = apply_filters( 'wpml_object_id', $obj->ID, $obj->post_type, true );
-
-			if ( (int) $id !== (int) $obj->ID ) {
-				$obj = get_post( $id );
-
-				if ( $obj ) {
-					$template_name = $obj->post_title;
-				}
-			}
-		}
-
-		return $template_name;
 	}
 
 	/**


### PR DESCRIPTION
Reverts pods-framework/pods#6219

This PR was redundant. Getting the correct template is already done by WPML within `get_posts()`