### PR TITLE
Fix the regression in filters display

### DIFF
--- a/ui/front/filters.php
+++ b/ui/front/filters.php
@@ -4,9 +4,9 @@
 	<?php
 	foreach ( $fields as $name => $field ) {
 		if ( in_array( $field['type'], array( 'pick', 'taxonomy' ), true ) && 'pick-custom' !== $field['pick_object'] && ! empty( $field['pick_object'] ) ) {
-			$field['options']['pick_format_type']   = 'single';
-			$field['options']['pick_format_single'] = 'dropdown';
-			$field['options']['pick_select_text']   = '-- ' . $field['label'] . ' --';
+			$field['pick_format_type']   = 'single';
+			$field['pick_format_single'] = 'dropdown';
+			$field['pick_select_text']   = '-- ' . $field['label'] . ' --';
 
 			$filter = pods_var_raw( 'filter_' . $name, 'get', '' );
 


### PR DESCRIPTION
## Description

According to https://pods.io/2021/02/11/pods-2-8-beta-1-released-and-the-field-guide-to-pods-2-8/ the access to $field['options']['option_name'] should be performed as $field['option_name']
As a result the filter options changed from "-- Taxonomy name --" to "-- Select one --" which was not desired.

## Changelog text for these changes

Bug: Regression in filters display (@gafiulov)

## PR checklist

- [X] I have tested my own code to confirm it works as I intended.
- [X] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [X] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [X] My code includes automated tests for PHP and/or JS (if applicable).
