### PR TITLE
i18n component v1.1 - translate Whatsit args

### DIFF
--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -123,7 +123,7 @@ class Pods_Component_I18n extends PodsComponent {
 			// Pod.
 			add_filter( 'pods_admin_setup_edit_tabs', array( $this, 'translation_tab' ), 99, 2 );
 			add_filter( 'pods_admin_setup_edit_options', array( $this, 'translation_options' ), 99, 2 );
-			// Pod Fields.
+			// Pod Groups.
 			add_filter( 'pods_admin_setup_edit_group_tabs', array( $this, 'translation_tab' ), 99, 2 );
 			add_filter( 'pods_admin_setup_edit_group_options', array( $this, 'translation_options' ), 99, 2 );
 			// Pod Fields.
@@ -134,7 +134,7 @@ class Pods_Component_I18n extends PodsComponent {
 			 * REGISTERING OBJ LABELS.
 			 */
 
-			// WP Object filters (post_type and taxonomy)
+			// WP Object filters (post_type and taxonomy).
 			add_filter( 'pods_register_post_type', array( $this, 'translate_register_wp_object' ), 10, 2 );
 			add_filter( 'pods_register_taxonomy', array( $this, 'translate_register_wp_object' ), 10, 2 );
 

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -142,6 +142,7 @@ class Pods_Component_I18n extends PodsComponent {
 				add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );
 				add_filter( 'pods_whatsit_get_description', array( $this, 'translate_description' ), 10, 2 );
 				add_filter( 'pods_whatsit_get_arg', array( $this, 'translate_arg' ), 10, 3 );
+				add_filter( 'pods_whatsit_get_args', array( $this, 'translate_args' ), 10, 2 );
 
 				foreach ( pods_form()->field_types() as $type => $data ) {
 					add_filter(
@@ -346,7 +347,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @param  mixed        $arg    The object argument.
 	 * @param  string       $name   The argument name.
-	 * @param  Pods\Whatsit $object The Pod Object.
+	 * @param  array|Pods\Whatsit $object The Pod Object.
 	 *
 	 * @return string
 	 */
@@ -357,6 +358,28 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		return $arg;
+	}
+
+	/**
+	 * Returns the translated arguments if available.
+	 *
+	 * @since 1.1.0
+	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_args' (filter)
+	 *
+	 * @param  array        $args   The object arguments.
+	 * @param  Pods\Whatsit $object The Pod Object.
+	 *
+	 * @return array
+	 */
+	public function translate_args( $args, $object ) {
+
+		foreach ( $args as $name => $value ) {
+			if ( $this->is_translatable_field( $name ) ) {
+				$args[ $name ] = $this->translate_arg( $value, $name, $object->getArrayCopy() );
+			}
+		}
+
+		return $args;
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -60,6 +60,12 @@ class Pods_Component_I18n extends PodsComponent {
 		'file_modal_add_button' => [
 			'depends-on' => [ 'type' => 'file' ],
 		],
+		'boolean_yes_label' => [
+			'depends-on' => [ 'type' => 'boolean' ],
+		],
+		'boolean_no_label' => [
+			'depends-on' => [ 'type' => 'boolean' ],
+		],
 	];
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -918,7 +918,7 @@ class Pods_Component_I18n extends PodsComponent {
 		/**
 		 * Overwrite translatable fields.
 		 *
-		 * @since 0.1
+		 * @since 2.8.4
 		 *
 		 * @param string[] $fields The translatable fields.
 		 */
@@ -942,7 +942,7 @@ class Pods_Component_I18n extends PodsComponent {
 	}
 
 	/**
-	 * @since 1.1
+	 * @since 2.8.4
 	 * @return array[]
 	 */
 	public function get_translatable_field_options( $key ) {
@@ -952,7 +952,7 @@ class Pods_Component_I18n extends PodsComponent {
 		/**
 		 * Overwrite translatable field options.
 		 *
-		 * @since 1.1
+		 * @since 2.8.4
 		 *
 		 * @param array  $field_options The translatable field options.
 		 * @param string $key           The field name.

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -155,7 +155,7 @@ class Pods_Component_I18n extends PodsComponent {
 			add_filter( 'pods_admin_menu_label', array( $this, 'translate_admin_menu_label' ), 10, 2 );
 
 			// Do not overwrite Whatsit object fields if we're editing Pods.
-			if ( ! $is_pods_edit_page && ! pods_doing_json() ) {
+			if ( ! $is_pods_edit_page && ! pods_doing_json() && ! wp_doing_ajax() ) {
 
 				// Pod Objects.
 				add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -234,6 +234,7 @@ class Pods_Component_I18n extends PodsComponent {
 	public function is_translatable_field( $name ) {
 
 		$translatable_fields = $this->get_translatable_fields();
+		$translatable_fields = array_keys( $translatable_fields );
 
 		// All fields that start with "label"
 		if ( strpos( $name, 'label' ) === 0 && false === strpos( $name, $this->locale ) ) {

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -925,7 +925,17 @@ class Pods_Component_I18n extends PodsComponent {
 		 *
 		 * @param string[] $fields The translatable fields.
 		 */
-		return apply_filters( 'pods_translatable_fields', $this->translatable_fields );
+		$fields = apply_filters( 'pods_translatable_fields', $this->translatable_fields );
+
+		// Backwards compatibility: Before v1.1 this was a list of field names instead of options.
+		foreach ( $fields as $name => $value ) {
+			if ( is_string( $value ) ) {
+				unset( $fields[ $name ] );
+				$fields[ $value ] = [];
+			}
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -898,22 +898,16 @@ class Pods_Component_I18n extends PodsComponent {
 			$native_name = $lang_data['native_name'];
 		}
 
-		if ( ! empty( $native_name ) && ! empty( $english_name ) ) {
-			if ( $native_name == $english_name ) {
-				return $english_name;
-			} else {
-				return $english_name . ' / ' . $native_name;
-			}
-		} else {
-			if ( ! empty( $english_name ) ) {
-				return $english_name;
-			}
-			if ( ! empty( $native_name ) ) {
-				return $native_name;
-			}
+		$label = '';
+
+		if ( ! empty( $english_name ) ) {
+			$label = $english_name;
+		}
+		if ( ! empty( $native_name ) && $label !== $native_name ) {
+			$label .= ' / ' . $native_name;
 		}
 
-		return '';
+		return $label;
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -73,7 +73,7 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		$is_component_page = false;
-		$is_pod_page = false;
+		$is_pods_edit_page = false;
 
 		if ( is_admin() && isset( $_GET['page'] ) ) {
 
@@ -82,8 +82,8 @@ class Pods_Component_I18n extends PodsComponent {
 			// Is the current page the admin page of this component or a Pods edit page?
 			if ( $this->admin_page === $page ) {
 				$is_component_page = true;
-			} elseif ( false !== strpos( $page, 'pods' ) ) {
-				$is_pod_page = true;
+			} elseif ( 'pods' === $page ) {
+				$is_pods_edit_page = true;
 			}
 		}
 
@@ -136,7 +136,7 @@ class Pods_Component_I18n extends PodsComponent {
 			add_filter( 'pods_admin_menu_page_title', array( $this, 'translate_admin_menu_page_title' ), 10, 2 );
 			add_filter( 'pods_admin_menu_label', array( $this, 'translate_admin_menu_label' ), 10, 2 );
 
-			if ( ! $is_pod_page ) {
+			if ( ! $is_pods_edit_page ) {
 
 				// Pod Objects.
 				add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -375,7 +375,7 @@ class Pods_Component_I18n extends PodsComponent {
 
 		foreach ( $args as $name => $value ) {
 			if ( $this->is_translatable_field( $name ) ) {
-				$args[ $name ] = $this->translate_arg( $value, $name, $object->getArrayCopy() );
+				$args[ $name ] = $this->translate_arg( $value, $name, $object );
 			}
 		}
 
@@ -861,9 +861,13 @@ class Pods_Component_I18n extends PodsComponent {
 		if ( ! array_key_exists( $locale, $this->languages ) ) {
 			return false;
 		}
-		$options = pods_v( 'options', $data, $data );
+		if ( $data instanceof Pods\Whatsit ) {
+			$enable_i18n = $data->get_arg( 'enable_i18n' );
+		} else {
+			$options = pods_v( 'options', $data, $data );
+			$enable_i18n = pods_v( 'enable_i18n', $options, null );
+		}
 
-		$enable_i18n = pods_v( 'enable_i18n', $options, null );
 		if ( null === $enable_i18n ) {
 			// If there are no i18n settings in the object data then assume it's enabled.
 			return true;

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -73,6 +73,7 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		$is_component_page = false;
+		$is_pod_page = false;
 
 		if ( is_admin() && isset( $_GET['page'] ) ) {
 
@@ -81,6 +82,8 @@ class Pods_Component_I18n extends PodsComponent {
 			// Is the current page the admin page of this component or a Pods edit page?
 			if ( $this->admin_page === $page ) {
 				$is_component_page = true;
+			} elseif ( false !== strpos( $page, 'pods' ) ) {
+				$is_pod_page = true;
 			}
 		}
 
@@ -94,6 +97,20 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		if ( $active ) {
+
+			/**
+			 * PODS ADMIN UI.
+			 */
+
+			// Pod.
+			add_filter( 'pods_admin_setup_edit_tabs', array( $this, 'pod_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_options', array( $this, 'pod_options' ), 99, 2 );
+			// Pod Fields.
+			add_filter( 'pods_admin_setup_edit_group_tabs', array( $this, 'pod_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_group_options', array( $this, 'pod_options' ), 99, 2 );
+			// Pod Fields.
+			add_filter( 'pods_admin_setup_edit_field_tabs', array( $this, 'pod_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_field_options', array( $this, 'pod_options' ), 99, 2 );
 
 			/**
 			 * REGISTERING OBJ LABELS.
@@ -115,37 +132,26 @@ class Pods_Component_I18n extends PodsComponent {
 			 * LABEL REPLACEMENT.
 			 */
 
-			// Setting pages.
+			// Menu labels.
 			add_filter( 'pods_admin_menu_page_title', array( $this, 'translate_admin_menu_page_title' ), 10, 2 );
 			add_filter( 'pods_admin_menu_label', array( $this, 'translate_admin_menu_label' ), 10, 2 );
 
-			// Pod Objects.
-			add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );
-			add_filter( 'pods_whatsit_get_description', array( $this, 'translate_description' ), 10, 2 );
-			add_filter( 'pods_whatsit_get_arg', array( $this, 'translate_arg' ), 10, 3 );
+			if ( ! $is_pod_page ) {
 
-			foreach ( pods_form()->field_types() as $type => $data ) {
-				add_filter(
-					'pods_form_ui_field_' . $type . '_options',
-					array( $this, 'translate_field_options' ),
-					10,
-					5
-				);
+				// Pod Objects.
+				add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );
+				add_filter( 'pods_whatsit_get_description', array( $this, 'translate_description' ), 10, 2 );
+				add_filter( 'pods_whatsit_get_arg', array( $this, 'translate_arg' ), 10, 3 );
+
+				foreach ( pods_form()->field_types() as $type => $data ) {
+					add_filter(
+						'pods_form_ui_field_' . $type . '_options',
+						array( $this, 'translate_field_options' ),
+						10,
+						5
+					);
+				}
 			}
-
-			/**
-			 * PODS ADMIN UI.
-			 */
-
-			// Pod.
-			add_filter( 'pods_admin_setup_edit_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_options', array( $this, 'pod_options' ), 99, 2 );
-			// Pod Fields.
-			add_filter( 'pods_admin_setup_edit_group_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_group_options', array( $this, 'pod_options' ), 99, 2 );
-			// Pod Fields.
-			add_filter( 'pods_admin_setup_edit_field_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_field_options', array( $this, 'pod_options' ), 99, 2 );
 
 		}//end if
 	}

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -816,6 +816,7 @@ class Pods_Component_I18n extends PodsComponent {
 					$locale_field             = $field;
 					$locale_field['name']     = $locale_name;
 					$locale_field['label']    = $locale;
+					$locale_field['default']  = '';
 
 					$i18n_fields[][ $locale_name ] = $locale_field;
 				}

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -233,8 +233,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function is_translatable_field( $name ) {
 
-		$translatable_fields = $this->get_translatable_fields();
-		$translatable_fields = array_keys( $translatable_fields );
+		$translatable_fields = $this->get_translatable_fields( 'names' );
 
 		// All fields that start with "label"
 		if ( strpos( $name, 'label' ) === 0 && false === strpos( $name, $this->locale ) ) {
@@ -442,7 +441,7 @@ class Pods_Component_I18n extends PodsComponent {
 			return $options;
 		}
 
-		foreach ( $this->get_translatable_fields() as $field ) {
+		foreach ( $this->get_translatable_fields( 'names' ) as $field ) {
 			$translation = pods_v( $field . '_' . $locale, $options, null );
 			if ( $translation ) {
 				$options[ $field ] = $translation;
@@ -915,9 +914,10 @@ class Pods_Component_I18n extends PodsComponent {
 	}
 
 	/**
+	 * @param string $return Return type (supports 'names').
 	 * @return array
 	 */
-	public function get_translatable_fields() {
+	public function get_translatable_fields( $return = '' ) {
 
 		/**
 		 * Overwrite translatable fields.
@@ -936,6 +936,10 @@ class Pods_Component_I18n extends PodsComponent {
 					$fields[ $value ] = [];
 				}
 			}
+		}
+
+		if ( 'names' === $return ) {
+			return array_keys( $fields );
 		}
 
 		return $fields;

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -122,6 +122,7 @@ class Pods_Component_I18n extends PodsComponent {
 			// Pod Objects.
 			add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );
 			add_filter( 'pods_whatsit_get_description', array( $this, 'translate_description' ), 10, 2 );
+			add_filter( 'pods_whatsit_get_arg', array( $this, 'translate_arg' ), 10, 3 );
 
 			foreach ( pods_form()->field_types() as $type => $data ) {
 				add_filter(
@@ -247,7 +248,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 * @param  string $key     The key / opion name to search for
 	 * @param  array|Pods\Whatsit  $data    Pod data (can also be an options array of a pod or field)
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public function get_value_translation( $current, $key, $data ) {
 
@@ -329,6 +330,23 @@ class Pods_Component_I18n extends PodsComponent {
 	public function translate_description( $description, $object ) {
 
 		return (string) $this->get_value_translation( $description, 'description', $object );
+	}
+
+	/**
+	 * Returns the translated argument if available.
+	 *
+	 * @since 1.0.0
+	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_arg' (filter)
+	 *
+	 * @param  mixed        $arg    The default argument.
+	 * @param  string       $name   The argument name.
+	 * @param  Pods\Whatsit $object The Pod Object.
+	 *
+	 * @return string
+	 */
+	public function translate_arg( $arg, $name, $object ) {
+
+		return $this->get_value_translation( $arg, $name, $object );
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -341,10 +341,10 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Returns the translated argument if available.
 	 *
-	 * @since 1.0.0
+	 * @since 1.1.0
 	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_arg' (filter)
 	 *
-	 * @param  mixed        $arg    The default argument.
+	 * @param  mixed        $arg    The object argument.
 	 * @param  string       $name   The argument name.
 	 * @param  Pods\Whatsit $object The Pod Object.
 	 *
@@ -355,6 +355,7 @@ class Pods_Component_I18n extends PodsComponent {
 		if ( $this->is_translatable_field( $name ) ) {
 			return $this->get_value_translation( $arg, $name, $object );
 		}
+
 		return $arg;
 	}
 

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -38,17 +38,29 @@ class Pods_Component_I18n extends PodsComponent {
 	public $capability           = 'pods_i18n_activate_lanuages';
 	public $nonce                = 'pods_i18n_activate_lanuages';
 
-	public $translatable_fields = array(
-		'label',
-		'description',
-		'placeholder',
-		'menu_name',
-		'name_admin_bar',
-		'pick_select_text',
-		'file_add_button',
-		'file_modal_title',
-		'file_modal_add_button',
-	);
+	/**
+	 * All fields that are translatable.
+	 * @var array
+	 */
+	protected $translatable_fields = [
+		'label' => [],
+		'description' => [],
+		'placeholder' => [],
+		'menu_name' => [],
+		'name_admin_bar' => [],
+		'pick_select_text' => [
+			'depends-on' => [ 'type' => 'pick' ],
+		],
+		'file_add_button' => [
+			'depends-on' => [ 'type' => 'file' ],
+		],
+		'file_modal_title' => [
+			'depends-on' => [ 'type' => 'file' ],
+		],
+		'file_modal_add_button' => [
+			'depends-on' => [ 'type' => 'file' ],
+		],
+	];
 
 	/**
 	 * {@inheritdoc}
@@ -789,6 +801,8 @@ class Pods_Component_I18n extends PodsComponent {
 					continue;
 				}
 
+				$i18n_options = $this->get_translatable_fields_options( $name );
+
 				// None of the i18n fields are required!
 				$field['required'] = false;
 
@@ -796,7 +810,7 @@ class Pods_Component_I18n extends PodsComponent {
 				$heading_field['type'] = 'heading';
 				$heading_field['name'] = $name . '_i18n';
 
-				$i18n_fields[][ $name . '_i18n' ] = $heading_field;
+				$i18n_fields[][ $name . '_i18n' ] = array_merge_recursive( $heading_field, $i18n_options );
 
 				$default_field = $field;
 				$default_field['type'] = 'html';
@@ -806,7 +820,7 @@ class Pods_Component_I18n extends PodsComponent {
 				$default_field['html_content_param'] = $name;
 				$default_field['html_content_param_default'] = '-';
 
-				$i18n_fields[][ $name . '_i18n_default' ] = $default_field;
+				$i18n_fields[][ $name . '_i18n_default' ] = array_merge_recursive( $default_field, $i18n_options );
 
 				foreach ( $this->languages as $locale => $lang_data ) {
 					if ( ! $this->obj_is_language_enabled( $locale, $object ) ) {
@@ -819,7 +833,7 @@ class Pods_Component_I18n extends PodsComponent {
 					$locale_field['label']    = $locale;
 					$locale_field['default']  = '';
 
-					$i18n_fields[][ $locale_name ] = $locale_field;
+					$i18n_fields[][ $locale_name ] = array_merge_recursive( $locale_field, $i18n_options );
 				}
 			}
 		}
@@ -904,7 +918,31 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function get_translatable_fields() {
 
-		return apply_filters( 'pods_translatable_fields', $this->translatable_fields );
+		$fields = array_keys( $this->translatable_fields );
+
+		/**
+		 * Overwrite translatable fields
+		 *
+		 * @since 0.1
+		 * @since 2.8.4 Added second type parameter.
+		 *
+		 * @param string[] $fields The translatable fields.
+		 * @param string   $type   Field type context (if available).
+		 */
+		return apply_filters( 'pods_translatable_fields', $fields );
 	}
 
+	/**
+	 * @return array[]
+	 */
+	public function get_translatable_fields_options( $key = null ) {
+
+		$fields = $this->translatable_fields;
+
+		if ( $key ) {
+			return pods_v( $key, $fields );
+		}
+
+		return $fields;
+	}
 }

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -6,7 +6,7 @@
  *
  * Description: Allow UI of Pods and fields to be translated.
  *
- * Version: 1.0
+ * Version: 1.1
  *
  * Category: I18n
  *

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -156,6 +156,7 @@ class Pods_Component_I18n extends PodsComponent {
 				add_filter( 'pods_whatsit_get_arg', array( $this, 'translate_arg' ), 10, 3 );
 				add_filter( 'pods_whatsit_get_args', array( $this, 'translate_args' ), 10, 2 );
 
+				// Non DFV field UI.
 				foreach ( pods_form()->field_types() as $type => $data ) {
 					add_filter(
 						'pods_form_ui_field_' . $type . '_options',
@@ -223,7 +224,7 @@ class Pods_Component_I18n extends PodsComponent {
 	}
 
 	/**
-	 * Check is a field name is set for translation
+	 * Check is a field name is set for translation.
 	 *
 	 * @since 0.1.0
 	 *

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -801,7 +801,7 @@ class Pods_Component_I18n extends PodsComponent {
 					continue;
 				}
 
-				$i18n_options = $this->get_translatable_fields_options( $name );
+				$i18n_options = $this->get_translatable_field_options( $name );
 
 				// None of the i18n fields are required!
 				$field['required'] = false;
@@ -918,31 +918,32 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function get_translatable_fields() {
 
-		$fields = array_keys( $this->translatable_fields );
-
 		/**
-		 * Overwrite translatable fields
+		 * Overwrite translatable fields.
 		 *
 		 * @since 0.1
-		 * @since 2.8.4 Added second type parameter.
 		 *
 		 * @param string[] $fields The translatable fields.
-		 * @param string   $type   Field type context (if available).
 		 */
-		return apply_filters( 'pods_translatable_fields', $fields );
+		return apply_filters( 'pods_translatable_fields', $this->translatable_fields );
 	}
 
 	/**
+	 * @since 1.1
 	 * @return array[]
 	 */
-	public function get_translatable_fields_options( $key = null ) {
+	public function get_translatable_field_options( $key ) {
 
-		$fields = $this->translatable_fields;
+		$field_options = pods_v( $key, $this->get_translatable_fields(), array() );
 
-		if ( $key ) {
-			return pods_v( $key, $fields );
-		}
-
-		return $fields;
+		/**
+		 * Overwrite translatable field options.
+		 *
+		 * @since 1.1
+		 *
+		 * @param array  $field_options The translatable field options.
+		 * @param string $key           The field name.
+		 */
+		return apply_filters( 'pods_translatable_field_options', $field_options, $key );
 	}
 }

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -103,14 +103,14 @@ class Pods_Component_I18n extends PodsComponent {
 			 */
 
 			// Pod.
-			add_filter( 'pods_admin_setup_edit_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_options', array( $this, 'pod_options' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_tabs', array( $this, 'translation_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_options', array( $this, 'translation_options' ), 99, 2 );
 			// Pod Fields.
-			add_filter( 'pods_admin_setup_edit_group_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_group_options', array( $this, 'pod_options' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_group_tabs', array( $this, 'translation_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_group_options', array( $this, 'translation_options' ), 99, 2 );
 			// Pod Fields.
-			add_filter( 'pods_admin_setup_edit_field_tabs', array( $this, 'pod_tab' ), 99, 2 );
-			add_filter( 'pods_admin_setup_edit_field_options', array( $this, 'pod_options' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_field_tabs', array( $this, 'translation_tab' ), 99, 2 );
+			add_filter( 'pods_admin_setup_edit_field_options', array( $this, 'translation_options' ), 99, 2 );
 
 			/**
 			 * REGISTERING OBJ LABELS.
@@ -763,7 +763,7 @@ class Pods_Component_I18n extends PodsComponent {
 	 *
 	 * @return array
 	 */
-	public function pod_tab( $tabs ) {
+	public function translation_tab( $tabs ) {
 
 		$tabs['i18n'] = __( 'Translations', 'pods' );
 
@@ -771,15 +771,16 @@ class Pods_Component_I18n extends PodsComponent {
 	}
 
 	/**
-	 * The i18n options
+	 * The i18n options.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param  array $options
+	 * @param array              $options
+	 * @param array|Pods\Whatsit $object
 	 *
 	 * @return array
 	 */
-	public function pod_options( $options, $pod ) {
+	public function translation_options( $options, $object ) {
 		$i18n_fields = [];
 
 		foreach ( $options as $tab => $fields ) {
@@ -808,7 +809,7 @@ class Pods_Component_I18n extends PodsComponent {
 				$i18n_fields[][ $name . '_i18n_default' ] = $default_field;
 
 				foreach ( $this->languages as $locale => $lang_data ) {
-					if ( ! $this->obj_is_language_enabled( $locale, (array) $pod ) ) {
+					if ( ! $this->obj_is_language_enabled( $locale, $object ) ) {
 						continue;
 					}
 
@@ -825,7 +826,7 @@ class Pods_Component_I18n extends PodsComponent {
 
 		$options['i18n'] = $i18n_fields;
 
-		// if ( $pod['type'] === '' )
+		// if ( $object['type'] === '' )
 		/*
 		$options[ 'pods-i18n' ] = array(
 			'enabled_languages' => array(

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -346,7 +346,10 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function translate_arg( $arg, $name, $object ) {
 
-		return $this->get_value_translation( $arg, $name, $object );
+		if ( $this->is_translatable_field( $name ) ) {
+			return $this->get_value_translation( $arg, $name, $object );
+		}
+		return $arg;
 	}
 
 	/**

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -888,21 +888,9 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function create_lang_label( $lang_data ) {
 
-		$english_name = '';
-		$native_name  = '';
+		$label       = pods_v( 'english_name', $lang_data, '' );
+		$native_name = pods_v( 'native_name', $lang_data, '' );
 
-		if ( isset( $lang_data['english_name'] ) ) {
-			$english_name = $lang_data['english_name'];
-		}
-		if ( isset( $lang_data['native_name'] ) ) {
-			$native_name = $lang_data['native_name'];
-		}
-
-		$label = '';
-
-		if ( ! empty( $english_name ) ) {
-			$label = $english_name;
-		}
 		if ( ! empty( $native_name ) && $label !== $native_name ) {
 			$label .= ' / ' . $native_name;
 		}

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -350,7 +350,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Returns the translated argument if available.
 	 *
-	 * @since 1.1.0
+	 * @since 2.8.4
 	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_arg' (filter)
 	 *
 	 * @param  mixed        $arg    The object argument.
@@ -371,7 +371,7 @@ class Pods_Component_I18n extends PodsComponent {
 	/**
 	 * Returns the translated arguments if available.
 	 *
-	 * @since 1.1.0
+	 * @since 2.8.4
 	 * @see   \Pods\Whatsit >> 'pods_whatsit_get_args' (filter)
 	 *
 	 * @param  array        $args   The object arguments.

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -148,7 +148,8 @@ class Pods_Component_I18n extends PodsComponent {
 			add_filter( 'pods_admin_menu_page_title', array( $this, 'translate_admin_menu_page_title' ), 10, 2 );
 			add_filter( 'pods_admin_menu_label', array( $this, 'translate_admin_menu_label' ), 10, 2 );
 
-			if ( ! $is_pods_edit_page ) {
+			// Do not overwrite Whatsit object fields if we're editing Pods.
+			if ( ! $is_pods_edit_page && ! pods_doing_json() ) {
 
 				// Pod Objects.
 				add_filter( 'pods_whatsit_get_label', array( $this, 'translate_label' ), 10, 2 );

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -223,7 +223,7 @@ class Pods_Component_I18n extends PodsComponent {
 		$translatable_fields = $this->get_translatable_fields();
 
 		// All fields that start with "label"
-		if ( strpos( $name, 'label' ) === 0 ) {
+		if ( strpos( $name, 'label' ) === 0 && false === strpos( $name, $this->locale ) ) {
 			return true;
 		}
 		// All translatable fields

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -233,26 +233,14 @@ class Pods_Component_I18n extends PodsComponent {
 	 */
 	public function is_translatable_field( $name ) {
 
-		$translatable_fields = $this->get_translatable_fields( 'names' );
-
-		// All fields that start with "label"
+		// All fields that start with "label".
 		if ( strpos( $name, 'label' ) === 0 && false === strpos( $name, $this->locale ) ) {
 			return true;
 		}
-		// All translatable fields
-		if ( in_array( $name, $translatable_fields, true ) ) {
+
+		// All translatable fields.
+		if ( in_array( $name, $this->get_translatable_fields( 'names' ), true ) ) {
 			return true;
-		}
-		// Custom fields data, the name must begin with field_data[
-		if ( strpos( $name, 'field_data[' ) === 0 ) {
-			$name = str_replace( 'field_data[', '', $name );
-			$name = rtrim( $name, ']' );
-			$name = explode( '][', $name );
-			$name = end( $name );
-			// All translatable fields from field_data[ (int) ][ $name ]
-			if ( in_array( $name, $translatable_fields, true ) ) {
-				return true;
-			}
 		}
 
 		return false;

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -931,7 +931,9 @@ class Pods_Component_I18n extends PodsComponent {
 		foreach ( $fields as $name => $value ) {
 			if ( is_string( $value ) ) {
 				unset( $fields[ $name ] );
-				$fields[ $value ] = [];
+				if ( ! isset( $fields[ $value ] ) ) {
+					$fields[ $value ] = [];
+				}
 			}
 		}
 

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -619,7 +619,16 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 			return $default;
 		}//end if
 
-		return $this->args[ $arg ];
+		/**
+		 * Allow filtering the object arguments / options.
+		 *
+		 * @since 2.8.4
+		 *
+		 * @param mixed   $value  The object argument value.
+		 * @param string  $name   The argument name.
+		 * @param Whatsit $object The object.
+		 */
+		return apply_filters( 'pods_whatsit_get_arg', $this->args[ $arg ], $arg, $this );
 	}
 
 	/**

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -800,7 +800,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	/**
 	 * Get list of object arguments.
 	 *
-	 * @return arra List of object arguments.
+	 * @return array List of object arguments.
 	 */
 	public function get_args() {
 		return $this->args;

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -803,7 +803,16 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	 * @return array List of object arguments.
 	 */
 	public function get_args() {
-		return $this->args;
+
+		/**
+		 * Allow filtering the object arguments.
+		 *
+		 * @since 2.8.4
+		 *
+		 * @param array   $args   The object arguments.
+		 * @param Whatsit $object The object.
+		 */
+		return apply_filters( 'pods_whatsit_get_args', $this->args, $this );
 	}
 
 	/**

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -576,11 +576,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 			$arg = 'id';
 		}
 
-		if ( ! isset( $this->args[ $arg ] ) ) {
-			// Maybe only return the default if we need a strict argument.
-			if ( $strict ) {
-				return $default;
-			}
+		if ( ! isset( $this->args[ $arg ] ) && ! $strict ) {
 
 			$table_info_fields = [
 				'object_name',
@@ -616,8 +612,9 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 				}
 			}
 
-			return $default;
 		}//end if
+
+		$value = isset( $this->args[ $arg ] ) ? $this->args[ $arg ] : $default;
 
 		/**
 		 * Allow filtering the object arguments / options.
@@ -628,7 +625,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 		 * @param string  $name   The argument name.
 		 * @param Whatsit $object The object.
 		 */
-		return apply_filters( 'pods_whatsit_get_arg', $this->args[ $arg ], $arg, $this );
+		return apply_filters( 'pods_whatsit_get_arg', $value, $arg, $this );
 	}
 
 	/**

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -803,7 +803,6 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	 * @return array List of object arguments.
 	 */
 	public function get_args() {
-
 		/**
 		 * Allow filtering the object arguments.
 		 *


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR adds a filter to modify all Pod Whatsit args.
The i18n component uses this filter to modify other existing args where needed.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6265 (confirmed)

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->
Pods i18n component v1.1

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
