### PR TITLE
Customize Color field labels

### DIFF
--- a/classes/fields/color.php
+++ b/classes/fields/color.php
@@ -44,16 +44,16 @@ class PodsField_Color extends PodsField {
 				'developer_mode'    => true,
 			),
 			static::$type . '_select_label'   => array(
-				'label'   => __( 'Select Label', 'pods' ),
-				'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Select Color', 'pods' ),
-				'default' => '',
-				'type'    => 'text',
+				'label'       => __( 'Select Color Label', 'pods' ),
+				'placeholder' => __( 'Select Color', 'pods' ),
+				'default'     => '',
+				'type'        => 'text',
 			),
 			static::$type . '_clear_label'   => array(
-				'label'   => __( 'Clear Label', 'pods' ),
-				'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Clear', 'pods' ),
-				'default' => '',
-				'type'    => 'text',
+				'label'       => __( 'Clear Label', 'pods' ),
+				'placeholder' => __( 'Clear', 'pods' ),
+				'default'     => '',
+				'type'        => 'text',
 			),
 		);
 

--- a/classes/fields/color.php
+++ b/classes/fields/color.php
@@ -45,11 +45,13 @@ class PodsField_Color extends PodsField {
 			),
 			static::$type . '_select_label'   => array(
 				'label'   => __( 'Select Label', 'pods' ),
+				'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Select Color', 'pods' ),
 				'default' => '',
 				'type'    => 'text',
 			),
 			static::$type . '_clear_label'   => array(
 				'label'   => __( 'Clear Label', 'pods' ),
+				'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Clear', 'pods' ),
 				'default' => '',
 				'type'    => 'text',
 			),

--- a/classes/fields/color.php
+++ b/classes/fields/color.php
@@ -43,6 +43,16 @@ class PodsField_Color extends PodsField {
 				'dependency'        => true,
 				'developer_mode'    => true,
 			),
+			static::$type . '_select_label'   => array(
+				'label'   => __( 'Select Label', 'pods' ),
+				'default' => '',
+				'type'    => 'text',
+			),
+			static::$type . '_clear_label'   => array(
+				'label'   => __( 'Clear Label', 'pods' ),
+				'default' => '',
+				'type'    => 'text',
+			),
 		);
 
 		return $options;

--- a/classes/fields/color.php
+++ b/classes/fields/color.php
@@ -101,6 +101,14 @@ class PodsField_Color extends PodsField {
 			return pods_view( PODS_DIR . 'ui/fields/' . $field_type . '.php', compact( array_keys( get_defined_vars() ) ) );
 		}
 
+		// Default labels.
+		if ( empty( $options[ static::$type . '_select_label' ] ) ) {
+			$options[ static::$type . '_select_label' ] = __( 'Select Color', 'pods' );
+		}
+		if ( empty( $options[ static::$type . '_clear_label' ] ) ) {
+			$options[ static::$type . '_clear_label' ] = __( 'Clear', 'pods' );
+		}
+
 		wp_enqueue_script( 'pods-dfv' );
 
 		$type = pods_v( 'type', $options, static::$type );

--- a/ui/js/dfv/src/config/prop-types.js
+++ b/ui/js/dfv/src/config/prop-types.js
@@ -189,6 +189,8 @@ export const FIELD_PROP_TYPE = {
 
 	// Color fields
 	color_repeatable: BOOLEAN_ALL_TYPES,
+	color_select_label: PropTypes.string,
+	color_clear_label: PropTypes.string,
 
 	// Currency fields
 	currency_decimal_handling: PropTypes.string,

--- a/ui/js/dfv/src/fields/color/index.js
+++ b/ui/js/dfv/src/fields/color/index.js
@@ -14,7 +14,13 @@ const Color = ( {
 	value,
 	setHasBlurred,
 } ) => {
-	const { name } = fieldConfig;
+	const {
+		name,
+		color_select_label: selectLabel = __( 'Select Color', 'pods' ),
+		color_clear_label: clearLabel = __( 'Clear', 'pods' ),
+	} = fieldConfig;
+
+	console.log( fieldConfig );
 
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -36,7 +42,7 @@ const Color = ( {
 				>
 					<ColorIndicator colorValue={ value || '' } />
 
-					{ __( 'Select Color', 'pods' ) }
+					{ selectLabel }
 				</button>
 
 				{ value && (
@@ -47,7 +53,7 @@ const Color = ( {
 						} }
 						className="button"
 					>
-						{ __( 'Clear', 'pods' ) }
+						{ clearLabel }
 					</button>
 				) }
 			</div>


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR will add two options to customize the color field labels.

Note: the placeholder options do not work because of this issue: #6275 

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6274 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
