### PR TITLE
Customize Pick field label "Add New"

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -237,10 +237,10 @@ class PodsField_Pick extends PodsField {
 				'default'     => 1,
 			],
 			static::$type . '_add_new_label'            => array(
-					'label'   => __( 'Add New Label', 'pods' ),
-					'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Add New', 'pods' ),
-					'default' => '',
-					'type'    => 'text',
+					'label'       => __( 'Add New Label', 'pods' ),
+					'placeholder' => __( 'Add New', 'pods' ),
+					'default'     => '',
+					'type'        => 'text',
 			),
 			static::$type . '_taggable'                 => [
 				'label'          => __( 'Taggable', 'pods' ),

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -236,6 +236,12 @@ class PodsField_Pick extends PodsField {
 				'type'        => 'boolean',
 				'default'     => 1,
 			],
+			static::$type . '_add_new_label'            => array(
+					'label'   => __( 'Add New Label', 'pods' ),
+					'help'    => __( 'Default', 'pods' ) . ': ' . __( 'Add New', 'pods' ),
+					'default' => '',
+					'type'    => 'text',
+			),
 			static::$type . '_taggable'                 => [
 				'label'          => __( 'Taggable', 'pods' ),
 				'help'           => __( 'Allow new values to be inserted when using an Autocomplete field', 'pods' ) . ' ' . $fallback_help,
@@ -886,6 +892,11 @@ class PodsField_Pick extends PodsField {
 		$options = ( is_array( $options ) || is_object( $options ) ) ? $options : (array) $options;
 
 		// Do anything we need to do here with options setup / enforcement.
+
+		// Default labels.
+		if ( empty( $options[ static::$type . '_add_new_label' ] ) ) {
+			$options[ static::$type . '_add_new_label' ] = __( 'Add New', 'pods' );
+		}
 
 		parent::input( $name, $value, $options, $pod, $id );
 	}

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -241,6 +241,7 @@ class PodsField_Pick extends PodsField {
 					'placeholder' => __( 'Add New', 'pods' ),
 					'default'     => '',
 					'type'        => 'text',
+					'depends-on'  => [ static::$type . '_allow_add_new' => true ]
 			),
 			static::$type . '_taggable'                 => [
 				'label'          => __( 'Taggable', 'pods' ),

--- a/ui/js/dfv/src/config/prop-types.js
+++ b/ui/js/dfv/src/config/prop-types.js
@@ -382,6 +382,7 @@ export const FIELD_PROP_TYPE = {
 	),
 	pick_ajax: BOOLEAN_ALL_TYPES,
 	pick_allow_add_new: BOOLEAN_ALL_TYPES,
+	pick_add_new_label: PropTypes.string,
 	pick_custom: PropTypes.string,
 	pick_display: PropTypes.string,
 	pick_display_format_multi: PropTypes.string,

--- a/ui/js/dfv/src/fields/pick/index.js
+++ b/ui/js/dfv/src/fields/pick/index.js
@@ -139,6 +139,7 @@ const Pick = ( props ) => {
 			iframe_title_add: addNewIframeTitle,
 			iframe_title_edit: editIframeTitle,
 			pick_allow_add_new: allowAddNew,
+			pick_add_new_label: addNewLabel = __( 'Add New', 'pods' ),
 			// pick_custom: pickCustomOptions,
 			// pick_display,
 			// pick_display_format_multi,
@@ -509,7 +510,7 @@ const Pick = ( props ) => {
 					onClick={ () => setShowAddNewIframe( true ) }
 					isSecondary
 				>
-					{ __( 'Add New', 'pods', ) }
+					{ addNewLabel }
 				</Button>
 			) : null }
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR will add an option to customize the "Add New" label for a pick field.

Note: the placeholder options do not work because of this issue: #6275

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6277 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
