### PR TITLE
Fix i18n loop since 2.8.6

### DIFF
--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -229,6 +229,11 @@ final class PodsI18n {
 
 		$args = wp_parse_args( $args, $defaults );
 
+		if ( doing_filter( 'pods_get_current_language' ) ) {
+			// Prevent loop.
+			$args['refresh'] = false;
+		}
+
 		if ( ! $args['refresh'] ) {
 			return self::$current_language;
 		}

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -277,12 +277,17 @@ final class PodsI18n {
 	public function get_current_language_context( $args = array() ) {
 
 		$defaults = array(
-			'refresh' => false,
+			'refresh' => empty( self::$current_language_context ),
 		);
 
 		$args = wp_parse_args( $args, $defaults );
 
-		if ( ! $args['refresh'] && ! empty( self::$current_language_context ) ) {
+		if ( doing_filter( 'pods_get_current_language_context' ) ) {
+			// Prevent loop.
+			$args['refresh'] = false;
+		}
+
+		if ( ! $args['refresh'] ) {
 			return self::$current_language_context;
 		}
 

--- a/classes/PodsI18n.php
+++ b/classes/PodsI18n.php
@@ -224,12 +224,12 @@ final class PodsI18n {
 	public function get_current_language( $args = array() ) {
 
 		$defaults = array(
-			'refresh' => false,
+			'refresh' => empty( self::$current_language ),
 		);
 
 		$args = wp_parse_args( $args, $defaults );
 
-		if ( ! $args['refresh'] && ! empty( self::$current_language ) ) {
+		if ( ! $args['refresh'] ) {
 			return self::$current_language;
 		}
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
The changes in 2.8.6 created a loop in getting the current language when using Polylang and having the User object extended.
This is because the Polylang integration uses `get_user_meta` which in turn calls get_current_language again.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #6334 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
