### PR TITLE
Wrong usage of is_type_covered(), should do the opposite

### DIFF
--- a/ui/admin/setup-add.php
+++ b/ui/admin/setup-add.php
@@ -402,7 +402,7 @@ $quick_actions = apply_filters( 'pods_admin_setup_add_quick_actions', $quick_act
 										$post_types = get_post_types();
 
 										foreach ( $post_types as $post_type => $label ) {
-											if ( empty( $post_type ) || isset( $ignore[ $post_type ] ) || 0 === strpos( $post_type, '_pods_' ) || $pods_meta->is_type_covered( 'post_type', $post_type ) ) {
+											if ( empty( $post_type ) || isset( $ignore[ $post_type ] ) || 0 === strpos( $post_type, '_pods_' ) || ! $pods_meta->is_type_covered( 'post_type', $post_type ) ) {
 												// Post type is ignored
 												unset( $post_types[ $post_type ] );
 
@@ -434,7 +434,7 @@ $quick_actions = apply_filters( 'pods_admin_setup_add_quick_actions', $quick_act
 										$taxonomies = get_taxonomies();
 
 										foreach ( $taxonomies as $taxonomy => $label ) {
-											if ( empty( $taxonomy ) || isset( $ignore[ $taxonomy ] ) || 0 === strpos( $taxonomy, '_pods_' ) || $pods_meta->is_type_covered( 'taxonomy', $taxonomy ) ) {
+											if ( empty( $taxonomy ) || isset( $ignore[ $taxonomy ] ) || 0 === strpos( $taxonomy, '_pods_' ) || ! $pods_meta->is_type_covered( 'taxonomy', $taxonomy ) ) {
 												// Taxonomy is ignored
 												unset( $taxonomies[ $taxonomy ] );
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #6358 

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
