### PR TITLE
Fix warning on 404 term pages

### DIFF
--- a/src/Pods/Theme/WP_Query_Integration.php
+++ b/src/Pods/Theme/WP_Query_Integration.php
@@ -47,6 +47,7 @@ class WP_Query_Integration {
 		if (
 			! empty( $query->query_vars['suppress_filters'] )
 			|| ! $query->is_main_query()
+			|| $query->is_404()
 			|| (
 				! $query->is_category()
 				&& ! $query->is_tag()

--- a/src/Pods/Theme/WP_Query_Integration.php
+++ b/src/Pods/Theme/WP_Query_Integration.php
@@ -55,7 +55,13 @@ class WP_Query_Integration {
 			return;
 		}
 
-		$taxonomy = $query->get_queried_object()->taxonomy;
+		$object = $query->get_queried_object();
+
+		if ( ! isset( $object->taxonomy ) ) {
+			return;
+		}
+
+		$taxonomy = $object->taxonomy;
 
 		// Find all CPT that have this taxonomy set.
 		$api = pods_api();


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
When accessing a 404 term archive Pods generates a warning.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6383 

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
