### PR TITLE
Use `pods_trim` instead of `trim` to accept other var types

### DIFF
--- a/src/Pods/Blocks/Types/Field.php
+++ b/src/Pods/Blocks/Types/Field.php
@@ -136,7 +136,7 @@ class Field extends Base {
 	 */
 	public function render( $attributes = [], $content = '', $block = null ) {
 		$attributes = $this->attributes( $attributes );
-		$attributes = array_map( 'trim', $attributes );
+		$attributes = array_map( 'pods_trim', $attributes );
 
 		if ( empty( $attributes['field'] ) ) {
 			if ( wp_is_json_request() && did_action( 'rest_api_init' ) ) {

--- a/src/Pods/Blocks/Types/Form.php
+++ b/src/Pods/Blocks/Types/Form.php
@@ -216,7 +216,7 @@ class Form extends Base {
 	 */
 	public function render( $attributes = [], $content = '', $block = null ) {
 		$attributes = $this->attributes( $attributes );
-		$attributes = array_map( 'trim', $attributes );
+		$attributes = array_map( 'pods_trim', $attributes );
 
 		// Prevent any previews of this block.
 		if ( wp_is_json_request() && did_action( 'rest_api_init' ) ) {

--- a/src/Pods/Blocks/Types/Item_List.php
+++ b/src/Pods/Blocks/Types/Item_List.php
@@ -369,7 +369,7 @@ class Item_List extends Base {
 	 */
 	public function render( $attributes = [], $content = '', $block = null ) {
 		$attributes = $this->attributes( $attributes );
-		$attributes = array_map( 'trim', $attributes );
+		$attributes = array_map( 'pods_trim', $attributes );
 
 		if ( empty( $attributes['template'] ) && empty( $attributes['template_custom'] ) ) {
 			if ( wp_is_json_request() && did_action( 'rest_api_init' ) ) {

--- a/src/Pods/Blocks/Types/Item_Single.php
+++ b/src/Pods/Blocks/Types/Item_Single.php
@@ -218,7 +218,7 @@ class Item_Single extends Base {
 	 */
 	public function render( $attributes = [], $content = '', $block = null ) {
 		$attributes = $this->attributes( $attributes );
-		$attributes = array_map( 'trim', $attributes );
+		$attributes = array_map( 'pods_trim', $attributes );
 
 		if (
 			empty( $attributes['template'] )

--- a/src/Pods/Blocks/Types/View.php
+++ b/src/Pods/Blocks/Types/View.php
@@ -140,7 +140,7 @@ class View extends Base {
 	 */
 	public function render( $attributes = [], $content = '', $block = null ) {
 		$attributes = $this->attributes( $attributes );
-		$attributes = array_map( 'trim', $attributes );
+		$attributes = array_map( 'pods_trim', $attributes );
 
 		if ( empty( $attributes['view'] ) ) {
 			if ( wp_is_json_request() && did_action( 'rest_api_init' ) ) {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Fixes #6386 

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
