### PR TITLE
Retain backwards compatibility with field name passed for pick fields

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -2789,7 +2789,12 @@ class PodsData {
 								$table = $the_field->get_table_info();
 
 								if ( ! empty( $table ) ) {
-									$field_cast = "`{$field_name}`.`" . $table['field_id'] . '`';
+									if ( is_int( $field_value ) ) {
+										$field_cast = "`{$field_name}`.`" . $table['field_id'] . '`';
+									} else {
+										// Prior to 2.8 this was the default query, retain backwards compatibility
+										$field_cast = "`{$field_name}`.`" . $table['field_index'] . '`';
+									}
 								}
 							}
 						} elseif ( ! in_array( $pod['type'], [ 'pod', 'table' ], true ) ) {


### PR DESCRIPTION
## Description

The change here https://github.com/pods-framework/pods/commit/55d150b631d153a29ae6fa8afca55226dd2727bc broke query generation on pick fields that don't have an explicit reference.  

For years now I've had code that called
```
$where = array( array( 'key' => 'style_revision', 'value' => '2015' ) );
$params = array( 'where' => $where, 'limit' => 16 );
$pod->find($params);

```

This stopped working with 2.8.  I can fix it in my code by changing the key to `style_revision.post_title` which might have always been the proper way to do it but we should retain backwards compatibility.