### PR TITLE
Error prevention in WP_Query_Integration

### DIFF
--- a/src/Pods/Theme/WP_Query_Integration.php
+++ b/src/Pods/Theme/WP_Query_Integration.php
@@ -45,7 +45,8 @@ class WP_Query_Integration {
 
 		// Skip if not on the archive we want.
 		if (
-			! empty( $query->query_vars['suppress_filters'] )
+			empty( $query->get_queried_object() )
+			|| ! empty( $query->query_vars['suppress_filters'] )
 			|| ! $query->is_main_query()
 			|| (
 				! $query->is_category()


### PR DESCRIPTION
It can happen that query_posts incorrectly results in a category query. Then the get_queried_object is empty and PHP throws a notice that it is trying to retrieve a property from an empty object.

So it is better to check that get_queried_object is not empty.
