### PR TITLE
Support a json string for field config

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -3762,7 +3762,13 @@ class Pods implements Iterator {
 		$form_fields = $params['fields'];
 
 		if ( null !== $form_fields && ! is_array( $form_fields ) && 0 < strlen( $form_fields ) ) {
-			$form_fields = explode( ',', $form_fields );
+			$json_form_fields = @json_decode( $form_fields, true );
+			if ( is_array( $json_form_fields ) ) {
+				$form_fields = $json_form_fields;
+			} else {
+				// Regular comma separated string.
+				$form_fields = explode( ',', $form_fields );
+			}
 		}
 
 		$all_fields = pods_config_get_all_fields( $this->pod_data );


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR allows a JSON string to be passed as a field configuration array for Pods Forms.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6435 

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See '....'

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
