### PR TITLE
Refresh language cache after WPML has switch language.

### DIFF
--- a/src/Pods/Integrations/WPML.php
+++ b/src/Pods/Integrations/WPML.php
@@ -15,7 +15,9 @@ class WPML extends Integration {
 	 * @inheritdoc
 	 */
 	protected $hooks = [
-		'action' => [],
+		'action' => [
+			'wpml_language_has_switched', [ 'wpml_language_has_switched' ],
+		],
 		'filter' => [
 			'pods_get_current_language' => [ 'pods_get_current_language', 10, 2 ],
 			'pods_api_get_table_info' => [ 'pods_api_get_table_info', 10, 7 ],
@@ -32,6 +34,19 @@ class WPML extends Integration {
 	 */
 	public static function is_active() {
 		return defined( 'ICL_SITEPRESS_VERSION' ) || ! empty( $GLOBALS['sitepress'] );
+	}
+
+	/**
+	 * Refresh language cache after WPML has switch language.
+	 *
+	 * @since 2.8.11
+	 *
+	 * @see \SitePress::switch_lang()
+	 *
+	 * @return void
+	 */
+	public function wpml_language_has_switched() {
+		pods_i18n()->get_current_language( array( 'refresh' => true ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #6448 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->
- Compatibility: Refresh language cache after WPML switched language.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
