### PR TITLE
Fix term autotemplates

### DIFF
--- a/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Front_End.php
+++ b/components/Templates/includes/auto-template/Pods_Templates_Auto_Template_Front_End.php
@@ -67,7 +67,7 @@ class Pods_Templates_Auto_Template_Front_End {
 				$pod = $obj->post_type;
 				break;
 			case $obj instanceof WP_Term:
-				$pod = $obj->name;
+				$pod = $obj->taxonomy;
 				break;
 			case $obj instanceof WP_User:
 				$pod = 'user';


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
The object param used to check for a Pod was incorrect.
This PR returns the option to use auto templates for term archives (description or other custom hook)

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6368

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Create taxonomy
2. Make sure your theme used a hook for taxonomy archives (archive.php). Default: `the_archive_description()`
3. Add auto template
4. Should be visible!

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
