### PR TITLE
Fix for multi-select fields having values imploded when saved on older ajax forms

### DIFF
--- a/ui/js/jquery.pods.js
+++ b/ui/js/jquery.pods.js
@@ -216,8 +216,16 @@
                             	value = null;
 							}
 
+							// Fix for FormData converting arrays into comma-separated strings.
                             if ( null !== value ) {
-                                postdata.append( field_name, value );
+								if ( field_name.endsWith( '[]' ) && Array.isArray( value ) ) {
+									value.forEach( ( subvalue ) => {
+										postdata.append( field_name, subvalue );
+									} );
+								} else {
+									postdata.append( field_name, value );
+								}
+
                             }
                         }
                     } );


### PR DESCRIPTION
## Description

Fix for multi-select fields having values imploded when saved on Pods ajax forms.

## Related GitHub issue(s)

Fixes https://github.com/pods-framework/pods/issues/6216

## Testing instructions

Use package from https://github.com/pods-framework/pods/issues/6216#issuecomment-1076280688, and try replicating the issue. 

## Changelog text for these changes

Fix: Fix for multi-select fields having values imploded when saved on Pods ajax forms.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
