### PR TITLE
Make sure the Pod is extended before handling changed fields

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5688,7 +5688,7 @@ class PodsAPI {
 			if ( 'get' === $mode ) {
 				$changed_fields_cache[ $cache_key ] = array();
 
-				if ( ! empty( $changed_pods_cache[ $pod ] ) ) {
+				if ( ! empty( $changed_pods_cache[ $pod ] ) && $changed_pods_cache[ $pod ]->valid() ) {
 					if ( $id != $changed_pods_cache[ $pod ]->id() ) {
 						$changed_pods_cache[ $pod ]->fetch( $id );
 					}


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
The `get` method didn't check the whether the Pod object is `valid` (extended or even is a Pod).
This PR adds a simple check to prevent export handling of non-Pods objects.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
#6521 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
