### PR TITLE
Pre-process relationships during save_pod_item() so that is done before saving to table storage as well

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5040,11 +5040,19 @@ class PodsAPI {
 			}
 
 			// WPML AJAX compatibility
-			if ( is_admin()
-				&& ( isset( $_POST['action'] ) && 'wpml_save_job_ajax' === $_POST['action'] )
-				|| ( isset( $_GET['page'] ) && false !== strpos( $_GET['page'], '/menu/languages.php' )
-					&& isset( $_POST['icl_ajx_action'] ) && isset( $_POST['_icl_nonce'] )
-					&& wp_verify_nonce( $_POST['_icl_nonce'], $_POST['icl_ajx_action'] . '_nonce' ) )
+			if (
+				is_admin()
+				&& (
+					(
+						isset( $_POST['action'] )
+						&& 'wpml_save_job_ajax' === $_POST['action']
+					)
+					|| (
+						isset( $_GET['page'], $_POST['icl_ajx_action'], $_POST['_icl_nonce'] )
+						&& false !== strpos( $_GET['page'], '/menu/languages.php' )
+						&& wp_verify_nonce( $_POST['_icl_nonce'], $_POST['icl_ajx_action'] . '_nonce' )
+					)
+				)
 			) {
 				$options['unique']            = 0;
 				$fields[ $field ]['unique']   = 0;

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5327,7 +5327,7 @@ class PodsAPI {
 		/**
 		 * Allow filtering the list of processed data values that will be used to do the final save.
 		 *
-		 * @since TBD
+		 * @since 2.8.22
 		 *
 		 * @param array $data_to_save The list of processed data values that will be used to do the final save.
 		 */
@@ -5504,10 +5504,12 @@ class PodsAPI {
 	/**
 	 * Prepare file/relationship data to be saved.
 	 *
-	 * @param \Pods\Whatsit\Pod|array $pod The Pod object.
-	 * @param \Pods\Whatsit\Field|array $field The field object.
-	 * @param array $values The values to be prepared.
-	 * @param array $pieces The pieces used for filtering. @todo Figure this out.
+	 * @since 2.8.22
+	 *
+	 * @param Pod|array   $pod    The Pod object.
+	 * @param Field|array $field  The field object.
+	 * @param array       $values The values to be prepared.
+	 * @param array       $pieces The pieces used for filtering.
 	 *
 	 * @return array|null The value_ids and field_save_values information used to save relationships data with, or null if field type is not tableless or is a simple relationship.
 	 */
@@ -9321,7 +9323,7 @@ class PodsAPI {
 			/**
 			 * Allow filtering whether bidirectional fallback should be used for podsrel table lookups.
 			 *
-			 * @since TBD
+			 * @since 2.8.22
 			 *
 			 * @param bool   $bidirectional_fallback The list of related IDs found.
 			 * @param int    $sister_id              The bidirectional sister field ID.

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5664,7 +5664,7 @@ class PodsAPI {
 							 *
 							 * @since 2.3.19
 							 */
-							$tag_data = apply_filters( 'pods_api_save_pod_item_taggable_data', $tag_data, $v, $search_data, $field, compact( $pieces ) );
+							$tag_data = apply_filters( 'pods_api_save_pod_item_taggable_data', $tag_data, $v, $search_data, $field, $pieces );
 
 							// Save $v to a new item on related object
 							$v = $search_data->add( $tag_data );

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -9265,6 +9265,8 @@ class PodsAPI {
 		} elseif ( ! $params->force_meta && ! pods_tableless() && pods_podsrel_enabled( $params->field, 'lookup' ) ) {
 			$params->field_id  = (int) $params->field_id;
 
+			$ids_in = implode( ', ', array_fill( 0, count( $params->ids ), '%d' ) );
+
 			$sister_id = pods_v( 'sister_id', $params->field, 0 );
 
 			if ( is_numeric( $sister_id ) ) {
@@ -9279,12 +9281,18 @@ class PodsAPI {
 				SELECT item_id, related_item_id
 				FROM `@wp_podsrel`
 				WHERE
-					`field_id` = {$params->field_id}
-					AND `item_id` IN ( {$idstring} )
+					`field_id` = %d
+					AND `item_id` IN ( {$ids_in} )
 				ORDER BY `weight`
 			";
 
-			$relationships = pods_query( $sql );
+			$prepare = [
+				$params->field_id,
+			];
+
+			$prepare = array_merge( $prepare, $params->ids );
+
+			$relationships = pods_query_prepare( $sql, $prepare );
 
 			if ( ! empty( $relationships ) ) {
 				foreach ( $relationships as $relation ) {
@@ -9317,12 +9325,12 @@ class PodsAPI {
 					SELECT item_id, related_item_id
 					FROM `@wp_podsrel`
 					WHERE
-						`related_field_id` = {$params->field_id}
-						AND `related_item_id` IN ( {$idstring} )
+						`related_field_id` = %d
+						AND `related_item_id` IN ( {$ids_in} )
 					ORDER BY `weight`
 				";
 
-				$relationships = pods_query( $sql );
+				$relationships = pods_query_prepare( $sql, $prepare );
 
 				if ( ! empty( $relationships ) ) {
 					foreach ( $relationships as $relation ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -9327,7 +9327,7 @@ class PodsAPI {
 						$gathered_ids[ (int) $relation->item_id ] = [];
 					}
 
-					$gathered_ids[ (int) $relation->item_id ] = (int) $relation->related_item_id;
+					$gathered_ids[ (int) $relation->item_id ][] = (int) $relation->related_item_id;
 				}
 			}
 
@@ -9365,7 +9365,7 @@ class PodsAPI {
 							$gathered_ids[ (int) $relation->related_item_id ] = [];
 						}
 
-						$gathered_ids[ (int) $relation->related_item_id ] = (int) $relation->item_id;
+						$gathered_ids[ (int) $relation->related_item_id ][] = (int) $relation->item_id;
 					}
 				}
 			}

--- a/includes/general.php
+++ b/includes/general.php
@@ -61,6 +61,25 @@ function pods_query( $sql, $error = 'Database Error', $results_error = null, $no
 }
 
 /**
+ * Prepare and run the query.
+ *
+ * @since 2.8.22
+ *
+ * @see   PodsData::query
+ *
+ * @param string $sql              SQL Query
+ * @param array  $prepare          Variables to prepare for the SQL query.
+ * @param string $error            (optional) The failure message
+ * @param string $results_error    (optional) Throw an error if a records are found
+ * @param string $no_results_error (optional) Throw an error if no records are found
+ *
+ * @return array|bool|mixed|null|void
+ */
+function pods_query_prepare( $sql, $prepare, $error = 'Database Error', $results_error = null, $no_results_error = null ) {
+	return pods_query( [ $sql, $prepare ], $error, $results_error, $no_results_error );
+}
+
+/**
  * Standardize filters / actions
  *
  * @param string $scope Scope of the filter / action (ui for PodsUI, api for PodsAPI, etc..)

--- a/src/Pods/Whatsit/Field.php
+++ b/src/Pods/Whatsit/Field.php
@@ -339,7 +339,7 @@ class Field extends Whatsit {
 	/**
 	 * Get whether the field allows for single or multi tableless field values.
 	 *
-	 * @since TBD
+	 * @since 2.8.22
 	 *
 	 * @return string Whether the field allows for single or multi tableless field values.
 	 */

--- a/src/Pods/Whatsit/Field.php
+++ b/src/Pods/Whatsit/Field.php
@@ -68,26 +68,26 @@ class Field extends Whatsit {
 
 		$special_args = [
 			// Pod args.
-			'pod_id'             => 'get_parent_id',
-			'pod'                => 'get_parent_name',
-			'pod_name'           => 'get_parent_name',
-			'pod_identifier'     => 'get_parent_identifier',
-			'pod_label'          => 'get_parent_label',
-			'pod_description'    => 'get_parent_description',
-			'pod_object'         => 'get_parent_object',
-			'pod_object_type'    => 'get_parent_object_type',
+			'pod_id'                    => 'get_parent_id',
+			'pod'                       => 'get_parent_name',
+			'pod_name'                  => 'get_parent_name',
+			'pod_identifier'            => 'get_parent_identifier',
+			'pod_label'                 => 'get_parent_label',
+			'pod_description'           => 'get_parent_description',
+			'pod_object'                => 'get_parent_object',
+			'pod_object_type'           => 'get_parent_object_type',
 			'pod_object_storage_type'   => 'get_parent_object_storage_type',
-			'pod_type'           => 'get_parent_type',
+			'pod_type'                  => 'get_parent_type',
 			// Group args.
-			'group_id'           => 'get_group_id',
-			'group_name'         => 'get_group_name',
-			'group_identifier'   => 'get_group_identifier',
-			'group_label'        => 'get_group_label',
-			'group_description'  => 'get_group_description',
-			'group_object'       => 'get_group_object',
-			'group_object_type'  => 'get_group_object_type',
+			'group_id'                  => 'get_group_id',
+			'group_name'                => 'get_group_name',
+			'group_identifier'          => 'get_group_identifier',
+			'group_label'               => 'get_group_label',
+			'group_description'         => 'get_group_description',
+			'group_object'              => 'get_group_object',
+			'group_object_type'         => 'get_group_object_type',
 			'group_object_storage_type' => 'get_group_object_storage_type',
-			'group_type'         => 'get_group_type',
+			'group_type'                => 'get_group_type',
 		];
 
 		if ( isset( $special_args[ $arg ] ) ) {

--- a/src/Pods/Whatsit/Field.php
+++ b/src/Pods/Whatsit/Field.php
@@ -327,14 +327,30 @@ class Field extends Whatsit {
 	 * @return int The field value limit.
 	 */
 	public function get_limit() {
-		$type   = $this->get_type();
-		$format = $this->get_arg( $type .'_format_type', 'single' );
+		$type = $this->get_type();
 
-		if ( 'multi' === $format ) {
-			return (int) $this->get_arg( $type . '_limit', 0 );
+		if ( 'multi' === $this->get_single_multi() ) {
+			return (int) $this->get_type_arg( '_limit', 0 );
 		}
 
 		return 1;
+	}
+
+	/**
+	 * Get whether the field allows for single or multi tableless field values.
+	 *
+	 * @since TBD
+	 *
+	 * @return string Whether the field allows for single or multi tableless field values.
+	 */
+	public function get_single_multi() {
+		$format_type = $this->get_arg( $this->get_type() .'_format_type', 'single' );
+
+		if ( ! $format_type ) {
+			return 'single';
+		}
+
+		return $format_type;
 	}
 
 	/**


### PR DESCRIPTION
This work ensures better support for table-based relationships and any other plugins that want to filter the final data before the saving processes for relationships/data/meta.