### PR TITLE
Implement prepare handling directly in PodsData::get_sql()

### DIFF
--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -394,7 +394,7 @@ class PodsData {
 		}
 
 		// Check for pod object.
-		if ( $table['pod'] instanceof Pod ) {
+		if ( ! empty( $table['pod'] ) && $table['pod'] instanceof Pod ) {
 			$this->pod_data = $table['pod'];
 		} else {
 			$this->table_info = $table;

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -2386,16 +2386,21 @@ class PodsData {
 		// Handle Preparations of Values (sprintf format).
 		if ( is_array( $sql ) ) {
 			if ( isset( $sql[0] ) && 1 < count( $sql ) ) {
+				$sql = array_values( $sql );
+
 				if ( 2 === count( $sql ) ) {
 					if ( ! is_array( $sql[1] ) ) {
-						$sql[1] = array( $sql[1] );
+						$sql[1] = [
+							$sql[1],
+						];
 					}
 
 					$params->sql = self::prepare( $sql[0], $sql[1] );
-				} elseif ( 3 === count( $sql ) ) {
-					$params->sql = self::prepare( $sql[0], array( $sql[1], $sql[2] ) );
 				} else {
-					$params->sql = self::prepare( $sql[0], array( $sql[1], $sql[2], $sql[3] ) );
+					$sql_query = array_shift( $sql );
+					$prepare   = $sql;
+
+					$params->sql = self::prepare( $sql_query, $prepare );
 				}
 			} else {
 				$params = (object) array_merge( get_object_vars( $params ), $sql );
@@ -3698,6 +3703,8 @@ class PodsData {
 	 * Get the complete sql
 	 *
 	 * @since 2.0.5
+	 *
+	 * @param string|array $sql The SQL query, optionally an array with the query first and the variables to prepare after that.
 	 */
 	public function get_sql( $sql = '' ) {
 
@@ -3705,6 +3712,25 @@ class PodsData {
 
 		if ( empty( $sql ) ) {
 			$sql = $this->sql;
+		}
+
+		if ( is_array( $sql ) ) {
+			$sql = array_values( $sql );
+
+			if ( 2 === count( $sql ) ) {
+				if ( ! is_array( $sql[1] ) ) {
+					$sql[1] = [
+						$sql[1],
+					];
+				}
+
+				$sql = self::prepare( $sql[0], $sql[1] );
+			} else {
+				$sql_query = array_shift( $sql );
+				$prepare   = $sql;
+
+				$sql = self::prepare( $sql_query, $prepare );
+			}
 		}
 
 		/**

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -685,7 +685,7 @@ class PodsField_File extends PodsField {
 			];
 		}
 
-		$value = array_unique( array_filter( $value ) );
+		$value = array_unique( array_filter( $value ), SORT_REGULAR );
 
 		// Handle File title saving.
 		foreach ( $value as $id ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -17,10 +17,10 @@ use Pods\Static_Cache;
  *
  * @see   PodsData::query
  *
- * @param string $sql              SQL Query
- * @param string $error            (optional) The failure message
- * @param string $results_error    (optional) Throw an error if a records are found
- * @param string $no_results_error (optional) Throw an error if no records are found
+ * @param string|array $sql              SQL Query
+ * @param string       $error            (optional) The failure message
+ * @param string       $results_error    (optional) Throw an error if a records are found
+ * @param string       $no_results_error (optional) Throw an error if no records are found
  *
  * @return array|bool|mixed|null|void
  * @since 2.0.0

--- a/init.php
+++ b/init.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Pods - Custom Content Types and Fields
  * Plugin URI:        https://pods.io/
  * Description:       Pods is a framework for creating, managing, and deploying customized content types and fields
- * Version:           2.8.22
+ * Version:           2.8.23-a-1
  * Author:            Pods Framework Team
  * Author URI:        https://pods.io/about/
  * Text Domain:       pods
@@ -43,7 +43,7 @@ if ( defined( 'PODS_VERSION' ) || defined( 'PODS_DIR' ) ) {
 	add_action( 'init', 'pods_deactivate_pods_ui' );
 } else {
 	// Current version.
-	define( 'PODS_VERSION', '2.8.22' );
+	define( 'PODS_VERSION', '2.8.23-a-1' );
 
 	// Current database version, this is the last version the database changed.
 	define( 'PODS_DB_VERSION', '2.3.5' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pods",
-  "version": "2.8.22",
+  "version": "2.8.23-a-1",
   "description": "Pods is a development framework for creating, extending, managing, and deploying customized content types in WordPress.",
   "author": "Pods Foundation, Inc",
   "homepage": "https://pods.io/",

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,14 @@ Pods really wouldn't be where it is without all the contributions from our [dono
 
 == Changelog ==
 
+= 2.8.23 - July 4th, 2022 =
+
+
+
+= 2.8.22.1 - July 3rd, 2022 =
+
+* Fixed: Resolve potential PHP errors from Relationship/File field saves by ensuring consistent array structures.
+
 = 2.8.22 - July 3rd, 2022 =
 
 * Added: Support `IN` and `NOT IN` comparisons for the Pods Templating `[if]` conditional shortcode that checks if the current value is/isn't within a comma-separated list of values. (@sc0ttkclark)

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: pods, custom post types, custom taxonomies, content types, custom fields, 
 Requires at least: 5.5
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 2.8.22
+Stable tag: 2.8.23-a-1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Description

pods_query() doesn’t directly run PodsData::query() and it uses PodsData::get_sql() first which can throw PHP warnings in certain cases with arrays

## Related GitHub issue(s)

#6554 #6555

## Changelog text for these changes

* Fixed: Resolved potential PHP warnings on certain sites by preparing SQL queries ahead of other string-related processing.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
