### PR TITLE
DateTime: Fix formatting issues and improve UI/UX

### DIFF
--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -333,6 +333,7 @@ class PodsField_DateTime extends PodsField {
 		if ( ! $this->is_empty( $value ) ) {
 
 			// Value should always be passed as storage format since 2.7.15.
+			// This was broken since 2.8.x and restored in 2.9.2 (#6389).
 			$formats = [
 				static::$storage_format,
 			];

--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { Dropdown } from '@wordpress/components';
 import Datetime from 'react-datetime';
 import moment from 'moment';
 import classnames from 'classnames';
@@ -308,36 +309,45 @@ const DateTime = ( {
 	}
 
 	return (
-		<Datetime
-			className="pods-react-datetime-fix"
-			value={ localMomentValue }
-			onChange={ ( newValue ) => handleChange( newValue ) }
-			dateFormat={ includeDateField ? momentDateFormat : false }
-			timeFormat={ includeTimeField ? momentTimeFormat : false }
-			isValidDate={ isValidDate }
-			initialViewDate={ initialViewDate }
-			renderInput={ ( props ) => (
-				<input
-					{ ...props }
-					value={ localStringValue }
-					onChange={ ( event ) => {
-						// Track local values, but don't change actual value
-						// until blur event.
-						setLocalStringValue( event.target.value );
-						setLocalMomentValue( moment( event.target.value, [ getDBFormat(), getFullFormat() ] ) );
-					} }
-					onBlur={ ( event ) => handleChange( event.target.value ) }
-					id={ htmlAttributes.id || `pods-form-ui-${ name }` }
-					name={ htmlAttributes.name || name }
-					className={
-						classnames(
-							'pods-form-ui-field pods-form-ui-field-type-datetime',
-							htmlAttributes.class
-						)
-					}
-				/>
-			) }
-		/>
+		<div>
+			<Dropdown
+				renderToggle={ ( state ) => (
+					<input
+						type="text"
+						value={ localStringValue }
+						onClick={ state.onToggle }
+						onChange={ ( event ) => {
+							// Track local values, but don't change actual value
+							// until blur event.
+							setLocalStringValue( event.target.value );
+							setLocalMomentValue( moment( event.target.value, [ getDBFormat(), getFullFormat() ] ) );
+						} }
+						onBlur={ ( event ) => handleChange( event.target.value ) }
+						id={ htmlAttributes.id || `pods-form-ui-${ name }` }
+						name={ htmlAttributes.name || name }
+						className={
+							classnames(
+								'pods-form-ui-field pods-form-ui-field-type-datetime',
+								htmlAttributes.class
+							)
+						}
+					/>
+				) }
+				renderContent={ () => (
+					<Datetime
+						className="pods-react-datetime-fix"
+						value={ localMomentValue }
+						onChange={ ( newValue ) => handleChange( newValue ) }
+						dateFormat={ includeDateField ? momentDateFormat : false }
+						timeFormat={ includeTimeField ? momentTimeFormat : false }
+						isValidDate={ isValidDate }
+						initialViewDate={ initialViewDate }
+						input={ false }
+						renderInput={ null }
+					/>
+				) }
+			/>
+		</div>
 	);
 };
 

--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -209,6 +209,14 @@ const DateTime = ( {
 		return momentObject.format( getFullFormat() );
 	};
 
+	const formatMomentObjectForDB = ( momentObject, defaultValue = '' ) => {
+		if ( ! momentObject.isValid() ) {
+			return defaultValue;
+		}
+
+		return momentObject.format( getDBFormat() );
+	};
+
 	const handleHTML5InputFieldChange = ( event ) => setValue( event.target.value );
 
 	// Keep local versions as a string (formatted and ready to display, and in case

--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -249,13 +249,19 @@ const DateTime = ( {
 	);
 
 	const handleChange = ( newValue ) => {
+		let momentObject = newValue;
+
+		if ( momentObject && ! moment.isMoment( momentObject ) ) {
+			momentObject = moment( newValue, [ getDBFormat(), getFullFormat() ] );
+		}
+
 		// Receives the selected moment object, if the date in the input is valid.
 		// If the date in the input is not valid, the callback receives the value of
 		// the input a string.
-		if ( moment.isMoment( newValue ) ) {
-			setValue( formatMomentObject( newValue ) );
-			setLocalStringValue( formatMomentObject( newValue ) );
-			setLocalMomentValue( newValue );
+		if ( moment.isMoment( momentObject ) ) {
+			setValue( formatMomentObjectForDB( momentObject ) );
+			setLocalStringValue( formatMomentObject( momentObject ) );
+			setLocalMomentValue( momentObject );
 		} else {
 			setValue( newValue );
 			setLocalStringValue( newValue );
@@ -325,8 +331,7 @@ const DateTime = ( {
 						value={ localStringValue }
 						onClick={ state.onToggle }
 						onChange={ ( event ) => {
-							// Track local values, but don't change actual value
-							// until blur event.
+							// Track local values, but don't change actual value until blur event.
 							setLocalStringValue( event.target.value );
 							setLocalMomentValue( moment( event.target.value, [ getDBFormat(), getFullFormat() ] ) );
 						} }

--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -324,6 +324,12 @@ const DateTime = ( {
 
 	return (
 		<div>
+			<input
+				readOnly={ true }
+				hidden={ true }
+				value={ value }
+				name={ htmlAttributes.name || name }
+			/>
 			<Dropdown
 				renderToggle={ ( state ) => (
 					<input
@@ -337,7 +343,6 @@ const DateTime = ( {
 						} }
 						onBlur={ ( event ) => handleChange( event.target.value ) }
 						id={ htmlAttributes.id || `pods-form-ui-${ name }` }
-						name={ htmlAttributes.name || name }
 						className={
 							classnames(
 								'pods-form-ui-field pods-form-ui-field-type-datetime',


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR fixes two issues with the new React based date/time fields.

1. UI/UX: With this PR the date/time picker opens nicely in a popover window (Dropdown component from WP core).
2. Formatting issues. Similar to what we did in 2.7.x this PR now includes 2 input fields. One hidden with the actual value and one for display which shows the selected format. The latter is also the toggle trigger for the popover date/time picker.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6857 
Fixes #6389

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Create color field (single and repeatable)
2. See current UI
3. Rebuild DFV with the changes in this PR
4. See new UI :)
5. Try the field in various different formats
6. You'll see that the AJAX handler always sends the DB format to the server.

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
