### PR TITLE
Custom repeatable fields separators

### DIFF
--- a/classes/PodsField.php
+++ b/classes/PodsField.php
@@ -576,10 +576,12 @@ class PodsField {
 		if ( $args->options instanceof Field ) {
 			$config = $args->options->export();
 
-			$config['repeatable']               = $args->options->is_repeatable();
-			$config['repeatable_add_new_label'] = $args->options->get_arg( 'repeatable_add_new_label', __( 'Add New', 'pods' ), true );
-			$config['repeatable_reorder']       = filter_var( $args->options->get_arg( 'repeatable_reorder', true ), FILTER_VALIDATE_BOOLEAN );
-			$config['repeatable_limit']         = $args->options->get_limit();
+			$config['repeatable']                  = $args->options->is_repeatable();
+			$config['repeatable_add_new_label']    = $args->options->get_arg( 'repeatable_add_new_label', __( 'Add New', 'pods' ), true );
+			$config['repeatable_reorder']          = filter_var( $args->options->get_arg( 'repeatable_reorder', true ), FILTER_VALIDATE_BOOLEAN );
+			$config['repeatable_limit']            = $args->options->get_limit();
+			$config['repeatable_format']           = $args->options->get_arg( 'repeatable_format', 'default', true );
+			$config['repeatable_format_separator'] = $args->options->get_arg( 'repeatable_format_separator', ', ', true );
 		} else {
 			$config = (array) $args->options;
 		}

--- a/includes/data.php
+++ b/includes/data.php
@@ -1865,6 +1865,20 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 	if ( ! empty( $params->fields ) && is_array( $params->fields ) && isset( $params->fields[ $params->field ] ) ) {
 		$params->field = $params->fields[ $params->field ];
 
+		if ( pods_v( 'repeatable', $params->field, false ) ) {
+			$format = pods_v( 'repeatable_format', $params->field, 'default' );
+			if ( 'default' !== $format ) {
+				$params->serial = false;
+				if ( 'custom' === $format ) {
+					$separator = pods_v( 'repeatable_format_separator', $params->field, $params->separator );
+					if ( $separator ) {
+						$params->and       = $separator;
+						$params->separator = $separator;
+					}
+				}
+			}
+		}
+
 		$simple_tableless_objects = PodsForm::simple_tableless_objects();
 
 		if ( ! empty( $params->field ) && ! is_string( $params->field ) && in_array( $params->field['type'], PodsForm::tableless_field_types(), true ) ) {

--- a/src/Pods/Admin/Config/Field.php
+++ b/src/Pods/Admin/Config/Field.php
@@ -105,7 +105,7 @@ class Field extends Base {
 		$repeatable_field_types = PodsForm::repeatable_field_types();
 
 		// Remove repeatable fields custom separator options.
-		$serial_repeatable_field_types = array_diff( $repeatable_field_types, [
+		$serial_repeatable_field_types = array_values( array_diff( $repeatable_field_types, [
 			'avatar',
 			'code',
 			'link',
@@ -113,7 +113,7 @@ class Field extends Base {
 			'paragraph',
 			'website',
 			'wysiwyg',
-		] );
+		] ) );
 
 		$options = [];
 

--- a/src/Pods/Admin/Config/Field.php
+++ b/src/Pods/Admin/Config/Field.php
@@ -100,8 +100,20 @@ class Field extends Base {
 	 * @return array List of fields for the Field object.
 	 */
 	public function get_fields( \Pods\Whatsit\Pod $pod, array $tabs ) {
-		$field_types           = PodsForm::field_types();
-		$tableless_field_types = PodsForm::tableless_field_types();
+		$field_types            = PodsForm::field_types();
+		$tableless_field_types  = PodsForm::tableless_field_types();
+		$repeatable_field_types = PodsForm::repeatable_field_types();
+
+		// Remove repeatable fields custom separator options.
+		$serial_repeatable_field_types = array_diff( $repeatable_field_types, [
+			'avatar',
+			'code',
+			'link',
+			'oembed',
+			'paragraph',
+			'website',
+			'wysiwyg',
+		] );
 
 		$options = [];
 
@@ -206,7 +218,7 @@ class Field extends Base {
 				'type'         => 'html',
 				'html_content' => '<hr />',
 				'depends-on'   => [
-					'type' => PodsForm::repeatable_field_types(),
+					'type' => $repeatable_field_types,
 				],
 			],
 			'repeatable'  => [
@@ -218,7 +230,7 @@ class Field extends Base {
 				'boolean_yes_label' => __( 'Allow multiple values', 'pods' ),
 				'dependency'        => true,
 				'depends-on'        => [
-					'type' => PodsForm::repeatable_field_types(),
+					'type' => $repeatable_field_types,
 				],
 			],
 			'repeatable_add_new_label'  => [
@@ -228,7 +240,7 @@ class Field extends Base {
 				'default'     => '',
 				'type'        => 'text',
 				'depends-on'  => [
-					'type'       => PodsForm::repeatable_field_types(),
+					'type'       => $repeatable_field_types,
 					'repeatable' => true,
 				],
 			],
@@ -236,7 +248,7 @@ class Field extends Base {
 				'label'                 => __( 'Repeatable - Display Format', 'pods' ),
 				'help'                  => __( 'Used as format for front-end display', 'pods' ),
 				'depends-on'  => [
-					'type'       => PodsForm::repeatable_field_types(),
+					'type'       => $serial_repeatable_field_types,
 					'repeatable' => true,
 				],
 				'default'               => 'default',
@@ -254,7 +266,7 @@ class Field extends Base {
 				'label'      => __( 'Repeatable - Display Format Separator', 'pods' ),
 				'help'       => __( 'Used as separator for front-end display.', 'pods' ),
 				'depends-on' => [
-					'type'              => PodsForm::repeatable_field_types(),
+					'type'              => $serial_repeatable_field_types,
 					'repeatable'        => true,
 					'repeatable_format' => 'custom',
 				],

--- a/src/Pods/Admin/Config/Field.php
+++ b/src/Pods/Admin/Config/Field.php
@@ -232,6 +232,35 @@ class Field extends Base {
 					'repeatable' => true,
 				],
 			],
+			'repeatable_format' => [
+				'label'                 => __( 'Repeatable - Display Format', 'pods' ),
+				'help'                  => __( 'Used as format for front-end display', 'pods' ),
+				'depends-on'  => [
+					'type'       => PodsForm::repeatable_field_types(),
+					'repeatable' => true,
+				],
+				'default'               => 'default',
+				'required'              => true,
+				'type'                  => 'pick',
+				'data'                  => [
+					'default'    => __( 'Item 1, Item 2, and Item 3', 'pods' ),
+					'non_serial' => __( 'Item 1, Item 2 and Item 3', 'pods' ),
+					'custom'     => __( 'Custom separator (without "and")', 'pods' ),
+				],
+				'pick_show_select_text' => 0,
+				'dependency'            => true,
+			],
+			'repeatable_format_separator' => [
+				'label'      => __( 'Repeatable - Display Format Separator', 'pods' ),
+				'help'       => __( 'Used as separator for front-end display.', 'pods' ),
+				'depends-on' => [
+					'type'              => PodsForm::repeatable_field_types(),
+					'repeatable'        => true,
+					'repeatable_format' => 'custom',
+				],
+				'default'    => ', ',
+				'type'       => 'text',
+			]
 		];
 
 		$options['advanced'] = [


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Currently the repeatable fields use the `pods_serial_comma` function using the default parameters.
This PR aims to extend the repeatable options the same way as the Pick field by adding a format field and a custom separator if the format field is set to `custom`.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6890

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->
![image](https://user-images.githubusercontent.com/826148/188443404-3a451769-daa1-4998-a9fa-f3a63f611c30.png)


## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
