### PR TITLE
Fix form counter starting with 0

### DIFF
--- a/ui/forms/form.php
+++ b/ui/forms/form.php
@@ -184,9 +184,8 @@ if ( 0 < $pod->id() ) {
 	}
 }
 
-$counter = (int) pods_static_cache_get( $pod->pod . '-counter', 'pods-forms' );
-
-$counter ++;
+$counter = pods_static_cache_get( $pod->pod . '-counter', 'pods-forms' );
+$counter = is_numeric( $counter ) ? $counter++ : 0;
 
 pods_static_cache_set( $pod->pod . '-counter', $counter, 'pods-forms' );
 ?>

--- a/ui/front/form.php
+++ b/ui/front/form.php
@@ -78,9 +78,8 @@ if ( isset( $_POST['_pods_nonce'] ) ) {
 
 $field_prefix = '';
 
-$counter = (int) pods_static_cache_get( $pod->pod . '-counter', 'pods-forms' );
-
-$counter ++;
+$counter = pods_static_cache_get( $pod->pod . '-counter', 'pods-forms' );
+$counter = is_numeric( $counter ) ? $counter++ : 0;
 
 pods_static_cache_set( $pod->pod . '-counter', $counter, 'pods-forms' );
 ?>


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR changes the form counter to make it start from 0 instead of 1 due to a DFV conflict since https://github.com/pods-framework/pods/commit/efe2af7b2bce7cd67f9c68059b30ede097072de0

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6915 

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

See issue. Repeat steps with this PR and it works.

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
