### PR TITLE
Fix template edit page editor

### DIFF
--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -432,6 +432,7 @@ class Pods_Templates extends PodsComponent {
 			return;
 		}
 
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_assets' ), 21 );
 		add_filter( 'enter_title_here', array( $this, 'set_title_text' ), 10, 2 );
 	}
 

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -191,8 +191,6 @@ class Pods_Templates extends PodsComponent {
 
 			add_action( 'add_meta_boxes_' . $this->object_type, array( $this, 'edit_page_form' ) );
 
-			add_action( 'pods_meta_groups', array( $this, 'add_meta_boxes' ) );
-
 			add_filter( 'get_post_metadata', array( $this, 'get_meta' ), 10, 4 );
 			add_filter( 'update_post_metadata', array( $this, 'save_meta' ), 10, 4 );
 
@@ -434,24 +432,6 @@ class Pods_Templates extends PodsComponent {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_assets' ), 21 );
 		add_filter( 'enter_title_here', array( $this, 'set_title_text' ), 10, 2 );
-	}
-
-	/**
-	 * Add meta boxes to the page
-	 *
-	 * @since 2.0.0
-	 */
-	public function add_meta_boxes() {
-		$pod = array(
-			'name' => $this->object_type,
-			'type' => 'post_type',
-		);
-
-		if ( isset( PodsMeta::$post_types[ $pod['name'] ] ) ) {
-			return;
-		}
-
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_assets' ), 21 );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Since Pods 2.9.5 (commit f433559a602f1ced90f57dc14f2766ccf9567fc8) the Pods template was missing the requires assets.
This PR fixed that.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #6921

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
