### PR TITLE
Fix error in registering taxonomy fields via code

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -243,6 +243,7 @@ class PodsMeta {
 	public static function enqueue() {
 		$type_map = [
 			'post_type'  => 'post_types',
+			'taxonomy'   => 'taxonomies',
 			'taxonomies' => 'taxonomies',
 			'setting'    => 'settings',
 		];


### PR DESCRIPTION
when i try to register taxonomy fields via the code using the example from pods.io site, it leads to a fatal error. You can replicate the error with the below code snippet

```
add_action('init', function () {
	$pod = [
		'name'           => 'category',
		'label'          => 'Authors',
		'description'    => '',
		'type'           => 'taxonomy',
		'storage'        => 'meta',
		'label_singular' => 'Author',
		'public'         => '1',
	];
	pods_register_type( $pod['type'], $pod['name'], $pod );
	$group = [
		'name'        => 'more_fields',
		'label'       => 'More Fields',
		'description' => '',
		'weight'      => 0,
	];
	$group_fields = [
		'books' => [
			'name'              => 'books',
			'label'             => 'Books',
			'description'       => '',
			'weight'            => 0,
			'type'              => 'pick',
			'pick_object'       => 'post_type',
			'pick_val'          => 'book',
			'pick_format_type'  => 'multi',
			'pick_format_multi' => 'list',
		],
	];
	pods_register_group( $group, $pod['name'], $group_fields );

});
```

when i change the type from `taxonomy` to `taxonomies` it doesnt show up on the screen( i guess its due to the fact that taxonomy pods are loaded by type set to taxonomy)

```
		self::$taxonomies = $api->load_pods( [
			'type'    => 'taxonomy',
			'refresh' => $refresh,
		] );
```


If i use `taxonomy` without the fix in the PR it throws this error
```

 Uncaught Error: Access to undeclared static property PodsMeta::$taxonomy in /var/www/html/wp-content/plugins/pods/classes/PodsMeta.php:256
Stack trace:
#0 /var/www/html/wp-content/plugins/pods/classes/PodsInit.php(1312): PodsMeta::enqueue()
#1 /var/www/html/wp-includes/class-wp-hook.php(307): PodsInit->setup_content_types(false)
#2 /var/www/html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
#3 /var/www/html/wp-includes/plugin.php(476): WP_Hook->do_action(Array)
#4 /var/www/html/wp-settings.php(598): do_action('init')
#5 /var/www/html/wp-config.php(133): require_once('/var/www/html/w...')
#6 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')
#7 /var/www/html/wp-admin/admin.php(34): require_once('/var/www/html/w...')
#8 /var/www/html/wp-admin/edit-tags.php(10): require_once('/var/www/html/w...')

```


I am not sure if the fix is right, can you take a look and provide comments ?
