### PR TITLE
Make `cpac_meta_value()` always return a string

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -615,8 +615,10 @@ class PodsMeta {
 			$meta = PodsForm::field_method( $pod['fields'][ $field ]['type'], 'ui', $id, $meta, $field, $pod['fields'][ $field ], $pod['fields'], $pod );
 		}
 
-		// always return a string
-		if ( ! is_string( $meta ) ) {
+		// Always return a string version.
+		if ( is_array( $meta ) && isset( $meta[0] ) ) {
+			$meta = pods_serial_comma( $meta, $pod->get_field( $field ) );
+		} elseif ( ! is_string( $meta ) ) {
 			$meta = '';
 		}
 

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -529,7 +529,7 @@ class PodsMeta {
 	 * @param int        $id
 	 * @param \AC_Column $obj
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function cpac_meta_value( $meta, $id, $obj ) {
 
@@ -613,6 +613,11 @@ class PodsMeta {
 			}
 
 			$meta = PodsForm::field_method( $pod['fields'][ $field ]['type'], 'ui', $id, $meta, $field, $pod['fields'][ $field ], $pod['fields'], $pod );
+		}
+
+		// always return a string
+		if ( ! is_string( $meta ) ) {
+			$meta = '';
 		}
 
 		return $meta;


### PR DESCRIPTION
## Description

Fixes the `cpac_meta_value()` function to always return a string, as the ACP `format()` function expects a string for its first argument.

## Related GitHub issue(s)

Fixes #6965.

## Testing instructions

1. Define a new multi-select field for a post type. Leave it uninitialized.
2. Display the new field as column on the post type admin list view.
3. You should not see an internal error message in one of the columns, nor a fatal TypeError in debug.log.
<!-- List of steps to test the changes so we can see confirm it works as intended. -->

## Changelog text for these changes

* Makes `cpac_meta_value()` always return a string, as the ACP `format()` function expects a string for its first argument.

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
