### PR TITLE
Fix occasional php warning

### DIFF
--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -481,7 +481,7 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		// Load the pod.
-		$pod = array_merge( $pod, (array) pods_v( 'options', $pod, [] ) );
+		$pod = array_merge( $pod, (array) pods_v( 'options', $pod, [], true ) );
 
 		$labels = array(
 			// Default

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -481,7 +481,7 @@ class Pods_Component_I18n extends PodsComponent {
 		}
 
 		// Load the pod.
-		$pod = array_merge( $pod, (array) pods_v( 'options', $pod, array() ) );
+		$pod = array_merge( $pod, (array) pods_v( 'options', $pod, [] ) );
 
 		$labels = array(
 			// Default

--- a/components/I18n/I18n.php
+++ b/components/I18n/I18n.php
@@ -480,10 +480,8 @@ class Pods_Component_I18n extends PodsComponent {
 			return $options;
 		}
 
-		// Load the pod
-		foreach ( $pod['options'] as $_option => $_value ) {
-			$pod[ $_option ] = $_value;
-		}
+		// Load the pod.
+		$pod = array_merge( $pod, (array) pods_v( 'options', $pod, array() ) );
 
 		$labels = array(
 			// Default


### PR DESCRIPTION
## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes: #7003 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
