### PR TITLE
Date format mapper - redo

### DIFF
--- a/src/Pods/Data/Map_Field_Values.php
+++ b/src/Pods/Data/Map_Field_Values.php
@@ -754,7 +754,6 @@ class Map_Field_Values {
 		switch ( $traverse[0] ) {
 			case '_format':
 				$format    = $traverse[1];
-				$wp_format = in_array( strtolower( $format ), array( 'wp', 'wordpress' ), true );
 
 				switch ( $format ) {
 					case 'date':

--- a/src/Pods/Data/Map_Field_Values.php
+++ b/src/Pods/Data/Map_Field_Values.php
@@ -746,13 +746,30 @@ class Map_Field_Values {
 
 		$value = $obj->field( $field, array( 'raw' => true ) );
 
+		// No fields modifiers found.
 		if ( empty( $traverse[0] ) || empty( $traverse[1] ) ) {
 			return null;
 		}
 
 		switch ( $traverse[0] ) {
 			case '_format':
-				$format = $traverse[1];
+				$format    = $traverse[1];
+				$wp_format = in_array( strtolower( $format ), array( 'wp', 'wordpress' ), true );
+
+				if ( $wp_format ) {
+					switch ( $field ) {
+						case 'date':
+							$format = get_option( 'date_format' );
+							break;
+						case 'time':
+							$format = get_option( 'time_format' );
+							break;
+						default:
+							$format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+							break;
+					}
+				}
+
 				$value = date_i18n( $format, strtotime( $value ) );
 				break;
 			default:

--- a/src/Pods/Data/Map_Field_Values.php
+++ b/src/Pods/Data/Map_Field_Values.php
@@ -735,6 +735,8 @@ class Map_Field_Values {
 		if ( 'post_type' === $object_type ) {
 			$date_fields[] = 'post_date';
 			$date_fields[] = 'post_date_gmt';
+			$date_fields[] = 'post_modified';
+			$date_fields[] = 'post_modified_gmt';
 		}
 
 		// Handle special field tags.

--- a/src/Pods/Data/Map_Field_Values.php
+++ b/src/Pods/Data/Map_Field_Values.php
@@ -756,18 +756,22 @@ class Map_Field_Values {
 				$format    = $traverse[1];
 				$wp_format = in_array( strtolower( $format ), array( 'wp', 'wordpress' ), true );
 
-				if ( $wp_format ) {
-					switch ( $field ) {
-						case 'date':
-							$format = get_option( 'date_format' );
-							break;
-						case 'time':
-							$format = get_option( 'time_format' );
-							break;
-						default:
-							$format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
-							break;
-					}
+				switch ( $format ) {
+					case 'date':
+					case 'wp_date':
+					case 'wordpress_date':
+						$format = get_option( 'date_format' );
+						break;
+					case 'time':
+					case 'wp_time':
+					case 'wordpress_time':
+						$format = get_option( 'time_format' );
+						break;
+					case 'datetime':
+					case 'wp':
+					case 'wordpress':
+						$format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+						break;
 				}
 
 				$value = date_i18n( $format, strtotime( $value ) );


### PR DESCRIPTION
Related: #4525
Related: #5675

## Description

<!-- A clear and concise description of what the code will change and do. -->
This is a redo from an earlier PR: #5676
With this PR you can set your own formats when using date fields.

Text from prev PR:

> The relates issue noted that using {@post_date} always displays the mysql format (Y-m-d h:i).
> This PR sets this to the default formatting settings from WordPress.
> 
> This PR also adds a format param to the magic tag: {@post_date._format.Y-m-d}, {@post_date._format.Y m d} and even {@post_date._format.Y.m.d} (note the dots).
> Currently this PR only supports this for core-field dates (post_date). But might be a cool feature for other date fields as well.
>
> Would like to have feedback/ideas on how to best implement this.

This PR does NOT change the default behavior. It only adds the option to define a format (or select WP default format).

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See '....'

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
