### PR TITLE
Add extra repeatable formats

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -214,6 +214,9 @@ class PodsField_Pick extends PodsField {
 				'data'                  => [
 					'default'    => __( 'Item 1, Item 2, and Item 3', 'pods' ),
 					'non_serial' => __( 'Item 1, Item 2 and Item 3', 'pods' ),
+					'br'         => __( 'Line breaks', 'pods' ),
+					'ul'         => __( 'Unordered list', 'pods' ),
+					'ol'         => __( 'Ordered list', 'pods' ),
 					'custom'     => __( 'Custom separator (without "and")', 'pods' ),
 				],
 				'pick_show_select_text' => 0,
@@ -903,23 +906,36 @@ class PodsField_Pick extends PodsField {
 
 		$display_format = pods_v( static::$type . '_display_format_multi', $options, 'default' );
 
-		if ( 'non_serial' === $display_format ) {
-			$args['serial'] = false;
+		switch ( $display_format ) {
+			case 'ul':
+			case 'ol':
+				$value = '<' . $display_format . '><li>' . implode( '</li><li>', $value ) . '</li></' . $display_format . '>';
+				break;
+			case 'br':
+				$value = implode( '<br />', $value );
+				break;
+			case 'non_serial':
+				$args['serial'] = false;
+				$value = pods_serial_comma( $value, $args );
+				break;
+			case 'custom':
+				$args['serial'] = false;
+
+				$separator = pods_v( static::$type . '_display_format_separator', $options, ', ' );
+				if ( ! empty( $separator ) ) {
+					$args['separator'] = $separator;
+
+					// Replicate separator behavior.
+					$args['and'] = $args['separator'];
+				}
+				$value = pods_serial_comma( $value, $args );
+				break;
+			default:
+				$value = pods_serial_comma( $value, $args );
+				break;
 		}
 
-		if ( 'custom' === $display_format ) {
-			$args['serial'] = false;
-
-			$separator = pods_v( static::$type . '_display_format_separator', $options, ', ' );
-			if ( ! empty( $separator ) ) {
-				$args['separator'] = $separator;
-
-				// Replicate separator behavior.
-				$args['and'] = $args['separator'];
-			}
-		}
-
-		return pods_serial_comma( $value, $args );
+		return $value;
 	}
 
 	/**

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -214,9 +214,9 @@ class PodsField_Pick extends PodsField {
 				'data'                  => [
 					'default'    => __( 'Item 1, Item 2, and Item 3', 'pods' ),
 					'non_serial' => __( 'Item 1, Item 2 and Item 3', 'pods' ),
-					'br'         => __( 'Line breaks', 'pods' ),
-					'ul'         => __( 'Unordered list', 'pods' ),
-					'ol'         => __( 'Ordered list', 'pods' ),
+					'br'         => __( 'One per line (br HTML tags)', 'pods' ),
+					'ul'         => __( 'Unordered HTML list', 'pods' ),
+					'ol'         => __( 'Ordered HTML list', 'pods' ),
 					'custom'     => __( 'Custom separator (without "and")', 'pods' ),
 				],
 				'pick_show_select_text' => 0,

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -909,7 +909,7 @@ class PodsField_Pick extends PodsField {
 		switch ( $display_format ) {
 			case 'ul':
 			case 'ol':
-				$value = '<' . $display_format . '><li>' . implode( '</li><li>', $value ) . '</li></' . $display_format . '>';
+				$value = '<' . $display_format . '><li>' . implode( '</li><li>', (array) $value ) . '</li></' . $display_format . '>';
 				break;
 			case 'br':
 				$value = implode( '<br />', $value );

--- a/includes/data.php
+++ b/includes/data.php
@@ -1954,9 +1954,7 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 				switch ( $format ) {
 					case 'ul':
 					case 'ol':
-						if ( is_array( $value ) ) {
-							$value = '<' . $format . '><li>' . implode( '</li><li>', $value ) . '</li></' . $format . '>';
-						}
+						$value = '<' . $format . '><li>' . implode( '</li><li>', (array) $value ) . '</li></' . $format . '>';
 					break;
 					case 'br':
 						if ( is_array( $value ) ) {

--- a/includes/data.php
+++ b/includes/data.php
@@ -1950,18 +1950,35 @@ function pods_serial_comma( $value, $field = null, $fields = null, $and = null, 
 			$format = pods_v( 'repeatable_format', $params->field, 'default', true );
 
 			if ( 'default' !== $format ) {
-				$params->serial = false;
 
-				if ( 'custom' === $format ) {
-					$separator = pods_v( 'repeatable_format_separator', $params->field );
+				switch ( $format ) {
+					case 'ul':
+					case 'ol':
+						if ( is_array( $value ) ) {
+							$value = '<' . $format . '><li>' . implode( '</li><li>', $value ) . '</li></' . $format . '>';
+						}
+					break;
+					case 'br':
+						if ( is_array( $value ) ) {
+							$value = implode( '<br />', $value );
+						}
+					break;
+					case 'non_serial':
+						$params->serial = false;
+					break;
+					case 'custom':
+						$params->serial = false;
 
-					// Default to comma separator.
-					if ( '' === $separator ) {
-						$separator = ', ';
-					}
+						$separator = pods_v( 'repeatable_format_separator', $params->field );
 
-					$params->and       = $separator;
-					$params->separator = $separator;
+						// Default to comma separator.
+						if ( '' === $separator ) {
+							$separator = ', ';
+						}
+
+						$params->and       = $separator;
+						$params->separator = $separator;
+					break;
 				}
 			}
 		}

--- a/src/Pods/Admin/Config/Field.php
+++ b/src/Pods/Admin/Config/Field.php
@@ -267,6 +267,9 @@ class Field extends Base {
 				'data'                  => [
 					'default'    => __( 'Item 1, Item 2, and Item 3', 'pods' ),
 					'non_serial' => __( 'Item 1, Item 2 and Item 3', 'pods' ),
+					'br'         => __( 'Line breaks', 'pods' ),
+					'ul'         => __( 'Unordered list', 'pods' ),
+					'ol'         => __( 'Ordered list', 'pods' ),
 					'custom'     => __( 'Custom separator (without "and")', 'pods' ),
 				],
 				'pick_show_select_text' => 0,

--- a/tests/codeception/wpunit/Pods/Field/PodsField_PickTest.php
+++ b/tests/codeception/wpunit/Pods/Field/PodsField_PickTest.php
@@ -89,6 +89,22 @@ class PodsField_PickTest extends Pods_UnitTestCase {
 		$expected = 'item1 | item2 | item3';
 
 		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+
+		// List display format.
+
+		$options['pick_display_format_multi'] = 'ul';
+
+		$expected = '<ul><li>item1</li><li>item2</li><li>item3</li></ul>';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
+
+		// Line break display format.
+
+		$options['pick_display_format_multi'] = 'br';
+
+		$expected = 'item1<br />item2<br />item3';
+
+		$this->assertEquals( $expected, $this->field->display( $value, null, $options ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR adds 3 extra display formats for field config:
- Line Breaks
- Unordered List
- Ordered List

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #7044 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
