### PR TITLE
Feature/7016 html5 date empty

### DIFF
--- a/ui/js/dfv/src/fields/datetime/index.js
+++ b/ui/js/dfv/src/fields/datetime/index.js
@@ -300,14 +300,18 @@ const DateTime = ( {
 		return isAfterStartYear && isBeforeEndYear;
 	};
 
-	useEffect( () => {
+	useEffect(() => {
 		const rangeValidationRule = {
-			rule: dateTimeValidator( yearRange, getDBFormat() ),
+			rule: dateTimeValidator(
+				yearRange,
+				getDBFormat(),
+				fieldConfig.datetime_allow_empty || false
+			),
 			condition: () => true,
 		};
 
-		addValidationRules( [ rangeValidationRule ] );
-	}, [] );
+		addValidationRules([rangeValidationRule]);
+	}, []);
 
 	// If we can use an HTML5 input field, we can just return an input field.
 	if ( useHTML5Field ) {

--- a/ui/js/dfv/src/helpers/validators.js
+++ b/ui/js/dfv/src/helpers/validators.js
@@ -109,8 +109,13 @@ export const numberValidator = (
 export const dateTimeValidator = (
 	yearRange,
 	momentFormat,
-) => ( value ) => {
-	if ( 'undefined' === typeof yearRange || ! yearRange.length ) {
+) => (value) => {
+	//If no value is set, we don't need to validate range.
+	//@see https://github.com/pods-framework/pods/issues/7016
+	if (!value) {
+		return true;
+	}
+	if ('undefined' === typeof yearRange || !yearRange.length) {
 		return true;
 	}
 

--- a/ui/js/dfv/src/helpers/validators.js
+++ b/ui/js/dfv/src/helpers/validators.js
@@ -109,10 +109,11 @@ export const numberValidator = (
 export const dateTimeValidator = (
 	yearRange,
 	momentFormat,
+	allowEmpty = false,
 ) => (value) => {
 	//If no value is set, we don't need to validate range.
 	//@see https://github.com/pods-framework/pods/issues/7016
-	if (!value) {
+	if (!value && allowEmpty) {
 		return true;
 	}
 	if ('undefined' === typeof yearRange || !yearRange.length) {


### PR DESCRIPTION


## Description

I made it so if you have an HTML5 date field that should allow empty date, it does not show validation.

## Related GitHub issue(s)

Fixes #7016

## Testing instructions

I made a Pod with three HTML5 date fields, one required, one not required that allows empty. 


POD: https://gist.github.com/Shelob9/8a1537c04f51d071b9d27a5ea36b702e

## Screenshots / screencast

![Screenshot 2023-04-19 190447](https://user-images.githubusercontent.com/1994311/233218155-0d621742-048f-4172-93f1-6ff3b5ef8a2c.jpg)

## Changelog text for these changes

Bug: Prevented invalid warning for HTML5 date fields that should allow empty value.

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
