### PR TITLE
Fetch object ID from WP object

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -161,6 +161,10 @@ class Pods implements Iterator {
 				// Post Type Archive.
 				$pod       = $pod->name;
 				$id_lookup = false;
+			} elseif ( $pod instanceof WP_Taxonomy ) {
+				// Taxonomy object.
+				$pod       = $pod->name;
+				$id_lookup = false;
 			} else {
 				// Unsupported pod object.
 				$pod       = null;

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -138,16 +138,25 @@ class Pods implements Iterator {
 		if ( $pod && ! is_string( $pod ) && ! $pod instanceof Pod ) {
 			if ( $pod instanceof WP_Post ) {
 				// Post Type Singular.
+				$id_lookup = false;
+				if ( null === $id ) {
+					$id = $pod->ID;
+				}
 				$pod       = $pod->post_type;
-				$id_lookup = true;
 			} elseif ( $pod instanceof WP_Term ) {
 				// Term Archive.
+				$id_lookup = false;
+				if ( null === $id ) {
+					$id = $pod->term_id;
+				}
 				$pod       = $pod->taxonomy;
-				$id_lookup = true;
 			} elseif ( $pod instanceof WP_User ) {
 				// Author Archive.
+				$id_lookup = false;
+				if ( null === $id ) {
+					$id = $pod->ID;
+				}
 				$pod       = 'user';
-				$id_lookup = true;
 			} elseif ( $pod instanceof WP_Post_Type ) {
 				// Post Type Archive.
 				$pod       = $pod->name;

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -141,18 +141,21 @@ class Pods implements Iterator {
 				if ( null === $id ) {
 					$id = $pod->ID;
 				}
+
 				$pod = $pod->post_type;
 			} elseif ( $pod instanceof WP_Term ) {
 				// Term Archive.
 				if ( null === $id ) {
 					$id = $pod->term_id;
 				}
+
 				$pod = $pod->taxonomy;
 			} elseif ( $pod instanceof WP_User ) {
 				// Author Archive.
 				if ( null === $id ) {
 					$id = $pod->ID;
 				}
+
 				$pod = 'user';
 			} elseif ( $pod instanceof WP_Post_Type ) {
 				// Post Type Archive.

--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -138,41 +138,31 @@ class Pods implements Iterator {
 		if ( $pod && ! is_string( $pod ) && ! $pod instanceof Pod ) {
 			if ( $pod instanceof WP_Post ) {
 				// Post Type Singular.
-				$id_lookup = false;
 				if ( null === $id ) {
 					$id = $pod->ID;
 				}
-				$pod       = $pod->post_type;
+				$pod = $pod->post_type;
 			} elseif ( $pod instanceof WP_Term ) {
 				// Term Archive.
-				$id_lookup = false;
 				if ( null === $id ) {
 					$id = $pod->term_id;
 				}
-				$pod       = $pod->taxonomy;
+				$pod = $pod->taxonomy;
 			} elseif ( $pod instanceof WP_User ) {
 				// Author Archive.
-				$id_lookup = false;
 				if ( null === $id ) {
 					$id = $pod->ID;
 				}
-				$pod       = 'user';
+				$pod = 'user';
 			} elseif ( $pod instanceof WP_Post_Type ) {
 				// Post Type Archive.
-				$pod       = $pod->name;
-				$id_lookup = false;
+				$pod = $pod->name;
 			} elseif ( $pod instanceof WP_Taxonomy ) {
 				// Taxonomy object.
-				$pod       = $pod->name;
-				$id_lookup = false;
+				$pod = $pod->name;
 			} else {
 				// Unsupported pod object.
-				$pod       = null;
-				$id_lookup = false;
-			}
-
-			if ( null === $id && $id_lookup ) {
-				$id = get_queried_object_id();
+				$pod = null;
 			}
 		}//end if
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
When passing a WP object to `pods()` we can use it's ID instead of the queried object.
This use of the param makes way more sense.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #7094 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
