### PR TITLE
fix: form ui label tooltip heading and anchor color contract (#7118)

### DIFF
--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -175,7 +175,7 @@ class Pods_Templates extends PodsComponent {
 				'name'       => 'restrict_capability',
 				'label'      => __( 'Restrict access by Capability', 'pods' ),
 				'help'       => [
-					__( '<h6>Capabilities</h6> Capabilities denote access to specific functionality in WordPress, and are assigned to specific User Roles. Please see the Roles and Capabilities component in Pods for an easy tool to add your own capabilities and roles.', 'pods' ),
+					__( '<h3>Capabilities</h3> Capabilities denote access to specific functionality in WordPress, and are assigned to specific User Roles. Please see the Roles and Capabilities component in Pods for an easy tool to add your own capabilities and roles.', 'pods' ),
 					'http://codex.wordpress.org/Roles_and_Capabilities',
 				],
 				'default'    => 0,

--- a/ui/styles/src/base/_wizard.scss
+++ b/ui/styles/src/base/_wizard.scss
@@ -157,6 +157,19 @@
 				padding: 7px 10px;
 				font-family: Georgia,"Times New Roman","Bitstream Charter",Times,serif;
 			}
+			/* 
+				issue #7118 
+				h3 color: inherit - improve color contract (accessibility)
+				 a color: inherit - improve color contract (accessibility)
+			*/
+			.qtip-content {
+				h3 {
+					color: inherit;
+				}
+				a {
+					color: inherit;
+				}
+			}
 			.inside {
 				padding: 0;
 

--- a/ui/styles/src/libs/_jquery-qtip.scss
+++ b/ui/styles/src/libs/_jquery-qtip.scss
@@ -21,6 +21,11 @@
 	word-wrap: break-word;
 }
 
+/* #7118 */
+.qtip-content :is(h3, a) {
+	color: inherit;
+}
+
 .qtip-titlebar {
 	position: relative;
 	padding: 5px 35px 5px 10px;


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Add `color: inherit;` to `h3` and `a` of `.qtip-content` div, now heading and anchor link has good color contract ratio.

## Related GitHub issue(s)
Fixes #7118 

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Go to 'Pods Admin'
2. Click on 'Add New'
3. Click on 'Create New'
4. Hover 'Content Type' `?` icon

## Screenshots / screencast
<img width="985" alt="Screenshot 2023-07-17 at 21 24 10" src="https://github.com/pods-framework/pods/assets/75633537/22fe5e57-ebd9-41e9-b262-c5ae9a2c2113">


<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->


## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
