### PR TITLE
Use new get_tax_prop method with backwards compatibility

### DIFF
--- a/src/Pods/Integrations/Polylang.php
+++ b/src/Pods/Integrations/Polylang.php
@@ -400,11 +400,21 @@ class Polylang extends Integration {
 
 		// If the language object exists, add it!
 		if ( $language && ! empty( $language->term_id ) ) {
-			$lang_data['t_id']     = (int) $language->term_id;
-			$lang_data['tt_id']    = (int) $language->term_taxonomy_id;
-			$lang_data['tl_t_id']  = (int) $language->tl_term_id;
-			$lang_data['tl_tt_id'] = (int) $language->tl_term_taxonomy_id;
-			$lang_data['term']     = $language;
+
+			$lang_data['term'] = $language;
+			$lang_data['t_id'] = (int) $language->term_id;
+
+			if ( method_exists( $language, 'get_tax_prop' ) ) {
+				// Since Polylang 3.4
+				$lang_data['tt_id']    = (int) $language->get_tax_prop( 'language', 'term_taxonomy_id' );
+				$lang_data['tl_t_id']  = (int) $language->get_tax_prop( 'term_language', 'term_id' );
+				$lang_data['tl_tt_id'] = (int) $language->get_tax_prop( 'term_language', 'term_taxonomy_id' );
+			} else {
+				// Pre Polylang 3.4
+				$lang_data['tt_id']    = (int) $language->term_taxonomy_id;
+				$lang_data['tl_t_id']  = (int) $language->tl_term_id;
+				$lang_data['tl_tt_id'] = (int) $language->tl_term_taxonomy_id;
+			}
 		}
 
 		$lang_data[ $locale ] = $lang_data;


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
This PR will update our compatibility code with the latest Polylang changes

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->
Fixes #7139 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
