### PR TITLE
Enhance user magictag

### DIFF
--- a/includes/data.php
+++ b/includes/data.php
@@ -1799,6 +1799,23 @@ function pods_evaluate_tag( $tag, $args = array() ) {
 		return $value;
 	}
 
+	// User special magic tag.
+	if ( 0 === strpos( $tag, 'user.' ) ) {
+		$pod = pods( 'user', get_current_user_id() );
+		if ( $pod->is_valid() && $pod->exists() ) {
+			$value = $pod->do_magic_tags( '{@' . substr( $tag, 5 ) . '}' );
+
+			if ( $value ) {
+
+				if ( $sanitize ) {
+					$value = pods_sanitize( $value );
+				}
+
+				return $value;
+			}
+		}
+	}
+
 	$tag = trim( $tag, ' {@}' );
 	$tag = explode( ',', $tag );
 	$tag = pods_trim( $tag );

--- a/includes/data.php
+++ b/includes/data.php
@@ -683,8 +683,6 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 
 					if ( 'user_pass' === $var || 'user_activation_key' === $var ) {
 						$value = '';
-					} elseif ( isset( $user->{$var} ) ) {
-						$value = $user->{$var};
 					} elseif ( 'role' === $var ) {
 						$value = '';
 
@@ -692,7 +690,14 @@ function pods_v( $var = null, $type = 'get', $default = null, $strict = false, $
 							$value = array_shift( $user->roles );
 						}
 					} else {
-						$value = get_user_meta( $user->ID, $var );
+						$value = '';
+						if ( isset( $user->data->{$var} ) ) {
+							$value = $user->data->{$var};
+						} elseif ( metadata_exists( 'user', $user->ID, $var ) ) {
+							$value = get_user_meta( $user->ID, $var );
+						} elseif ( isset( $user->{$var} ) ) {
+							$value = $user->{$var};
+						}
 					}
 
 					if ( is_array( $value ) && ! empty( $value ) ) {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->

Currently the {@user.##} magic tag is quite limited to the WP_User object only.
This won't properly support multiple metedata values and also doesn't consider the a possible User Pod.
This PR fixes this by fixing two things:
- `pods_v()` > Proper order of getting user properties or metadata
- `pods_evaluate_tag()` > If a user Pod exists, it will run the tag through this Pod first.

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #7150 

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [ ] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
