### PR TITLE
Add support for disabling Quick Edit for Post Types and Taxonomies in WP 6.4+

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1167,6 +1167,7 @@ class PodsInit {
 					'revisions'       => (boolean) pods_v( 'supports_revisions', $post_type, false ),
 					'page-attributes' => (boolean) pods_v( 'supports_page_attributes', $post_type, false ),
 					'post-formats'    => (boolean) pods_v( 'supports_post_formats', $post_type, false ),
+					'quick-edit'      => (boolean) pods_v( 'supports_quick_edit', $post_type, true ),
 				);
 
 				// Custom Supported
@@ -1812,6 +1813,50 @@ class PodsInit {
 	}
 
 	/**
+	 * Filter whether Quick Edit should be enabled for the given post type.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool   $enable    Whether to enable the Quick Edit functionality.
+	 * @param string $post_type The post type name.
+	 *
+	 * @return bool Whether to enable the Quick Edit functionality.
+	 */
+	public function quick_edit_enabled_for_post_type( bool $enable, string $post_type ) {
+		if ( ! $enable ) {
+			return $enable;
+		}
+
+		if ( ! isset( PodsMeta::$post_types[ $post_type ] ) ) {
+			return $enable;
+		}
+
+		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$post_types[ $post_type ], true );
+	}
+
+	/**
+	 * Filter whether Quick Edit should be enabled for the given taxonomy.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool   $enable   Whether to enable the Quick Edit functionality.
+	 * @param string $taxonomy The taxonomy name.
+	 *
+	 * @return bool Whether to enable the Quick Edit functionality.
+	 */
+	public function quick_edit_enabled_for_taxonomy( bool $enable, string $taxonomy ) {
+		if ( ! $enable ) {
+			return $enable;
+		}
+
+		if ( ! isset( PodsMeta::$taxonomies[ $taxonomy ] ) ) {
+			return $enable;
+		}
+
+		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$taxonomies[ $taxonomy ], true );
+	}
+
+	/**
 	 * Check if we need to flush WordPress rewrite rules
 	 * This gets run during 'init' action late in the game to give other plugins time to register their rewrite rules
 	 */
@@ -2438,6 +2483,10 @@ class PodsInit {
 
 		// Compatibility for Query Monitor conditionals
 		add_filter( 'query_monitor_conditionals', array( $this, 'filter_query_monitor_conditionals' ) );
+
+		// Support for quick edit in WP 6.4+.
+		add_filter( 'quick_edit_enabled_for_post_type', [ $this, 'quick_edit_enabled_for_post_type' ], 10, 2 );
+		add_filter( 'quick_edit_enabled_for_taxonomy', [ $this, 'quick_edit_enabled_for_taxonomy' ], 10, 2 );
 	}
 
 	/**

--- a/src/Pods/Admin/Config/Pod.php
+++ b/src/Pods/Admin/Config/Pod.php
@@ -1015,6 +1015,16 @@ class Pod extends Base {
 				],
 			];
 
+			// Add support for disabling Quick Edit in WP 6.4+.
+			if ( pods_version_check( 'wp', '6.4-beta-1' ) ) {
+				$options['advanced']['post_type_supports']['boolean_group']['supports_quick_edit'] = [
+					'name'    => 'supports_quick_edit',
+					'label'   => __( 'Quick Edit', 'pods' ),
+					'type'    => 'boolean',
+					'default' => 1,
+				];
+			}
+
 			/**
 			 * Allow filtering the list of supported features for the post type
 			 *
@@ -1321,6 +1331,16 @@ class Pod extends Base {
 					'excludes-on' => [ 'default_term_name' => '' ],
 				],
 			];
+
+			// Add support for disabling Quick Edit in WP 6.4+.
+			if ( pods_version_check( 'wp', '6.4-beta-1' ) ) {
+				$options['advanced']['supports_quick_edit'] = [
+					'name'    => 'supports_quick_edit',
+					'label'   => __( 'Enable Quick Edit', 'pods' ),
+					'type'    => 'boolean',
+					'default' => 1,
+				];
+			}
 
 			$related_objects = PodsForm::field_method( 'pick', 'related_objects', true );
 


### PR DESCRIPTION
## Description

This adds support for disabling the Quick Edit feature for Post Type and Taxonomies which was added in WP 6.4 via https://core.trac.wordpress.org/ticket/19343#comment:23

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Edit a custom post type or custom taxonomy pod
2. Go to Advanced tab
3. Uncheck the support for Quick Edit
4. Save the pod
5. Check the WP screen for that object and confirm quick edit is either enabled or disabled based on your previous change

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
