### PR TITLE
Fix custom capability fallback

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1232,10 +1232,10 @@ class PodsInit {
 					$cpt_rewrite['slug'] = preg_replace( '/[^a-zA-Z0-9%\-_\/]/', '-', $cpt_rewrite['slug'] );
 				}
 
-				$capability_type = pods_v( 'capability_type', $post_type, 'post' );
+				$capability_type = pods_v( 'capability_type', $post_type, 'post', true );
 
 				if ( 'custom' === $capability_type ) {
-					$capability_type = pods_v( 'capability_type_custom', $post_type, pods_v( 'name', $post_type, 'post' ) );
+					$capability_type = pods_v( 'capability_type_custom', $post_type, pods_v( 'name', $post_type, 'post', true ), true );
 				}
 
 				$show_in_menu = (boolean) pods_v( 'show_in_menu', $post_type, true );

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1235,7 +1235,7 @@ class PodsInit {
 				$capability_type = pods_v( 'capability_type', $post_type, 'post' );
 
 				if ( 'custom' === $capability_type ) {
-					$capability_type = pods_v( 'capability_type_custom', $post_type, 'post' );
+					$capability_type = pods_v( 'capability_type_custom', $post_type, pods_v( 'name', $post_type, 'post' ) );
 				}
 
 				$show_in_menu = (boolean) pods_v( 'show_in_menu', $post_type, true );


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
Currently if you leave the custom capability field empty it will fallback to `post` instead of the CPT name.
This PR fixes this :)

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Related #7218

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Create CPT with custom cap
3. Leave custom cap empty
4. Switch to role that includes the custom edit caps (edit_cpt/edit_cpts) but doesn't have the default edit_post and edit_posts caps.
5. Try to edit CPT post
6. You can't! :(
7. Apply patch
8. You can! :)

## Changelog text for these changes

<!-- Please include a human readable description of what your change did for our changelog in the readme.txt -->
<!-- Feature: You can now do XYZ. #IssueNumber (@your-GH-username) -->
<!-- Enhancement: XYZ will now ABC. #IssueNumber (@your-GH-username) -->
<!-- Bug: XYZ now does ABC correctly. #IssueNumber (@your-GH-username) -->
<!-- If your fix addresses multiple things, please list each unique issue as separate changelog items. -->

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
