### PR TITLE
Make GitHub display shorter tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = tab
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 # spaces_around_operators = true


### PR DESCRIPTION
## Description

Currently TAB characters are displayed as 8 spaces.
This PR make tabs half as wide.

