### PR TITLE
Relationship Field Sync Taxonomy: Checkbox & Unblock Sync

### DIFF
--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -449,6 +449,8 @@ class PodsField_Pick extends PodsField {
 						'^taxonomy-.*$',
 					],
 				],
+				'type'           => 'boolean',
+				'default'        => 0,
 			]
 		];
 
@@ -1924,25 +1926,26 @@ class PodsField_Pick extends PodsField {
 			}
 		} elseif ( $options instanceof Field || $options instanceof Value_Field ) {
 			$related_field = $options->get_bidirectional_field();
-
-			if ( ! $related_field ) {
-				return;
-			}
-
-			$related_pod        = $related_field->get_parent_object();
-			$related_pick_limit = $related_field->get_limit();
-
-			if ( null === $current_ids ) {
-				$current_ids = self::$api->lookup_related_items( $options['id'], $pod['id'], $id, $options, $pod );
-			}
-
-			// Get ids to remove.
-			if ( null === $remove_ids ) {
-				$remove_ids = array_diff( $current_ids, $value_ids );
+			
+			if ( $related_field ) {
+				$related_pod        = $related_field->get_parent_object();
+				$related_pick_limit = $related_field->get_limit();
+	
+				if ( null === $current_ids ) {
+					$current_ids = self::$api->lookup_related_items( $options['id'], $pod['id'], $id, $options, $pod );
+				}
+	
+				// Get ids to remove.
+				if ( null === $remove_ids ) {
+					$remove_ids = array_diff( $current_ids, $value_ids );
+				}
 			}
 		}
 
-		if ( empty( $related_field ) || empty( $related_pod ) ) {
+		if (
+			( empty( $related_field ) || empty( $related_pod ) )
+			&& empty( $options[ static::$type . '_sync_taxonomy' ] )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

- Change taxonomy sync option from text to boolean.
- Change bidirectional relationship check from preventing taxonomy sync feature from running due to early `return`

## Related GitHub issue(s)

#7334

## Changelog text for these changes

Bug: Relationship Field Taxonomy Sync now works correctly and presents as checkbox. User Interface for taxonomies using this feature should be hidden in taxonomy Admin UI settings to avoid confusion, as changes relationship field will update core taxonomy, but core taxonomy user interfaces will not update relationship field. @pdclark

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
