### PR TITLE
REST API Write access - Fix invalid default value

### DIFF
--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -4418,7 +4418,7 @@ class PodsAdmin {
 				'label'             => __( 'Allow All Fields To Be Updated', 'pods' ),
 				'help'              => __( 'Allow all fields to be updated via the REST API. If unchecked fields must be enabled on a field by field basis.', 'pods' ),
 				'type'              => 'boolean',
-				'default'           => pods_v( 'name', $pod ),
+				'default'           => '',
 				'depends-on'        => [ 'rest_enable' => true, 'read_all' => true ],
 			],
 			/*'write_all_access'   => [

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -4375,21 +4375,21 @@ class PodsAdmin {
 		}
 
 		$options['rest-api'] = [
-			'rest_enable' => [
+			'rest_enable'             => [
 				'label'      => __( 'Enable', 'pods' ),
 				'help'       => __( 'Add REST API support for this Pod.', 'pods' ),
 				'type'       => 'boolean',
 				'default'    => '',
 				'dependency' => true,
 			],
-			'rest_base'   => [
+			'rest_base'               => [
 				'label'      => __( 'REST Base (if any)', 'pods' ),
 				'help'       => __( 'This will form the url for the route. Default / empty value here will use the pod name.', 'pods' ),
 				'type'       => 'text',
 				'default'    => '',
 				'depends-on' => [ 'rest_enable' => true ],
 			],
-			'rest_namespace'   => [
+			'rest_namespace'          => [
 				'label'       => __( 'REST API namespace', 'pods' ),
 				'help'        => __( 'This will change the namespace URL of the REST API route to a different one from the default one that all normal route endpoints use.', 'pods' ),
 				'type'        => 'text',
@@ -4397,7 +4397,7 @@ class PodsAdmin {
 				'placeholder' => 'wp/v2',
 				'depends-on'  => [ 'rest_enable' => true ],
 			],
-			'read_all'    => [
+			'read_all'                => [
 				'label'      => __( 'Show All Fields (read-only)', 'pods' ),
 				'help'       => __( 'Show all fields in REST API. If unchecked fields must be enabled on a field by field basis.', 'pods' ),
 				'type'       => 'boolean',
@@ -4405,7 +4405,7 @@ class PodsAdmin {
 				'depends-on' => [ 'rest_enable' => true ],
 				'dependency' => true,
 			],
-			'read_all_access'   => [
+			'read_all_access'         => [
 				'label'             => __( 'Read All Access', 'pods' ),
 				'help'              => __( 'By default the REST API will allow the fields to be returned for everyone who has access to that endpoint/object. You can also restrict the access of your field based on whether the person is logged in.', 'pods' ),
 				'type'              => 'boolean',
@@ -4414,7 +4414,7 @@ class PodsAdmin {
 					'read_all' => true,
 				],
 			],
-			'write_all'   => [
+			'write_all'               => [
 				'label'      => __( 'Allow All Fields To Be Updated', 'pods' ),
 				'help'       => __( 'Allow all fields to be updated via the REST API. If unchecked fields must be enabled on a field by field basis.', 'pods' ),
 				'type'       => 'boolean',
@@ -4430,20 +4430,20 @@ class PodsAdmin {
 					'write_all' => true,
 				],
 			],*/
-			'rest_api_field_mode'   => [
-				'label'             => __( 'Field Mode', 'pods' ),
-				'help'              => __( 'Specify how you would like your values returned in the REST API responses. If you choose to show Both raw and rendered values then an object will be returned for each field that contains the value and rendered properties.', 'pods' ),
-				'type'              => 'pick',
+			'rest_api_field_mode'     => [
+				'label'              => __( 'Field Mode', 'pods' ),
+				'help'               => __( 'Specify how you would like your values returned in the REST API responses. If you choose to show Both raw and rendered values then an object will be returned for each field that contains the value and rendered properties.', 'pods' ),
+				'type'               => 'pick',
 				'pick_format_single' => 'radio',
-				'default'           => 'value',
-				'depends-on'        => [ 'rest_enable' => true ],
-				'data'       => [
+				'default'            => 'value',
+				'depends-on'         => [ 'rest_enable' => true ],
+				'data'               => [
 					'value'            => __( 'Raw values', 'pods' ),
 					'render'           => __( 'Rendered values', 'pods' ),
 					'value_and_render' => __( 'Both raw and rendered values {value: raw_value, rendered: rendered_value}', 'pods' ),
 				],
 			],
-			'rest_api_field_location'   => [
+			'rest_api_field_location' => [
 				'label'              => __( 'Field Location', 'pods' ),
 				'help'               => __( 'Specify where you would like your values returned in the REST API responses. To show in the "meta" object of the response, you must have Custom Fields enabled in the Post Type Supports features.', 'pods' ),
 				'type'               => 'pick',

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -4415,11 +4415,11 @@ class PodsAdmin {
 				],
 			],
 			'write_all'   => [
-				'label'             => __( 'Allow All Fields To Be Updated', 'pods' ),
-				'help'              => __( 'Allow all fields to be updated via the REST API. If unchecked fields must be enabled on a field by field basis.', 'pods' ),
-				'type'              => 'boolean',
-				'default'           => '',
-				'depends-on'        => [ 'rest_enable' => true, 'read_all' => true ],
+				'label'      => __( 'Allow All Fields To Be Updated', 'pods' ),
+				'help'       => __( 'Allow all fields to be updated via the REST API. If unchecked fields must be enabled on a field by field basis.', 'pods' ),
+				'type'       => 'boolean',
+				'default'    => '',
+				'depends-on' => [ 'rest_enable' => true, 'read_all' => true ],
 			],
 			/*'write_all_access'   => [
 				'label'             => __( 'Write All Access', 'pods' ),

--- a/classes/PodsRESTFields.php
+++ b/classes/PodsRESTFields.php
@@ -225,7 +225,14 @@ class PodsRESTFields {
 
 		$pod_mode_arg = $mode . '_all';
 
-		$all_fields_can_use_mode = filter_var( $pod->get_arg( $pod_mode_arg, false ), FILTER_VALIDATE_BOOLEAN );
+		$pod_mode = $pod->get_arg( $pod_mode_arg, false );
+
+		// Backcompat for a previous bug in Pods < 3.2.7 where the default value was the pod name instead of '0'.
+		if ( $pod_mode === $pod->get_name() ) {
+			$pod_mode = 0;
+		}
+
+		$all_fields_can_use_mode = filter_var( $pod_mode, FILTER_VALIDATE_BOOLEAN );
 		$all_fields_access       = 'read' === $mode && filter_var( $pod->get_arg( 'read_all_access', false ), FILTER_VALIDATE_BOOLEAN );
 
 		// Check if user must be logged in to access all fields and override whether they can use it.


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the code will change and do. -->
De default value for the `write_all` option of a Pod was set to the Pod name. This results in incorrect parsing of a boolean in `PodsRESTFields::field_allowed_to_extend()` in `write` mode.

@sc0ttkclark See testing instructions. I'm not sure how you would like to implement something that will repair old Pods. You could check for `! empty()` instead of using `filter_var()` but that might not be desirable. 

## Related GitHub issue(s)

<!-- If you are aware of any existing GitHub issues https://github.com/pods-framework/pods/issues then please note them here. -->
<!-- List each issue by simply typing the issue number "#1234" and GitHub will automatically link it up for you. -->
<!-- If this fixes a bug or solves a feature requests, please use the phrase "Fixes #1234" so that it will automatically get closed on release. -->

Fixes #7327

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Create a Pod without this patch and enable write mode.
2. Go to `PodsRESTFields::field_allowed_to_extend()` and dump `$all_fields_can_use_mode`. It will return false, allways.
3. Verify with `$pod->get_arg( $pod_mode_arg, 'value_not_set' )` and see it returns the Pod name instead of a 1 or 0.
4. Apply this patch
5. Disable REST write access and save Pod (important, otherwise it won't reset the value)
6. Re-enable REST Write access and save Pod.
7. Redo 1, 2 and 3 and you'll see it returns the correct values now.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
