### PR TITLE
Improve REST authentication method when registering fields

### DIFF
--- a/classes/PodsRESTFields.php
+++ b/classes/PodsRESTFields.php
@@ -27,6 +27,7 @@ class PodsRESTFields {
 
 	/**
 	 * The user ID for the authenticated user.
+	 *
 	 * @var int
 	 */
 	private static $rest_user_id;

--- a/classes/PodsRESTFields.php
+++ b/classes/PodsRESTFields.php
@@ -26,6 +26,12 @@ class PodsRESTFields {
 	protected $pod = null;
 
 	/**
+	 * The user ID for the authenticated user.
+	 * @var int
+	 */
+	private static $rest_user_id;
+
+	/**
 	 * Constructor for class
 	 *
 	 * @since 2.5.6
@@ -100,6 +106,21 @@ class PodsRESTFields {
 		}
 
 		$this->pod = $pod;
+	}
+
+	/**
+	 * Validates if a current user or application is logged in.
+	 *
+	 * @return bool
+	 */
+	public static function is_rest_authenticated(): bool {
+		if ( isset( self::$rest_user_id ) ) {
+			return ! empty( self::$rest_user_id );
+		}
+
+		self::$rest_user_id = wp_validate_application_password( get_current_user_id() );
+
+		return ! empty( self::$rest_user_id );
 	}
 
 	/**
@@ -230,7 +251,7 @@ class PodsRESTFields {
 
 		// Check if user must be logged in to access all fields and override whether they can use it.
 		if ( $all_fields_can_use_mode && $all_fields_access ) {
-			$all_fields_can_use_mode = is_user_logged_in();
+			$all_fields_can_use_mode = self::is_rest_authenticated();
 		}
 
 		// Maybe get the Field object from the Pod.
@@ -260,7 +281,7 @@ class PodsRESTFields {
 
 		// Check if user must be logged in to access field and override whether they can use it.
 		if ( $can_use_mode && $access ) {
-			$can_use_mode = is_user_logged_in();
+			$can_use_mode = self::is_rest_authenticated();
 		}
 
 		return $can_use_mode;

--- a/classes/PodsRESTFields.php
+++ b/classes/PodsRESTFields.php
@@ -26,13 +26,6 @@ class PodsRESTFields {
 	protected $pod = null;
 
 	/**
-	 * The user ID for the authenticated user.
-	 *
-	 * @var int
-	 */
-	private static $rest_user_id;
-
-	/**
 	 * Constructor for class
 	 *
 	 * @since 2.5.6
@@ -115,13 +108,20 @@ class PodsRESTFields {
 	 * @return bool
 	 */
 	public static function is_rest_authenticated(): bool {
-		if ( isset( self::$rest_user_id ) ) {
-			return ! empty( self::$rest_user_id );
+		$is_rest_authenticated = (bool) pods_static_cache_get( __FUNCTION__, __CLASS__ );
+
+		if ( $is_rest_authenticated ) {
+			return true;
 		}
 
-		self::$rest_user_id = wp_validate_application_password( get_current_user_id() );
+		$is_rest_authenticated = (
+			is_user_logged_in()
+			|| wp_validate_application_password( get_current_user_id() )
+		);
 
-		return ! empty( self::$rest_user_id );
+		pods_static_cache_set( __FUNCTION__, (int) $is_rest_authenticated, __CLASS__ );
+
+		return $is_rest_authenticated;
 	}
 
 	/**

--- a/tests/codeception/wpunit/Pods/PodsRESTFieldsTest.php
+++ b/tests/codeception/wpunit/Pods/PodsRESTFieldsTest.php
@@ -160,6 +160,8 @@ class PodsRESTFieldsTest extends Pods_UnitTestCase {
 		$this->full_write_pod_id = null;
 		$this->full_write_pod    = null;
 
+		pods_static_cache_clear();
+
 		// Reset current user.
 		global $current_user;
 


### PR DESCRIPTION
Instead of checking if the user is logged in it also checks if the user a basic auth for applications is used.

## Description

<!-- A clear and concise description of what the code will change and do. -->

Fixes #7340

@sc0ttkclark I'm not 100% sure this will be the best method. You could also already set the current WP user so WP core doesn't revalidate using the same method. I'll leave this up to your judgement.

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

See #7340

Try the same with this patch and see it now works!

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
