### PR TITLE
Fixing strlen() error

### DIFF
--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3000,7 +3000,7 @@ class PodsUI {
 
 							echo PodsForm::submit_button( $this->header['search'], 'button', false, false, array( 'id' => $this->num_prefix . 'search' . $this->num . '-submit' ) );
 
-							if ( NULL === $this->search ) {
+							if ( 0 < strlen( (string) $this->search ) ) {
 								$clear_filters = array(
 									$this->num_prefix . 'search' . $this->num => false,
 								);

--- a/classes/PodsUI.php
+++ b/classes/PodsUI.php
@@ -3000,7 +3000,7 @@ class PodsUI {
 
 							echo PodsForm::submit_button( $this->header['search'], 'button', false, false, array( 'id' => $this->num_prefix . 'search' . $this->num . '-submit' ) );
 
-							if ( 0 < strlen( $this->search ) ) {
+							if ( NULL === $this->search ) {
 								$clear_filters = array(
 									$this->num_prefix . 'search' . $this->num => false,
 								);


### PR DESCRIPTION
## Description
Fix the message "PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/wp-content/plugins/pods/classes/PodsUI.php on line 3003" that show on pods manage page

## Testing instructions

1. Create a new Pod
2. Sett it to show on menu
3. Enter to de menu

## Screenshots / screencast
![Captura de pantalla 2025-02-01 - 19 51 48](https://github.com/user-attachments/assets/15a87f8c-8605-4272-a4b7-e60f55ec4cd5)
