### PR TITLE
Generate build provenance attestation during deployment

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -22,7 +22,7 @@ jobs:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         VERSION: ${{ env.PLUGIN_VERSION }}
     - name: Generate build provenance attestation
-      uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+      uses: johnbillion/action-wordpress-plugin-attestation@0.7.1
       with:
         zip-path: ${{ steps.deploy.outputs.zip-path }}
     - name: Send message to Slack API

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -14,10 +14,17 @@ jobs:
       uses: actions/checkout@v4
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@master
+      id: deploy
+      with:
+        generate-zip: true
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         VERSION: ${{ env.PLUGIN_VERSION }}
+    - name: Generate build provenance attestation
+      uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+      with:
+        zip-path: ${{ steps.deploy.outputs.zip-path }}
     - name: Send message to Slack API
       uses: archive/github-actions-slack@v2.7.0
       id: notify


### PR DESCRIPTION
## Description

This uses [the WordPress Plugin Attestation action](https://github.com/johnbillion/action-wordpress-plugin-attestation) to generate a build provenance attestation for the zip file of Pods. This ties the zip file on wordpress.org back to the GitHub Actions workflow that performed the deployment.

## Testing instructions

This isn't testable in isolation because the workflow only runs when you publish a release, but [it's used by several other plugins](https://github.com/johnbillion/action-wordpress-plugin-attestation/network/dependents).

## Changelog text for these changes

Enhancement: A build provenance attestation is now generated for each deployment to the wordpress.org plugin directory. (@johnbillion)
