### PR TITLE
Enable a fix for 7430 by making sure tinymce-s textarea exist before …

### DIFF
--- a/ui/js/dfv/src/fields/wysiwyg/tinymce.js
+++ b/ui/js/dfv/src/fields/wysiwyg/tinymce.js
@@ -60,7 +60,9 @@ const TinyMCE = ( {
 			onReadyStateChange
 		);
 		window.wp.oldEditor.remove( fieldId );
-		textarea.removeAttribute( 'style' );
+        if (textarea) {
+		    textarea.removeAttribute( 'style' );
+        }
 		didMountRef.current = false;
 	}
 


### PR DESCRIPTION
…being accessed

## Description

The code will make sure that when using conditional logic with tinyMce the whole script won't crash.

## Related GitHub issue(s)

https://github.com/pods-framework/pods/issues/7430

## Testing instructions

<!-- List of steps to test the changes so we can see confirm it works as intended. -->

1. Create a pods with conditional logic applied to a tinyMce field.
2. Trigger the conditinal logic and see  if the script crash.

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

The code will make sure that when using conditional logic with tinyMce the whole script won't crash.


## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
