### PR TITLE
Feature/7472 podstest unit test failing

### DIFF
--- a/tests/codeception/wpunit/Pods/Shortcode/PodsTest.php
+++ b/tests/codeception/wpunit/Pods/Shortcode/PodsTest.php
@@ -54,7 +54,7 @@ class PodsTest extends Pods_UnitTestCase {
 		$this->pod_id = $api->save_pod( array(
 			'type'   => 'pod',
 			'name'   => $this->pod_name,
-			'public'  => 1,
+			'public' => 1,
 		) );
 
 		$params = array(


### PR DESCRIPTION
## Description

sets up the pod intended as a public pod in the testing class as public. 

## Related GitHub issue(s)

#7472 

## Testing instructions

run the unit tests vendor/bin/codecept run wpunit  tests/codeception/wpunit/Pods/Shortcode/PodsTest.php:test_shortcode_pods -v

## PR checklist

- [x ] I have tested my own code to confirm it works as I intended.
- [ x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
