### PR TITLE
Introduce hourly verification of the PLC DID and FAIR metadata

### DIFF
--- a/.github/workflows/verify-distribution.yml
+++ b/.github/workflows/verify-distribution.yml
@@ -1,0 +1,43 @@
+name: Verify Plugin Distribution
+on:
+  schedule:
+    # Once per hour
+    #
+    #        ┌───────────── minute           (0 - 59)
+    #        │  ┌────────── hour             (0 - 23)
+    #        │  │  ┌─────── day of the month (1 - 31)
+    #        │  │  │  ┌──── month            (1 - 12 or JAN-DEC)
+    #        │  │  │  │  ┌─ day of the week  (0 - 6 or SUN-SAT)
+    #        │  │  │  │  │
+    #        │  │  │  │  │
+    #        │  │  │  │  │
+    - cron: '45 *  *  *  *'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/verify-distribution.yml'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/verify-distribution.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  fair:
+    name: Verify FAIR status
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
+    steps:
+      - name: Install fair-tools
+        run: | #shell
+          npm install -g fair-tools@0.8.1
+
+      - name: Verify PLC DID and FAIR metadata
+        run: | #shell
+          fair-tools did verify \
+            --did "did:plc:e3rm6t7cspgpzaf47kn3nnsl"


### PR DESCRIPTION
## Description

This introduces a GitHub Actions workflow which runs on an hourly schedule. The workflow runs `fair-tools did verify` which is the command in [my fair-tools package](https://github.com/johnbillion/fair-tools) which runs a full verification of:

  1. The PLC DID operation log starting at its genesis. This is the most complete verification of the PLC DID and its log that's possible.
  2. The FAIR service endpoint and the FAIR metadata document that it serves. Includes verification of the signature and checksum for the latest release artifact.
  3. The `fair://` domain alias. There isn't one for Pods currently so it skips the check. If you were to add one to the DID document it would detect it and validate its DNS entry.

## Why?

This acts as an early warning mechanism that provides the following benefits:

1. A correctness check for your FAIR service endpoint and its FAIR metadata document. If you make a mistake with your FAIR metadata document, such as messing up the checksum for the latest release artifact, it will detect it and fail the workflow. It also fails the workflow if the service endpoint is down or serves an invalid response.
2. A supply chain security enhancement for your FAIR metadata document. If someone were to take control of your service endpoint and publish a malicious release to its FAIR metadata document, the workflow would detect the invalid signature and fail the workflow.
3. A supply chain security enhancement for your PLC DID. It should be impossible for anyone to publish a false entry to your DID log due to its self-certifying nature, but this validates the log anyway and will detect if the DID gets tombstoned.

## Testing instructions

The workflow will run as part of this PR. Its output can be seen in the Checks tab. The workflow can also be triggered manually from the Actions tab (once this PR is merged).

## Screenshots / screencast

No screenshot, but here's the output:

```
Verifying did:plc:e3rm6t7cspgpzaf47kn3nnsl...

DID Log Validation:
  ✓ 4 operations validated
  ✓ Current state computed successfully

Service Endpoints:

  https://stats.pods.io/wp-json/fair-beacon/v1/packages/did:plc:e3rm6t7cspgpzaf47kn3nnsl:
    ✓ Metadata document valid
    ✓ Release v3.3.4
      ✓ https://api.github.com/repos/pods-framework/pods/zipball/3.3.4: Signature valid (did:plc:e3rm6t7cspgpzaf47kn3nnsl#fair_3cb126), checksum valid

Domain Aliases:
  - No fair:// alias configured

Overall: PASSED
```

If any item were to fail, for example the checksum of the latest release artifact doesn't match the one in your FAIR metadata document, then that check would fail and cause the workflow to fail.

## Changelog text for these changes

Enhancement: Introduce hourly verification of the PLC DID and FAIR metadata.

## PR checklist

- [X] I have tested my own code to confirm it works as I intended.
- [ ] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
