### PR TITLE
Fix: Preserve conditional field values when hidden (issue #7475)

### DIFF
--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -5119,14 +5119,6 @@ class PodsAPI {
 						continue;
 					}
 
-					// Check if the field should save its value even when hidden.
-					$save_value_when_hidden = (bool) pods_v( 'conditional_logic_save_value', $fields[ $active_field_name ], false );
-
-					// Skip clearing the value if save_value_when_hidden is enabled.
-					if ( $save_value_when_hidden ) {
-						continue;
-					}
-
 					// Unset the field value.
 					$field_values[ $active_field_name ]    = null;
 					$fields[ $active_field_name ]['value'] = null;

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1532,6 +1532,16 @@ class PodsMeta {
 						}
 					}
 
+					// Check if field wasn't submitted (likely hidden by conditional logic).
+					if ( ! isset( $_POST[ 'pods_meta_' . $field['name'] ] ) ) {
+						// If save_value_when_hidden is enabled, skip this field to preserve existing DB value.
+						$conditional_logic_save = (bool) pods_v( 'conditional_logic_save_value', $field, false );
+
+						if ( $conditional_logic_save ) {
+							continue;
+						}
+					}
+
 					$data[ $field['name'] ] = '';
 
 					if ( isset( $_POST[ 'pods_meta_' . $field['name'] ] ) ) {


### PR DESCRIPTION
## Summary

Fixes #7475 - Adds an option to preserve conditional field values when the field is hidden by conditional logic.

## Problem

When a field is hidden by conditional logic, saving the form clears the field's value in the database. This happens because:
1. `PodsMeta.php` initializes ALL fields with an empty string default
2. Hidden fields aren't submitted via `$_POST`
3. The empty value overwrites the existing database value

## Solution

Added a new field option **"Save Value When Hidden"** (`conditional_logic_save_value`) that:
- Appears in the Conditional Logic tab for fields with conditional logic enabled
- When enabled, skips adding the field to the save data if it wasn't submitted (hidden)
- This preserves the existing database value instead of clearing it

## Changes

### `src/Pods/Admin/Config/Field.php`
Added new `conditional_logic_save_value` boolean option to field configuration.

### `classes/PodsMeta.php`

**Before:**
```php
if ( ! pods_permission( $field ) ) {
    if ( 1 !== (int) pods_v( 'hidden', $field, 0 ) ) {
        continue;
    }
}

$data[ $field['name'] ] = '';

if ( isset( $_POST[ 'pods_meta_' . $field['name'] ] ) ) {
    $data[ $field['name'] ] = $_POST[ 'pods_meta_' . $field['name'] ];
}
```

**After:**
```php
if ( ! pods_permission( $field ) ) {
    if ( 1 !== (int) pods_v( 'hidden', $field, 0 ) ) {
        continue;
    }
}

// Check if field wasn't submitted (likely hidden by conditional logic).
if ( ! isset( $_POST[ 'pods_meta_' . $field['name'] ] ) ) {
    // If save_value_when_hidden is enabled, skip this field to preserve existing DB value.
    $conditional_logic_save = (bool) pods_v( 'conditional_logic_save_value', $field, false );

    if ( $conditional_logic_save ) {
        continue;
    }
}

$data[ $field['name'] ] = '';

if ( isset( $_POST[ 'pods_meta_' . $field['name'] ] ) ) {
    $data[ $field['name'] ] = $_POST[ 'pods_meta_' . $field['name'] ];
}
```

### `classes/PodsAPI.php`

**Before:**
```php
// Skip if the field is visible and can be saved.
if ( $is_visible ) {
    continue;
}

// Check if the field should save its value even when hidden.
$save_value_when_hidden = (bool) pods_v( 'conditional_logic_save_value', $fields[ $active_field_name ], false );

// Skip clearing the value if save_value_when_hidden is enabled.
if ( $save_value_when_hidden ) {
    continue;
}

// Unset the field value.
$field_values[ $active_field_name ]    = null;
$fields[ $active_field_name ]['value'] = null;
```

**After:**
```php
// Skip if the field is visible and can be saved.
if ( $is_visible ) {
    continue;
}

// Unset the field value.
$field_values[ $active_field_name ]    = null;
$fields[ $active_field_name ]['value'] = null;
```

## Testing

1. Create a Pod with conditional logic (e.g., Show Banner = Yes/No)
2. Add a conditional field (e.g., Banner Content) that shows when Show Banner = Yes
3. Edit the field and enable "Preserve field value when conditionally hidden"
4. Enter content in Banner Content and save
5. Set Show Banner = No and save
6. Reload the page and set Show Banner = Yes
7. ✅ Banner Content value is preserved

## Checklist

- [x] Code follows WordPress coding standards
- [x] Changes tested manually
- [x] No breaking changes
- [x] Feature is opt-in (requires enabling the option)

---

## Screen Recording

**Before:** https://videos.faisalahammad.com/recordings/hR9KDdIgMfSUNC1nh3hm

**After:** https://videos.faisalahammad.com/recordings/P91zwf3QD774GdGqLovP

### Plugin Zip

[pods-issue-7475-save-conditional-value.zip](https://github.com/user-attachments/files/24965461/pods-issue-7475-save-conditional-value.zip)