### PR TITLE
Fix repeatable WYSIWYG fields infinite loop after import (Issue #7465)

### DIFF
--- a/ui/js/dfv/src/fields/wysiwyg/index.js
+++ b/ui/js/dfv/src/fields/wysiwyg/index.js
@@ -54,7 +54,13 @@ const Wysiwyg = ( props ) => {
 				<ReactQuill
 					value={ value || '' }
 					onBlur={ () => setHasBlurred() }
-					onChange={ setValue }
+					onChange={ ( content, delta, source ) => {
+			// Only update state for user-initiated changes
+			// to prevent infinite loops on mount/programmatic updates
+			if ( source === 'user' ) {
+				setValue( content );
+			}
+		} }
 					theme="snow"
 					modules={ {
 						toolbar: QUILL_TOOLBAR_OPTIONS,


### PR DESCRIPTION
## Summary

Fixes #7465 - Repeatable WYSIWYG fields become uneditable after WordPress content import, causing React error #185 ("Maximum update depth exceeded").

## Problem Analysis

### 🔴 The Bug

When editing a post with repeatable WYSIWYG fields (using Quill editor) that were imported via WordPress XML Import, the fields become completely uneditable and the browser console shows:

```
Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185
```

This error means **"Maximum update depth exceeded"** - an infinite re-render loop in React.

### 🔍 Root Cause

The issue is in `ui/js/dfv/src/fields/wysiwyg/index.js` where ReactQuill's `onChange` handler directly calls `setValue`:

```jsx
// ❌ BEFORE - Causes infinite loop
<ReactQuill
  value={ value || '' }
  onChange={ setValue }  // Problem here!
  ...
/>
```

**Why this causes an infinite loop:**

1. **ReactQuill mounts** with imported HTML content → fires `onChange(content, delta, source)`
2. **`setValue(content)` is called** → updates React state
3. **Component re-renders** with the "new" value (same content, but React sees it as changed)
4. **ReactQuill detects value prop change** → fires `onChange` again
5. **Loop continues indefinitely** → React Error #185

The `source` parameter in ReactQuill's `onChange` tells us *why* the change happened:
- `'user'` = User typed/edited content
- `'api'` = Programmatic change (like setting initial value)
- `'silent'` = Internal change that shouldn't trigger events

### ✅ The Fix

Only call `setValue` when the change was initiated by the user:

```jsx
// ✅ AFTER - No infinite loop
<ReactQuill
  value={ value || '' }
  onChange={ ( content, delta, source ) => {
    // Only update state for user-initiated changes
    // to prevent infinite loops on mount/programmatic updates
    if ( source === 'user' ) {
      setValue( content );
    }
  } }
  ...
/>
```

This is the [recommended approach from react-quill documentation](https://github.com/zenoamaro/react-quill#controlled-mode-caveats).

## Code Changes

### Before/After Diff

```diff
 <ReactQuill
   value={ value || '' }
   onBlur={ () => setHasBlurred() }
-  onChange={ setValue }
+  onChange={ ( content, delta, source ) => {
+    // Only update state for user-initiated changes
+    // to prevent infinite loops on mount/programmatic updates
+    if ( source === 'user' ) {
+      setValue( content );
+    }
+  } }
   theme="snow"
   modules={ { toolbar: QUILL_TOOLBAR_OPTIONS } }
   readOnly={ toBool( readOnly ) }
 />
```

### Files Changed

| File | Change |
|------|--------|
| `ui/js/dfv/src/fields/wysiwyg/index.js` | Fixed `onChange` handler to check `source` parameter |

## Testing

### Automated Tests
- ✅ All 42 Jest tests pass
- ✅ Production build compiles successfully

### Manual Testing
- ✅ Imported the reporter's Pod configuration and WordPress XML export
- ✅ Verified repeatable WYSIWYG fields are now editable
- ✅ No React errors in browser console
- ✅ Content saves and persists correctly

## How to Test

1. Install [this patched plugin zip](https://github.com/user-attachments/files/24976019/pods-fix-7465.zip)
2. Import the Pod configuration from the issue
3. Import the WordPress XML export from the issue
4. Edit the imported "tuote" post type items
5. Verify WYSIWYG fields are editable with no console errors

## Screenshots

**Before:**
<img width="2554" height="1323" alt="image" src="https://github.com/user-attachments/assets/0226bbd6-faef-4fb9-8604-f35b5ec65b55" />

**After:**
<img width="3840" height="1926" alt="25B26829-6AF3-4ACD-BB01-BA20AD82630A" src="https://github.com/user-attachments/assets/2078e4f3-f1ff-4729-ba00-8010ed8529cc" />

## Related

- Issue: #7465
- React Error Reference: https://reactjs.org/docs/error-decoder.html?invariant=185
- react-quill Controlled Mode: https://github.com/zenoamaro/react-quill#controlled-mode-caveats