### PR TITLE
Fix: Defer WP-CLI command registration to prevent textdomain warning

### DIFF
--- a/classes/cli/PodsAPI_CLI_Command.php
+++ b/classes/cli/PodsAPI_CLI_Command.php
@@ -504,4 +504,8 @@ class PodsAPI_CLI_Command extends WP_CLI_Command {
 
 }
 
-WP_CLI::add_command( 'pods-legacy-api', 'PodsAPI_CLI_Command' );
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_hook( 'after_wp_load', function() {
+		WP_CLI::add_command( 'pods-legacy-api', 'PodsAPI_CLI_Command' );
+	} );
+}

--- a/classes/cli/Pods_CLI_Command.php
+++ b/classes/cli/Pods_CLI_Command.php
@@ -385,4 +385,8 @@ class Pods_CLI_Command extends WP_CLI_Command {
 
 }
 
-WP_CLI::add_command( 'pods-legacy', 'Pods_CLI_Command' );
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_hook( 'after_wp_load', function() {
+		WP_CLI::add_command( 'pods-legacy', 'Pods_CLI_Command' );
+	} );
+}


### PR DESCRIPTION
## Summary

This PR fixes the `_load_textdomain_just_in_time` warning that appears on every WP-CLI command when Pods is activated.

Fixes #7458

## Problem

When I run any WP-CLI command on WordPress 6.7.0 or later with Pods activated, I see this warning:

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. 
Translation loading for the `pods` domain was triggered too early. 
This is usually an indicator for some code in the plugin or theme running too early. 
Translations should be loaded at the `init` action or later.
```

## Root Cause

I traced the issue to the legacy CLI command files. The problem is that both files call `WP_CLI::add_command()` at file-level scope (outside any function or hook):

**File: `classes/cli/Pods_CLI_Command.php` (line 388)**
**File: `classes/cli/PodsAPI_CLI_Command.php` (line 507)**

These files are loaded during the `plugins_loaded` hook in `PodsInit::run()`:

```php
// PodsInit.php lines 2438-2443
if ( defined( 'WP_CLI' ) && WP_CLI ) {
    require_once PODS_DIR . 'classes/cli/Pods_CLI_Command.php';
    require_once PODS_DIR . 'classes/cli/PodsAPI_CLI_Command.php';
    // ...
}
```

When PHP executes `require_once`, the `WP_CLI::add_command()` calls run immediately. WP-CLI then inspects the command class and finds `__()` translation function calls inside the class methods. This triggers WordPress to load the `pods` textdomain before the `init` hook fires, which causes the warning.

## Solution

I wrapped the `WP_CLI::add_command()` calls inside a `WP_CLI::add_hook('after_wp_load', ...)` callback. The `after_wp_load` hook fires after WordPress completes initialization, so the textdomain is properly loaded before any translation functions run.

This follows the same pattern already used in `src/Pods/CLI/Service_Provider.php`.

## Code Changes

### Before (Pods_CLI_Command.php)

```php
WP_CLI::add_command( 'pods-legacy', 'Pods_CLI_Command' );
```

### After (Pods_CLI_Command.php)

```php
if ( defined( 'WP_CLI' ) && WP_CLI ) {
    WP_CLI::add_hook( 'after_wp_load', function() {
        WP_CLI::add_command( 'pods-legacy', 'Pods_CLI_Command' );
    } );
}
```

### Before (PodsAPI_CLI_Command.php)

```php
WP_CLI::add_command( 'pods-legacy-api', 'PodsAPI_CLI_Command' );
```

### After (PodsAPI_CLI_Command.php)

```php
if ( defined( 'WP_CLI' ) && WP_CLI ) {
    WP_CLI::add_hook( 'after_wp_load', function() {
        WP_CLI::add_command( 'pods-legacy-api', 'PodsAPI_CLI_Command' );
    } );
}
```

## Testing

1. Activate Pods on a WordPress 6.7+ installation
2. Run any WP-CLI command (for example: `wp plugin list`)
3. Before fix: The textdomain warning appears
4. After fix: No warning appears
5. Verify legacy CLI commands still work: `wp pods-legacy --help` and `wp pods-legacy-api --help`

## Checklist

- [x] PHP syntax check passes
- [x] Changes follow existing code patterns in the codebase
- [x] Backward compatible (no breaking changes)

## Plugin Zip
[pods-fix-7458.zip](https://github.com/user-attachments/files/24976771/pods-fix-7458.zip)