### PR TITLE
Clean up attachments from incomplete form uploads

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1768,6 +1768,7 @@ class PodsInit {
 
 				new PodsRESTFields( $post_type_name );
 			}
+
 		}//end foreach
 
 		foreach ( $existing_taxonomies as $taxonomy_name => $taxonomy_name_again ) {
@@ -1797,6 +1798,7 @@ class PodsInit {
 
 				new PodsRESTFields( $taxonomy_name );
 			}
+
 		}//end foreach
 
 		if ( ! empty( PodsMeta::$user ) ) {
@@ -2217,6 +2219,8 @@ class PodsInit {
 
 		delete_option( 'pods_callouts' );
 
+		wp_clear_scheduled_hook( 'pods_cleanup_pending_form_uploads' );
+
 		pods_api()->cache_flush_pods();
 
 	}
@@ -2551,6 +2555,13 @@ class PodsInit {
 		add_filter( 'post_updated_messages', [ $this, 'setup_updated_messages' ], 10, 1 );
 		add_action( 'delete_attachment', [ $this, 'delete_attachment' ] );
 
+		// Schedule daily cleanup of attachments uploaded to forms that were never completed.
+		if ( ! wp_next_scheduled( 'pods_cleanup_pending_form_uploads' ) ) {
+			wp_schedule_event( time(), 'daily', 'pods_cleanup_pending_form_uploads' );
+		}
+
+		add_action( 'pods_cleanup_pending_form_uploads', [ $this, 'cleanup_pending_form_uploads' ] );
+
 		// Register widgets
 		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
 
@@ -2683,6 +2694,37 @@ class PodsInit {
 		 * @param int $_ID The attachment ID being deleted.
 		 */
 		do_action( 'pods_init_delete_attachment', $_ID );
+	}
+
+	/**
+	 * Delete attachments that were uploaded to Pods forms that were never completed.
+	 *
+	 * Skips recently uploaded attachments to avoid removing
+	 * files for forms still being filled out.
+	 */
+	public function cleanup_pending_form_uploads() {
+		$time_threshold = time() - 12 * HOUR_IN_SECONDS;
+
+		$attachments = get_posts( [
+			'post_type'  => 'attachment',
+			'meta_key'   => '_pods_pending_form_upload',
+			'fields'     => 'ids',
+			'nopaging'   => true,
+		] );
+
+		if ( empty( $attachments ) ) {
+			return;
+		}
+
+		foreach ( $attachments as $attachment_id ) {
+			$uploaded_at = (int) get_post_meta( $attachment_id, '_pods_pending_form_upload', true );
+
+			if ( $uploaded_at > $time_threshold ) {
+				continue;
+			}
+
+			wp_delete_attachment( (int) $attachment_id, true );
+		}
 	}
 
 	/**

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -766,6 +766,9 @@ class PodsField_File extends PodsField {
 				continue;
 			}
 
+			// Form submitted: remove pending upload flag.
+			delete_post_meta( $attachment_id, '_pods_pending_form_upload' );
+
 			// Check whether attachment is a valid image type.
 			if ( null === $first_attachment_id && 'image/' === substr( $attachment->post_mime_type, 0, 6 ) ) {
 				$first_attachment_id = $attachment_id;
@@ -1341,6 +1344,9 @@ class PodsField_File extends PodsField {
 
 					pods_error( '<div style="color:#FF0000">Error: ' . implode( '</div><div>', $errors ) . '</div>' );
 				} else {
+					// Mark as pending so incomplete form uploads can be cleaned up later.
+					update_post_meta( $attachment_id, '_pods_pending_form_upload', time() );
+
 					$attachment = get_post( $attachment_id, ARRAY_A );
 
 					$attachment['filename'] = basename( $attachment['guid'] );


### PR DESCRIPTION
## Summary

- Tags file field attachments with `_pods_pending_form_upload` post meta (timestamp) when uploaded via AJAX in `Pods->form()`
- Removes the flag when the form is successfully saved via `PodsField_File::save()`
- Adds a daily WP-Cron job that deletes flagged attachments that are no longer pending
- Skips attachments uploaded within the last 12 hours to allow time for forms still being filled out
- Unschedules the cron on plugin deactivation

Fixes #7459

## Test plan

- [ ] Create a Pod with a File/Image/Video field and render with `$pod->form()`
- [ ] Upload a file — verify `_pods_pending_form_upload` meta is set on the attachment
- [ ] Submit the form — verify the meta is removed
- [ ] Upload a file and abandon the form — verify meta persists
- [ ] Trigger cron manually (`do_action('pods_cleanup_pending_form_uploads')`) with a backdated timestamp — verify the attachment is deleted
- [ ] Verify attachments uploaded less than 12 hours ago are not deleted by the cron