### PR TITLE
Add Settings link to Pods plugin action links on Plugins page ( #7519)

### DIFF
--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -160,6 +160,7 @@ class PodsInit {
 		add_action( 'plugins_loaded', [ $this, 'activate_install' ], 9 );
 		add_action( 'after_setup_theme', [ $this, 'after_setup_theme' ] );
 		add_action( 'wp_loaded', [ $this, 'flush_rewrite_rules' ] );
+		add_filter( 'plugin_action_links_' . plugin_basename( PODS_FILE ), [ $this, 'settings_link' ] );
 	}
 
 	/**
@@ -1906,6 +1907,21 @@ class PodsInit {
 			pods_transient_clear( 'pods_flush_rewrites' );
 		}
 	}
+
+	/**
+	 * Add Pods settings link
+	 * 
+	 * @param array $links
+	 * 
+	 * @return array
+	 * @since 3.3.8
+	 * @author monzuralam
+	 **/
+	public function settings_link( $links ) {
+        $links['pods_settings'] = sprintf( '<a href="%s">%s</a>', admin_url( 'admin.php?page=pods-settings' ), esc_html__( 'Settings', 'pods' ) );
+
+        return $links;
+    }
 
 	/**
 	 * Update Post Type messages

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -160,7 +160,7 @@ class PodsInit {
 		add_action( 'plugins_loaded', [ $this, 'activate_install' ], 9 );
 		add_action( 'after_setup_theme', [ $this, 'after_setup_theme' ] );
 		add_action( 'wp_loaded', [ $this, 'flush_rewrite_rules' ] );
-		add_filter( 'plugin_action_links_' . plugin_basename( PODS_FILE ), [ $this, 'settings_link' ] );
+		add_filter( 'plugin_action_links_' . PODS_SLUG, [ $this, 'settings_link' ] );
 	}
 
 	/**
@@ -1909,19 +1909,32 @@ class PodsInit {
 	}
 
 	/**
-	 * Add Pods settings link
+	 * Add custom action links for Pods.
 	 * 
-	 * @param array $links
+	 * @param string[] $actions An array of plugin action links.
 	 * 
-	 * @return array
-	 * @since 3.3.8
-	 * @author monzuralam
+	 * @return string[] An array of plugin action links.
+	 * @since TBD
 	 **/
-	public function settings_link( $links ) {
-        $links['pods_settings'] = sprintf( '<a href="%s">%s</a>', admin_url( 'admin.php?page=pods-settings' ), esc_html__( 'Settings', 'pods' ) );
+	public function settings_link( array $links ): array {
+		// Check if the Pods admin menu is disabled.
+		if ( defined( 'PODS_DISABLE_ADMIN_MENU' ) && ! PODS_DISABLE_ADMIN_MENU ) {
+			return $links;
+		}
 
-        return $links;
-    }
+		// Check if user has access to the Pods Settings page.
+		if ( ! pods_is_admin( 'pods_settings' ) ) {
+			return $links;
+		}
+
+		$links['pods_settings'] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( admin_url( 'admin.php?page=pods-settings' ) ),
+			esc_html__( 'Settings', 'pods' )
+		);
+
+		return $links;
+	}
 
 	/**
 	 * Update Post Type messages

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1910,11 +1910,12 @@ class PodsInit {
 
 	/**
 	 * Add custom action links for Pods.
-	 * 
-	 * @param string[] $actions An array of plugin action links.
-	 * 
-	 * @return string[] An array of plugin action links.
+	 *
 	 * @since TBD
+	 *
+	 * @param string[] $actions An array of plugin action links.
+	 *
+	 * @return string[] An array of plugin action links.
 	 **/
 	public function settings_link( array $links ): array {
 		// Check if the Pods admin menu is disabled.


### PR DESCRIPTION
## Description

This PR adds a **“Settings”** link to the Pods plugin action links displayed on the WordPress Plugins page (`wp-admin/plugins.php`).

Currently, the Pods plugin only shows the **Deactivate** link. This update adds a direct **Settings** link beside it, allowing users to quickly access the main Pods admin/settings screen without needing to manually navigate through the admin menu.

This improves usability, aligns Pods with common WordPress plugin UX patterns, and provides a better experience for both new and existing users.

---

## Related GitHub issue(s)

Fixes #7519

(Replace `#7519` with the related feature request issue number after it is created.)

---

## Testing instructions

1. Go to **WordPress Admin → Plugins → Installed Plugins**
2. Locate the **Pods – Custom Content Types and Fields** plugin
3. Verify the plugin action links section below the plugin name
4. Confirm that both **Deactivate** and **Settings** links are visible
5. Click on **Settings**
6. Confirm it correctly redirects to the main Pods admin/settings screen

---

## Screenshots / screencast

### Before

Only **Deactivate** link is shown.

<img width="973" height="74" alt="image" src="https://github.com/user-attachments/assets/73859b27-dd39-4bd9-be4a-434c4a357312" />

### After

Both **Deactivate** and **Settings** links are shown.

<img width="970" height="74" alt="image" src="https://github.com/user-attachments/assets/a18f4af1-492d-400e-8d83-dd6eb9698494" />

---

## Changelog text for these changes

Enhancement: Pods plugin now includes a Settings link on the Plugins page for quicker admin access. #7519 (@monzuralam)

---

## PR checklist

* [x] I have tested my own code to confirm it works as I intended.
* [x] My code follows the WordPress Coding Standards.
* [x] My code follows the WordPress Inline Documentation Standards.
* [ ] My code includes automated tests for PHP and/or JS (if applicable).
