### PR TITLE
Fix empty number fields saving as zero

### DIFF
--- a/ui/js/dfv/src/helpers/formatNumberWithPodsFormat.js
+++ b/ui/js/dfv/src/helpers/formatNumberWithPodsFormat.js
@@ -72,9 +72,9 @@ export const parseFloatWithPodsFormat = (
 	newValue,
 	format,
 ) => {
-	// Turn empty string to 0.
-	if ( '' === newValue ) {
-		return 0;
+	// Preserve intentionally empty values.
+	if ( '' === newValue || undefined === newValue || null === newValue ) {
+		return '';
 	}
 
 	// If we get a float value, we don't need to do anything.
@@ -99,9 +99,9 @@ export const formatNumberWithPodsFormat = (
 	decimalHandling = 'none',
 	decimals = 'auto',
 ) => {
-	// Skip empty strings or undefined.
+	// Preserve intentionally empty values.
 	if ( '' === newValue || undefined === newValue || null === newValue ) {
-		return '0';
+		return '';
 	}
 
 	const thousands = getThousandsSeparatorFromPodsFormat( format );

--- a/ui/js/dfv/src/helpers/test/formatNumberWithPodsFormat.test.js
+++ b/ui/js/dfv/src/helpers/test/formatNumberWithPodsFormat.test.js
@@ -1,6 +1,7 @@
 /* global global */
 import {
 	formatNumberWithPodsFormat,
+	parseFloatWithPodsFormat,
 } from '../formatNumberWithPodsFormat.js';
 
 describe( 'formatNumberWithPodsFormat.js', () => {
@@ -94,15 +95,19 @@ describe( 'formatNumberWithPodsFormat.js', () => {
 	} );
 
 	it( 'handles non-string and non-numeric values', () => {
-		expect( formatNumberWithPodsFormat( undefined, 'i18n' ) ).toEqual( '0' );
-
-		expect( formatNumberWithPodsFormat( null, 'i18n' ) ).toEqual( '0' );
-
 		expect( formatNumberWithPodsFormat( 123, 'i18n' ) ).toEqual( '123' );
 
-		expect( formatNumberWithPodsFormat( '', 'i18n' ) ).toEqual( '0' );
-
 		expect( formatNumberWithPodsFormat( 'abc', 'i18n' ) ).toEqual( undefined );
+	} );
+
+	it( 'preserves intentionally empty values', () => {
+		expect( parseFloatWithPodsFormat( '', 'i18n' ) ).toEqual( '' );
+		expect( parseFloatWithPodsFormat( undefined, 'i18n' ) ).toEqual( '' );
+		expect( parseFloatWithPodsFormat( null, 'i18n' ) ).toEqual( '' );
+
+		expect( formatNumberWithPodsFormat( '', 'i18n' ) ).toEqual( '' );
+		expect( formatNumberWithPodsFormat( undefined, 'i18n' ) ).toEqual( '' );
+		expect( formatNumberWithPodsFormat( null, 'i18n' ) ).toEqual( '' );
 	} );
 
 	it( 'strips unneeded zero decimal values', () => {


### PR DESCRIPTION
## Summary
Fixes #7110.

Preserves intentionally empty values in DFV number formatting/parsing instead of coercing them to `0`. This allows optional Plain Number fields to be cleared and saved blank.

## Details
`parseFloatWithPodsFormat()` previously converted an empty string to `0`, which caused cleared number inputs to repopulate/save as zero.

`formatNumberWithPodsFormat()` also formatted empty/null/undefined values as `"0"`.

This change keeps empty/null/undefined values empty while preserving real numeric zero values.

## Testing
- Applied the fix to a development WordPress site using Pods.
- Rebuilt the DFV bundle and confirmed clearing a previously filled Plain Number field saves and reloads as blank.
- Confirmed actual `0` remains valid.
- Ran focused Jest test:

```bash
npm run jest -- formatNumberWithPodsFormat
```

- Ran ESLint on changed files:

```bash
./node_modules/.bin/eslint ui/js/dfv/src/helpers/formatNumberWithPodsFormat.js ui/js/dfv/src/helpers/test/formatNumberWithPodsFormat.test.js
```

- Ran production webpack build:

```bash
npm run webpack-production
```

Note: full `npm run lint-js` currently reports pre-existing repo-wide lint issues outside this change.