### PR TITLE
fix(core): replace (boolean) cast with (bool) for PHP 8.5

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -673,7 +673,7 @@ class Pods implements Iterator {
 		}
 
 		if ( null !== $params->single ) {
-			$params->single = (boolean) $params->single;
+			$params->single = (bool) $params->single;
 		}
 
 		$params->name = trim( (string) $params->name );
@@ -2404,9 +2404,9 @@ class Pods implements Iterator {
 			'offset'              => null,
 			'page'                => (int) $this->page,
 			'page_var'            => $this->page_var,
-			'pagination'          => (boolean) $this->pagination,
+			'pagination'          => (bool) $this->pagination,
 			// Search parameters.
-			'search'              => (boolean) $this->search,
+			'search'              => (bool) $this->search,
 			'search_var'          => $this->search_var,
 			'search_query'        => null,
 			'search_mode'         => $this->search_mode,
@@ -2449,8 +2449,8 @@ class Pods implements Iterator {
 		$this->offset     = (int) $params->offset;
 		$this->page       = (int) $params->page;
 		$this->page_var   = $params->page_var;
-		$this->pagination = (boolean) $params->pagination;
-		$this->search     = (boolean) $params->search;
+		$this->pagination = (bool) $params->pagination;
+		$this->search     = (bool) $params->search;
 		$this->search_var = $params->search_var;
 		$this->filter_var = $params->filter_var;
 		$params->join     = (array) $params->join;
@@ -3637,7 +3637,7 @@ class Pods implements Iterator {
 		 *
 		 * @since 2.8.0
 		 */
-		$include_obj = (boolean) apply_filters( 'pods_helper_include_obj', false, $params );
+		$include_obj = (bool) apply_filters( 'pods_helper_include_obj', false, $params );
 
 		// Clean up helper callback (if string).
 		if ( is_string( $params['helper'] ) ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -1808,7 +1808,7 @@ class PodsAPI {
 			$params->name = pods_clean_name( $params->name );
 		}
 
-		$params->overwrite = ! empty( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->overwrite = ! empty( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		$order_group_fields = null;
 
@@ -3250,8 +3250,8 @@ class PodsAPI {
 		$params->pod_id = $pod['id'];
 		$params->pod    = $pod['name'];
 
-		$params->is_new    = isset( $params->is_new ) ? (boolean) $params->is_new : false;
-		$params->overwrite = isset( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->is_new    = isset( $params->is_new ) ? (bool) $params->is_new : false;
+		$params->overwrite = isset( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		$reserved_keywords = pods_reserved_keywords( 'wp-post' );
 
@@ -4268,13 +4268,13 @@ class PodsAPI {
 		$id_required = false;
 
 		if ( isset( $params->id_required ) ) {
-			$id_required = (boolean) $params->id_required;
+			$id_required = (bool) $params->id_required;
 
 			unset( $params->id_required );
 		}
 
-		$params->is_new    = isset( $params->is_new ) ? (boolean) $params->is_new : false;
-		$params->overwrite = isset( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->is_new    = isset( $params->is_new ) ? (bool) $params->is_new : false;
+		$params->overwrite = isset( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		if ( ! $pod && ( ! isset( $params->pod ) || empty( $params->pod ) ) && ( ! isset( $params->pod_id ) || empty( $params->pod_id ) ) ) {
 			return pods_error( __( 'Pod ID or name is required', 'pods' ), $this );
@@ -4938,7 +4938,7 @@ class PodsAPI {
 		}
 
 		if ( isset( $params->is_new_item ) ) {
-			$is_new_item = (boolean) $params->is_new_item;
+			$is_new_item = (bool) $params->is_new_item;
 		}
 
 		// Allow Helpers to bypass subsequent helpers in recursive save_pod_item calls
@@ -5448,7 +5448,7 @@ class PodsAPI {
 						|| in_array( pods_v( 'pick_object', $field_data ), $simple_tableless_objects, true )
 					)
 				);
-				$simple = (boolean) $this->do_hook( 'tableless_custom', $simple, $field_data, $field, $fields, $pod, $params );
+				$simple = (bool) $this->do_hook( 'tableless_custom', $simple, $field_data, $field, $fields, $pod, $params );
 
 				$is_repeatable_field = (
 					(
@@ -7068,7 +7068,7 @@ class PodsAPI {
 		$params['fields']        = (array) pods_v( 'fields', $params, [], true );
 		$params['depth']         = (int) pods_v( 'depth', $params, 2, true );
 		$params['object_fields'] = (array) pods_v( 'object_fields', $pod->pod_data, [], true );
-		$params['flatten']       = (boolean) pods_v( 'flatten', $params, false, true );
+		$params['flatten']       = (bool) pods_v( 'flatten', $params, false, true );
 		$params['context']       = pods_v( 'context', $params, null, true );
 
 		if ( empty( $params['fields'] ) ) {
@@ -7545,7 +7545,7 @@ class PodsAPI {
 			$params->delete_all = $delete_all;
 		}
 
-		$params->delete_all = (boolean) $params->delete_all;
+		$params->delete_all = (bool) $params->delete_all;
 
 		// Reset content
 		if ( true === $params->delete_all ) {
@@ -7759,7 +7759,7 @@ class PodsAPI {
 		}
 
 		$simple = ( 'pick' === $field['type'] && in_array( pods_v( 'pick_object', $field ), $simple_tableless_objects, true ) );
-		$simple = (boolean) $this->do_hook( 'tableless_custom', $simple, $field, $pod, $params );
+		$simple = (bool) $this->do_hook( 'tableless_custom', $simple, $field, $pod, $params );
 
 		// @todo Push this logic into pods_object_storage_delete_pod action.
 		if ( $table_operation && $pod && 'table' === $pod['storage'] && ( ! in_array( $field['type'], $tableless_field_types, true ) || $simple ) ) {
@@ -7839,7 +7839,7 @@ class PodsAPI {
 		}
 
 		if ( ! isset( $params->delete_all ) ) {
-			$params->delete_all = (boolean) $delete_all;
+			$params->delete_all = (bool) $delete_all;
 		}
 
 		$group = $this->load_group( $params, false );
@@ -8561,7 +8561,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}
@@ -8632,7 +8632,7 @@ class PodsAPI {
 		}
 
 		try {
-			return (boolean) $this->load_field( $load_params );
+			return (bool) $this->load_field( $load_params );
 		} catch ( Exception $exception ) {
 			pods_debug_log( $exception );
 
@@ -8908,7 +8908,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}
@@ -8996,7 +8996,7 @@ class PodsAPI {
 		}
 
 		try {
-			return (boolean) $this->load_group( $load_params );
+			return (bool) $this->load_group( $load_params );
 		} catch ( Exception $exception ) {
 			pods_debug_log( $exception );
 
@@ -9140,7 +9140,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}

--- a/classes/PodsArray.php
+++ b/classes/PodsArray.php
@@ -154,7 +154,7 @@ class PodsArray implements ArrayAccess {
 				$value = abs( $value );
 			}
 		} elseif ( 'boolean' === $type || 'bool' === $type ) {
-			$value = (boolean) $value;
+			$value = (bool) $value;
 		} elseif ( 'in_array' === $type && is_array( $default ) ) {
 			if ( is_array( $value ) ) {
 				foreach ( $value as $k => $v ) {

--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -691,7 +691,7 @@ class PodsComponents {
 
 		$toggled = null;
 
-		$toggle_mode = (boolean) pods_v( 'toggle', 'get', $toggle_mode );
+		$toggle_mode = (bool) pods_v( 'toggle', 'get', $toggle_mode );
 
 		if ( $toggle_mode ) {
 			$toggled = $this->activate_component( $component );
@@ -720,11 +720,11 @@ class PodsComponents {
 			}
 
 			if ( ! pods_developer() ) {
-				if ( true === (boolean) pods_v( 'DeveloperMode', $component_data, false ) ) {
+				if ( true === (bool) pods_v( 'DeveloperMode', $component_data, false ) ) {
 					continue;
 				}
 
-				if ( true === (boolean) pods_v( 'TablelessMode', $component_data, false ) ) {
+				if ( true === (bool) pods_v( 'TablelessMode', $component_data, false ) ) {
 					continue;
 				}
 			}

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -953,7 +953,7 @@ class PodsData {
 		// Validate.
 		$params->page = pods_absint( $params->page );
 
-		$params->pagination = (boolean) $params->pagination;
+		$params->pagination = (bool) $params->pagination;
 
 		if ( 0 === $params->page || ! $params->pagination ) {
 			$params->page = 1;
@@ -1167,7 +1167,7 @@ class PodsData {
 			$this->search_mode = $params->search_mode;
 		}
 
-		$params->search = (boolean) $params->search;
+		$params->search = (bool) $params->search;
 
 		if ( 1 === (int) pods_v( 'pods_debug_params_all', 'get', 0 ) && pods_is_admin( array( 'pods' ) ) ) {
 			pods_debug( __METHOD__ . ':' . __LINE__ );
@@ -2945,7 +2945,7 @@ class PodsData {
 		}
 
 		$field_compare         = strtoupper( trim( (string) pods_v( 'compare', $q, $field_compare, true ) ) );
-		$field_sanitize        = (boolean) pods_v( 'sanitize', $q, true );
+		$field_sanitize        = (bool) pods_v( 'sanitize', $q, true );
 		$field_sanitize_format = pods_v( 'sanitize_format', $q, null, true );
 		$field_cast            = pods_v( 'cast', $q, null, true );
 

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -1407,7 +1407,7 @@ class PodsForm {
 		 * @since 2.0.0
 		 * @deprecated 2.8.0
 		 */
-		return (boolean) apply_filters( 'pods_form_field_permission', $permission, $type, $name, $options, $fields, $pod, $id, $params );
+		return (bool) apply_filters( 'pods_form_field_permission', $permission, $type, $name, $options, $fields, $pod, $id, $params );
 	}
 
 	/**

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1179,18 +1179,18 @@ class PodsInit {
 
 				// Supported
 				$cpt_supported = [
-					'title'           => (boolean) pods_v( 'supports_title', $post_type, false ),
-					'editor'          => (boolean) pods_v( 'supports_editor', $post_type, false ),
-					'author'          => (boolean) pods_v( 'supports_author', $post_type, false ),
-					'thumbnail'       => (boolean) pods_v( 'supports_thumbnail', $post_type, false ),
-					'excerpt'         => (boolean) pods_v( 'supports_excerpt', $post_type, false ),
-					'trackbacks'      => (boolean) pods_v( 'supports_trackbacks', $post_type, false ),
-					'custom-fields'   => (boolean) pods_v( 'supports_custom_fields', $post_type, false ),
-					'comments'        => (boolean) pods_v( 'supports_comments', $post_type, false ),
-					'revisions'       => (boolean) pods_v( 'supports_revisions', $post_type, false ),
-					'page-attributes' => (boolean) pods_v( 'supports_page_attributes', $post_type, false ),
-					'post-formats'    => (boolean) pods_v( 'supports_post_formats', $post_type, false ),
-					'quick-edit'      => (boolean) pods_v( 'supports_quick_edit', $post_type, true ),
+					'title'           => (bool) pods_v( 'supports_title', $post_type, false ),
+					'editor'          => (bool) pods_v( 'supports_editor', $post_type, false ),
+					'author'          => (bool) pods_v( 'supports_author', $post_type, false ),
+					'thumbnail'       => (bool) pods_v( 'supports_thumbnail', $post_type, false ),
+					'excerpt'         => (bool) pods_v( 'supports_excerpt', $post_type, false ),
+					'trackbacks'      => (bool) pods_v( 'supports_trackbacks', $post_type, false ),
+					'custom-fields'   => (bool) pods_v( 'supports_custom_fields', $post_type, false ),
+					'comments'        => (bool) pods_v( 'supports_comments', $post_type, false ),
+					'revisions'       => (bool) pods_v( 'supports_revisions', $post_type, false ),
+					'page-attributes' => (bool) pods_v( 'supports_page_attributes', $post_type, false ),
+					'post-formats'    => (bool) pods_v( 'supports_post_formats', $post_type, false ),
+					'quick-edit'      => (bool) pods_v( 'supports_quick_edit', $post_type, true ),
 				];
 
 				// Custom Supported
@@ -1207,20 +1207,20 @@ class PodsInit {
 
 				// Genesis Support
 				if ( function_exists( 'genesis' ) ) {
-					$cpt_supported['genesis-seo']             = (boolean) pods_v( 'supports_genesis_seo', $post_type, false );
-					$cpt_supported['genesis-layouts']         = (boolean) pods_v( 'supports_genesis_layouts', $post_type, false );
-					$cpt_supported['genesis-simple-sidebars'] = (boolean) pods_v( 'supports_genesis_simple_sidebars', $post_type, false );
+					$cpt_supported['genesis-seo']             = (bool) pods_v( 'supports_genesis_seo', $post_type, false );
+					$cpt_supported['genesis-layouts']         = (bool) pods_v( 'supports_genesis_layouts', $post_type, false );
+					$cpt_supported['genesis-simple-sidebars'] = (bool) pods_v( 'supports_genesis_simple_sidebars', $post_type, false );
 				}
 
 				// YARPP Support
 				if ( defined( 'YARPP_VERSION' ) ) {
-					$cpt_supported['yarpp_support'] = (boolean) pods_v( 'supports_yarpp_support', $post_type, false );
+					$cpt_supported['yarpp_support'] = (bool) pods_v( 'supports_yarpp_support', $post_type, false );
 				}
 
 				// Jetpack Support
 				if ( class_exists( 'Jetpack' ) ) {
-					$cpt_supported['supports_jetpack_publicize'] = (boolean) pods_v( 'supports_jetpack_publicize', $post_type, false );
-					$cpt_supported['supports_jetpack_markdown']  = (boolean) pods_v( 'supports_jetpack_markdown', $post_type, false );
+					$cpt_supported['supports_jetpack_publicize'] = (bool) pods_v( 'supports_jetpack_publicize', $post_type, false );
+					$cpt_supported['supports_jetpack_markdown']  = (bool) pods_v( 'supports_jetpack_markdown', $post_type, false );
 				}
 
 				$cpt_supports = [];
@@ -1240,12 +1240,12 @@ class PodsInit {
 				}
 
 				// Rewrite
-				$cpt_rewrite       = (boolean) pods_v( 'rewrite', $post_type, true );
+				$cpt_rewrite       = (bool) pods_v( 'rewrite', $post_type, true );
 				$cpt_rewrite_array = [
 					'slug'       => pods_v( 'rewrite_custom_slug', $post_type, str_replace( '_', '-', $post_type_name ), true ),
-					'with_front' => (boolean) pods_v( 'rewrite_with_front', $post_type, true ),
-					'feeds'      => (boolean) pods_v( 'rewrite_feeds', $post_type, (boolean) pods_v( 'has_archive', $post_type, false ) ),
-					'pages'      => (boolean) pods_v( 'rewrite_pages', $post_type, true ),
+					'with_front' => (bool) pods_v( 'rewrite_with_front', $post_type, true ),
+					'feeds'      => (bool) pods_v( 'rewrite_feeds', $post_type, (bool) pods_v( 'has_archive', $post_type, false ) ),
+					'pages'      => (bool) pods_v( 'rewrite_pages', $post_type, true ),
 				];
 
 				if ( false !== $cpt_rewrite ) {
@@ -1261,7 +1261,7 @@ class PodsInit {
 					$capability_type = pods_v( 'capability_type_custom', $post_type, pods_v( 'name', $post_type, 'post', true ), true );
 				}
 
-				$show_in_menu = (boolean) pods_v( 'show_in_menu', $post_type, true );
+				$show_in_menu = (bool) pods_v( 'show_in_menu', $post_type, true );
 
 				if ( $show_in_menu && 0 < strlen( (string) pods_v( 'menu_location_custom', $post_type ) ) ) {
 					$show_in_menu = (string) pods_v( 'menu_location_custom', $post_type );
@@ -1278,31 +1278,31 @@ class PodsInit {
 					'label'               => $cpt_label,
 					'labels'              => $cpt_labels,
 					'description'         => esc_html( pods_v( 'description', $post_type ) ),
-					'public'              => (boolean) pods_v( 'public', $post_type, true ),
-					'publicly_queryable'  => (boolean) pods_v( 'publicly_queryable', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
-					'exclude_from_search' => (boolean) pods_v( 'exclude_from_search', $post_type, ( (boolean) pods_v( 'public', $post_type, true ) ? false : true ) ),
-					'show_ui'             => (boolean) pods_v( 'show_ui', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
+					'public'              => (bool) pods_v( 'public', $post_type, true ),
+					'publicly_queryable'  => (bool) pods_v( 'publicly_queryable', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
+					'exclude_from_search' => (bool) pods_v( 'exclude_from_search', $post_type, ( (bool) pods_v( 'public', $post_type, true ) ? false : true ) ),
+					'show_ui'             => (bool) pods_v( 'show_ui', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
 					'show_in_menu'        => $show_in_menu,
-					'show_in_nav_menus'   => (boolean) pods_v( 'show_in_nav_menus', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
-					'show_in_admin_bar'   => (boolean) pods_v( 'show_in_admin_bar', $post_type, (boolean) pods_v( 'show_in_menu', $post_type, true ) ),
+					'show_in_nav_menus'   => (bool) pods_v( 'show_in_nav_menus', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
+					'show_in_admin_bar'   => (bool) pods_v( 'show_in_admin_bar', $post_type, (bool) pods_v( 'show_in_menu', $post_type, true ) ),
 					'menu_position'       => (int) pods_v( 'menu_position', $post_type, 0, true ),
 					'menu_icon'           => $menu_icon,
 					'capability_type'     => $capability_type,
 					// 'capabilities' => $cpt_capabilities,
-					'map_meta_cap'        => (boolean) pods_v( 'capability_type_extra', $post_type, true ),
-					'hierarchical'        => (boolean) pods_v( 'hierarchical', $post_type, false ),
-					'can_export'          => (boolean) pods_v( 'can_export', $post_type, true ),
+					'map_meta_cap'        => (bool) pods_v( 'capability_type_extra', $post_type, true ),
+					'hierarchical'        => (bool) pods_v( 'hierarchical', $post_type, false ),
+					'can_export'          => (bool) pods_v( 'can_export', $post_type, true ),
 					'supports'            => $cpt_supports,
 					// 'register_meta_box_cb' => array($this, 'manage_meta_box'),
 					// 'permalink_epmask' => EP_PERMALINK,
-					'has_archive'         => ( (boolean) pods_v( 'has_archive', $post_type, false ) ) ? pods_v( 'has_archive_slug', $post_type, true, true ) : false,
+					'has_archive'         => ( (bool) pods_v( 'has_archive', $post_type, false ) ) ? pods_v( 'has_archive_slug', $post_type, true, true ) : false,
 					'rewrite'             => $cpt_rewrite,
-					'query_var'           => ( false !== (boolean) pods_v( 'query_var', $post_type, true ) ? pods_v( 'query_var_string', $post_type, $post_type_name, true ) : false ),
-					'delete_with_user'    => (boolean) pods_v( 'delete_with_user', $post_type, true ),
+					'query_var'           => ( false !== (bool) pods_v( 'query_var', $post_type, true ) ? pods_v( 'query_var_string', $post_type, $post_type_name, true ) : false ),
+					'delete_with_user'    => (bool) pods_v( 'delete_with_user', $post_type, true ),
 					'_provider'           => 'pods',
 				];
 
-				if ( (boolean) pods_v( 'disable_create_posts', $post_type, false ) ) {
+				if ( (bool) pods_v( 'disable_create_posts', $post_type, false ) ) {
 					$pods_post_types[ $post_type_name ]['capabilities'] = [
 						'create_posts' => false,
 					];
@@ -1315,7 +1315,7 @@ class PodsInit {
 				}
 
 				// REST API
-				$rest_enabled = (boolean) pods_v( 'rest_enable', $post_type, false );
+				$rest_enabled = (bool) pods_v( 'rest_enable', $post_type, false );
 
 				if ( $rest_enabled ) {
 					$rest_base = sanitize_title( pods_v( 'rest_base', $post_type, $post_type_name ) );
@@ -1376,7 +1376,7 @@ class PodsInit {
 						continue;
 					}
 
-					if ( false !== (boolean) pods_v( 'built_in_taxonomies_' . $taxonomy, $post_type, false ) ) {
+					if ( false !== (bool) pods_v( 'built_in_taxonomies_' . $taxonomy, $post_type, false ) ) {
 						$cpt_taxonomies[] = $taxonomy;
 
 						if ( isset( $supported_post_types[ $taxonomy ] ) && ! in_array( $post_type_name, $supported_post_types[ $taxonomy ], true ) ) {
@@ -1438,11 +1438,11 @@ class PodsInit {
 				$ct_labels['desc_field_description']     = pods_v( 'label_desc_field_description', $taxonomy, '', true );
 
 				// Rewrite
-				$ct_rewrite       = (boolean) pods_v( 'rewrite', $taxonomy, true );
+				$ct_rewrite       = (bool) pods_v( 'rewrite', $taxonomy, true );
 				$ct_rewrite_array = [
 					'slug'         => pods_v( 'rewrite_custom_slug', $taxonomy, str_replace( '_', '-', $taxonomy_name ), true ),
-					'with_front'   => (boolean) pods_v( 'rewrite_with_front', $taxonomy, true ),
-					'hierarchical' => (boolean) pods_v( 'rewrite_hierarchical', $taxonomy, (boolean) pods_v( 'hierarchical', $taxonomy, false ) ),
+					'with_front'   => (bool) pods_v( 'rewrite_with_front', $taxonomy, true ),
+					'hierarchical' => (bool) pods_v( 'rewrite_hierarchical', $taxonomy, (bool) pods_v( 'hierarchical', $taxonomy, false ) ),
 				];
 
 				if ( false !== $ct_rewrite ) {
@@ -1484,22 +1484,22 @@ class PodsInit {
 					'label'                 => $ct_label,
 					'labels'                => $ct_labels,
 					'description'           => esc_html( pods_v( 'description', $taxonomy ) ),
-					'public'                => (boolean) pods_v( 'public', $taxonomy, true ),
-					'publicly_queryable'    => (boolean) pods_v( 'publicly_queryable', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_ui'               => (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_in_menu'          => (boolean) pods_v( 'show_in_menu', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_in_nav_menus'     => (boolean) pods_v( 'show_in_nav_menus', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_tagcloud'         => (boolean) pods_v( 'show_tagcloud', $taxonomy, (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ) ),
-					'show_in_quick_edit'    => (boolean) pods_v( 'show_in_quick_edit', $taxonomy, (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ) ),
-					'hierarchical'          => (boolean) pods_v( 'hierarchical', $taxonomy, false ),
+					'public'                => (bool) pods_v( 'public', $taxonomy, true ),
+					'publicly_queryable'    => (bool) pods_v( 'publicly_queryable', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_ui'               => (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_in_menu'          => (bool) pods_v( 'show_in_menu', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_in_nav_menus'     => (bool) pods_v( 'show_in_nav_menus', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_tagcloud'         => (bool) pods_v( 'show_tagcloud', $taxonomy, (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ) ),
+					'show_in_quick_edit'    => (bool) pods_v( 'show_in_quick_edit', $taxonomy, (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ) ),
+					'hierarchical'          => (bool) pods_v( 'hierarchical', $taxonomy, false ),
 					// 'capability_type'       => $capability_type,
 					'capabilities'          => $tax_capabilities,
-					// 'map_meta_cap'          => (boolean) pods_v( 'capability_type_extra', $taxonomy, true ),
+					// 'map_meta_cap'          => (bool) pods_v( 'capability_type_extra', $taxonomy, true ),
 					'update_count_callback' => pods_v( 'update_count_callback', $taxonomy, null, true ),
-					'query_var'             => ( false !== (boolean) pods_v( 'query_var', $taxonomy, true ) ? pods_v( 'query_var_string', $taxonomy, $taxonomy_name, true ) : false ),
+					'query_var'             => ( false !== (bool) pods_v( 'query_var', $taxonomy, true ) ? pods_v( 'query_var_string', $taxonomy, $taxonomy_name, true ) : false ),
 					'rewrite'               => $ct_rewrite,
-					'show_admin_column'     => (boolean) pods_v( 'show_admin_column', $taxonomy, false ),
-					'sort'                  => (boolean) pods_v( 'sort', $taxonomy, false ),
+					'show_admin_column'     => (bool) pods_v( 'show_admin_column', $taxonomy, false ),
+					'sort'                  => (bool) pods_v( 'sort', $taxonomy, false ),
 					'_provider'             => 'pods',
 				];
 
@@ -1523,7 +1523,7 @@ class PodsInit {
 				}
 
 				// REST API
-				$rest_enabled = (boolean) pods_v( 'rest_enable', $taxonomy, false );
+				$rest_enabled = (bool) pods_v( 'rest_enable', $taxonomy, false );
 
 				if ( $rest_enabled ) {
 					$rest_base = sanitize_title( pods_v( 'rest_base', $taxonomy, $taxonomy_name ) );
@@ -1552,8 +1552,8 @@ class PodsInit {
 
 				// Integration for Single Value Taxonomy UI
 				if ( function_exists( 'tax_single_value_meta_box' ) ) {
-					$pods_taxonomies[ $taxonomy_name ]['single_value'] = (boolean) pods_v( 'single_value', $taxonomy, false );
-					$pods_taxonomies[ $taxonomy_name ]['required']     = (boolean) pods_v( 'single_value_required', $taxonomy, false );
+					$pods_taxonomies[ $taxonomy_name ]['single_value'] = (bool) pods_v( 'single_value', $taxonomy, false );
+					$pods_taxonomies[ $taxonomy_name ]['required']     = (bool) pods_v( 'single_value_required', $taxonomy, false );
 				}
 
 				// Post Types
@@ -1567,7 +1567,7 @@ class PodsInit {
 						continue;
 					}
 
-					if ( false !== (boolean) pods_v( 'built_in_post_types_' . $post_type, $taxonomy, false ) ) {
+					if ( false !== (bool) pods_v( 'built_in_post_types_' . $post_type, $taxonomy, false ) ) {
 						$ct_post_types[] = $post_type;
 
 						if ( isset( $supported_taxonomies[ $post_type ] ) && ! in_array( $taxonomy_name, $supported_taxonomies[ $post_type ], true ) ) {
@@ -1756,7 +1756,7 @@ class PodsInit {
 			$pod = $post_types[ $post_type_name ];
 
 			// REST API
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				if ( empty( $wp_post_types[ $post_type_name ]->show_in_rest ) ) {
@@ -1785,7 +1785,7 @@ class PodsInit {
 			$pod = $taxonomies[ $taxonomy_name ];
 
 			// REST API
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				if ( empty( $wp_taxonomies[ $taxonomy_name ]->show_in_rest ) ) {
@@ -1803,7 +1803,7 @@ class PodsInit {
 		if ( ! empty( PodsMeta::$user ) ) {
 			$pod = current( PodsMeta::$user );
 
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				new PodsRESTFields( $pod );
@@ -1813,7 +1813,7 @@ class PodsInit {
 		if ( ! empty( PodsMeta::$media ) ) {
 			$pod = current( PodsMeta::$media );
 
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				new PodsRESTFields( $pod );
@@ -1858,7 +1858,7 @@ class PodsInit {
 			return $enable;
 		}
 
-		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$post_types[ $post_type ], true );
+		return (bool) pods_v( 'supports_quick_edit', PodsMeta::$post_types[ $post_type ], true );
 	}
 
 	/**
@@ -1880,7 +1880,7 @@ class PodsInit {
 			return $enable;
 		}
 
-		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$taxonomies[ $taxonomy ], true );
+		return (bool) pods_v( 'supports_quick_edit', PodsMeta::$taxonomies[ $taxonomy ], true );
 	}
 
 	/**
@@ -2013,7 +2013,7 @@ class PodsInit {
 				10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels['singular_name'], esc_url( $preview_post_link ), $labels['singular_name'] ),
 			];
 
-			if ( false === (boolean) $pods_cpt_ct['post_types'][ $post_type['name'] ]['public'] ) {
+			if ( false === (bool) $pods_cpt_ct['post_types'][ $post_type['name'] ]['public'] ) {
 				// translators: %s is the singular label.
 				$messages[ $post_type['name'] ][1] = sprintf( __( '%s updated.', 'pods' ), $labels['singular_name'] );
 				// translators: %s is the singular label.

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1505,7 +1505,7 @@ class PodsMeta {
 		$data = [];
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -1796,7 +1796,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2045,7 +2045,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2283,7 +2283,7 @@ class PodsMeta {
 		$data = [];
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2758,7 +2758,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {

--- a/classes/PodsRESTHandlers.php
+++ b/classes/PodsRESTHandlers.php
@@ -282,7 +282,7 @@ class PodsRESTHandlers {
 
 		global $wp_rest_additional_fields;
 
-		$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+		$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 		if ( $pod && $rest_enable && ! empty( $wp_rest_additional_fields[ $type ] ) ) {
 			$fields = $pod->fields();

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -994,8 +994,8 @@ class PodsField_File extends PodsField {
 			$link = '{{link}}';
 		}
 
-		$editable = (boolean) $editable;
-		$linked   = (boolean) $linked;
+		$editable = (bool) $editable;
+		$linked   = (bool) $linked;
 		?>
 		<li class="pods-file hidden" id="pods-file-<?php echo esc_attr( $id ); ?>">
 			<?php

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -305,7 +305,7 @@ class PodsField_Link extends PodsField_Website {
 	 * Init the editor needed for WP Link modal to work
 	 */
 	public function validate_link_modal() {
-		$init = (boolean) pods_static_cache_get( 'init', __METHOD__ );
+		$init = (bool) pods_static_cache_get( 'init', __METHOD__ );
 
 		if ( $init ) {
 			return;

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -1110,7 +1110,7 @@ class PodsField_Pick extends PodsField {
 			$field_data = pods_static_cache_get( $field_options['name'] . '/' . $field_options['id'], __CLASS__ . '/field_data' ) ?: [];
 
 			if ( isset( $field_data['autocomplete'] ) ) {
-				$ajax = (boolean) $field_data['autocomplete'];
+				$ajax = (bool) $field_data['autocomplete'];
 			}
 		}
 
@@ -1838,7 +1838,7 @@ class PodsField_Pick extends PodsField {
 
 					$related_data[ 'remove_ids_' . $id ] = $remove_ids;
 
-					$related_required   = (boolean) pods_v( 'required', $related_field, 0 );
+					$related_required   = (bool) pods_v( 'required', $related_field, 0 );
 					$related_pick_limit = (int) pods_v( static::$type . '_limit', $related_field, 0 );
 
 					if ( 'single' === pods_v( static::$type . '_format_type', $related_field ) ) {

--- a/components/Migrate-ACF/Migrate-ACF.php
+++ b/components/Migrate-ACF/Migrate-ACF.php
@@ -120,7 +120,7 @@ class Pods_Migrate_ACF extends PodsComponent {
 
 		if ( isset( $params->post_type ) && ! empty( $params->post_type ) ) {
 			foreach ( $params->post_type as $post_type => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_post_types[] = $post_type;
 				}
 			}
@@ -130,7 +130,7 @@ class Pods_Migrate_ACF extends PodsComponent {
 
 		if ( isset( $params->taxonomy ) && ! empty( $params->taxonomy ) ) {
 			foreach ( $params->taxonomy as $taxonomy => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_taxonomies[] = $taxonomy;
 				}
 			}

--- a/components/Migrate-CPTUI/Migrate-CPTUI.php
+++ b/components/Migrate-CPTUI/Migrate-CPTUI.php
@@ -126,7 +126,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 
 		if ( isset( $params->post_type ) && ! empty( $params->post_type ) ) {
 			foreach ( $params->post_type as $post_type => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_post_types[] = $post_type;
 				}
 			}
@@ -136,7 +136,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 
 		if ( isset( $params->taxonomy ) && ! empty( $params->taxonomy ) ) {
 			foreach ( $params->taxonomy as $taxonomy => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_taxonomies[] = $taxonomy;
 				}
 			}

--- a/components/Migrate-PHP/Migrate-PHP.php
+++ b/components/Migrate-PHP/Migrate-PHP.php
@@ -159,13 +159,13 @@ class Pods_Migrate_PHP extends PodsComponent {
 		$has_objects_to_migrate = ! empty( $pod_templates_selected ) || ! empty( $pod_pages_selected );
 
 		foreach ( $pod_templates_selected as $object_id => $checked ) {
-			if ( true === (boolean) $checked && isset( $pod_templates_available_to_migrate[ (int) $object_id ] ) ) {
+			if ( true === (bool) $checked && isset( $pod_templates_available_to_migrate[ (int) $object_id ] ) ) {
 				$pod_templates[] = $object_id;
 			}
 		}
 
 		foreach ( $pod_pages_selected as $object_id => $checked ) {
-			if ( true === (boolean) $checked && isset( $pod_pages_available_to_migrate[ (int) $object_id ] ) ) {
+			if ( true === (bool) $checked && isset( $pod_pages_available_to_migrate[ (int) $object_id ] ) ) {
 				$pod_pages[] = $object_id;
 			}
 		}

--- a/components/Pages.php
+++ b/components/Pages.php
@@ -554,7 +554,7 @@ class Pods_Pages extends PodsComponent {
 			10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 		];
 
-		if ( false === (boolean) $post_type->public ) {
+		if ( false === (bool) $post_type->public ) {
 			// translators: %s is the singular label.
 			$messages[ $post_type->name ][1] = sprintf( __( '%s updated.', 'pods' ), $labels->singular_name );
 			// translators: %s is the singular label.
@@ -1045,13 +1045,13 @@ class Pods_Pages extends PodsComponent {
 				'page_template' => get_post_meta( $object['ID'], 'page_template', true ),
 				'title'         => get_post_meta( $object['ID'], 'page_title', true ),
 				'options'       => [
-					'admin_only'              => (boolean) get_post_meta( $object['ID'], 'admin_only', true ),
-					'restrict_role'           => (boolean) get_post_meta( $object['ID'], 'restrict_role', true ),
-					'restrict_capability'     => (boolean) get_post_meta( $object['ID'], 'restrict_capability', true ),
+					'admin_only'              => (bool) get_post_meta( $object['ID'], 'admin_only', true ),
+					'restrict_role'           => (bool) get_post_meta( $object['ID'], 'restrict_role', true ),
+					'restrict_capability'     => (bool) get_post_meta( $object['ID'], 'restrict_capability', true ),
 					'roles_allowed'           => get_post_meta( $object['ID'], 'roles_allowed', true ),
 					'capability_allowed'      => get_post_meta( $object['ID'], 'capability_allowed', true ),
-					'restrict_redirect'       => (boolean) get_post_meta( $object['ID'], 'restrict_redirect', true ),
-					'restrict_redirect_login' => (boolean) get_post_meta( $object['ID'], 'restrict_redirect_login', true ),
+					'restrict_redirect'       => (bool) get_post_meta( $object['ID'], 'restrict_redirect', true ),
+					'restrict_redirect_login' => (bool) get_post_meta( $object['ID'], 'restrict_redirect_login', true ),
 					'restrict_redirect_url'   => get_post_meta( $object['ID'], 'restrict_redirect_url', true ),
 					'pod'                     => get_post_meta( $object['ID'], 'pod', true ),
 					'pod_slug'                => get_post_meta( $object['ID'], 'pod_slug', true ),
@@ -1091,13 +1091,13 @@ class Pods_Pages extends PodsComponent {
 			'page_template' => get_post_meta( $id, 'page_template', true ),
 			'title'         => get_post_meta( $id, 'page_title', true ),
 			'options'       => [
-				'admin_only'              => (boolean) get_post_meta( $id, 'admin_only', true ),
-				'restrict_role'           => (boolean) get_post_meta( $id, 'restrict_role', true ),
-				'restrict_capability'     => (boolean) get_post_meta( $id, 'restrict_capability', true ),
+				'admin_only'              => (bool) get_post_meta( $id, 'admin_only', true ),
+				'restrict_role'           => (bool) get_post_meta( $id, 'restrict_role', true ),
+				'restrict_capability'     => (bool) get_post_meta( $id, 'restrict_capability', true ),
 				'roles_allowed'           => get_post_meta( $id, 'roles_allowed', true ),
 				'capability_allowed'      => get_post_meta( $id, 'capability_allowed', true ),
-				'restrict_redirect'       => (boolean) get_post_meta( $id, 'restrict_redirect', true ),
-				'restrict_redirect_login' => (boolean) get_post_meta( $id, 'restrict_redirect_login', true ),
+				'restrict_redirect'       => (bool) get_post_meta( $id, 'restrict_redirect', true ),
+				'restrict_redirect_login' => (bool) get_post_meta( $id, 'restrict_redirect_login', true ),
 				'restrict_redirect_url'   => get_post_meta( $id, 'restrict_redirect_url', true ),
 				'pod'                     => get_post_meta( $id, 'pod', true ),
 				'pod_slug'                => get_post_meta( $id, 'pod_slug', true ),
@@ -1281,7 +1281,7 @@ class Pods_Pages extends PodsComponent {
 		if ( false !== self::$exists ) {
 			$permission = pods_permission( self::$exists );
 
-			$permission = (boolean) apply_filters( 'pods_pages_permission', $permission, self::$exists );
+			$permission = (bool) apply_filters( 'pods_pages_permission', $permission, self::$exists );
 
 			if ( $permission ) {
 				$content = false;

--- a/components/Roles/Roles.php
+++ b/components/Roles/Roles.php
@@ -289,7 +289,7 @@ class Pods_Roles extends PodsComponent {
 		$capabilities = [];
 
 		foreach ( $params->capabilities as $capability => $x ) {
-			if ( empty( $capability ) || true !== (boolean) $x ) {
+			if ( empty( $capability ) || true !== (bool) $x ) {
 				continue;
 			}
 
@@ -354,7 +354,7 @@ class Pods_Roles extends PodsComponent {
 		$new_capabilities = [];
 
 		foreach ( $params->capabilities as $capability => $x ) {
-			if ( empty( $capability ) || true !== (boolean) $x ) {
+			if ( empty( $capability ) || true !== (bool) $x ) {
 				continue;
 			}
 

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -303,7 +303,7 @@ class Pods_Templates extends PodsComponent {
 			10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 		];
 
-		if ( false === (boolean) $post_type->public ) {
+		if ( false === (bool) $post_type->public ) {
 			// translators: %s is the singular label.
 			$messages[ $post_type->name ][1] = sprintf( __( '%s updated.', 'pods' ), $labels->singular_name );
 			// translators: %s is the singular label.
@@ -621,7 +621,7 @@ class Pods_Templates extends PodsComponent {
 
 				$permission = pods_permission( $template );
 
-				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
+				$permission = (bool) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
 				if ( ! $permission ) {
 					if ( 1 === (int) pods_v( 'show_restrict_message', $options, 1 ) ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -2925,7 +2925,7 @@ function pods_field( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;
@@ -3011,7 +3011,7 @@ function pods_field_display( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field_display( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;
@@ -3047,7 +3047,7 @@ function pods_field_raw( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field_raw( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;

--- a/sql/upgrade/PodsUpgrade.php
+++ b/sql/upgrade/PodsUpgrade.php
@@ -252,7 +252,7 @@ class PodsUpgrade {
 		$method = str_replace( 'migrate_', '', $method );
 
 		if ( null !== $x ) {
-			$this->progress[ $method ][ $x ] = (boolean) $v;
+			$this->progress[ $method ][ $x ] = (bool) $v;
 		} else {
 			$this->progress[ $method ] = $v;
 		}
@@ -273,7 +273,7 @@ class PodsUpgrade {
 			if ( null === $x ) {
 				return $this->progress[ $method ];
 			} elseif ( isset( $this->progress[ $method ][ $x ] ) ) {
-				return (boolean) $this->progress[ $method ][ $x ];
+				return (bool) $this->progress[ $method ][ $x ];
 			}
 		}
 

--- a/src/Pods/Whatsit/Block_Field.php
+++ b/src/Pods/Whatsit/Block_Field.php
@@ -307,7 +307,7 @@ class Block_Field extends Field {
 		];
 
 		$label   = $this->get_arg( 'label' );
-		$default = (boolean) $this->get_arg( 'default', 0 );
+		$default = (bool) $this->get_arg( 'default', 0 );
 
 		if ( 'radio' === $format_type ) {
 			return [

--- a/src/Pods/Whatsit/Storage.php
+++ b/src/Pods/Whatsit/Storage.php
@@ -486,7 +486,7 @@ abstract class Storage {
 	 * @param bool $enabled Whether to enable fallback mode.
 	 */
 	public function fallback_mode( $enabled = true ) {
-		$this->fallback_mode = (boolean) $enabled;
+		$this->fallback_mode = (bool) $enabled;
 	}
 
 	/**

--- a/src/Pods/Whatsit/Storage/Post_Type.php
+++ b/src/Pods/Whatsit/Storage/Post_Type.php
@@ -194,7 +194,7 @@ class Post_Type extends Collection {
 		$fallback_mode = $this->fallback_mode;
 
 		if ( isset( $args['fallback_mode'] ) ) {
-			$fallback_mode = (boolean) $args['fallback_mode'];
+			$fallback_mode = (bool) $args['fallback_mode'];
 		}
 
 		$meta_query = [];

--- a/src/Pods/Whatsit/Store.php
+++ b/src/Pods/Whatsit/Store.php
@@ -714,7 +714,7 @@ class Store {
 
 		// Filter objects by internal.
 		if ( isset( $args['internal'] ) ) {
-			$args['internal'] = (boolean) $args['internal'];
+			$args['internal'] = (bool) $args['internal'];
 
 			$objects = array_filter( $objects, static function( $object ) use ( $args ) {
 				$internal = false;
@@ -725,7 +725,7 @@ class Store {
 					$internal = $object['internal'];
 				}
 
-				return $args['internal'] === (boolean) $internal;
+				return $args['internal'] === (bool) $internal;
 			} );
 		}
 

--- a/ui/forms/form.php
+++ b/ui/forms/form.php
@@ -31,7 +31,7 @@ if ( empty( $fields ) || ! is_array( $fields ) ) {
 if ( ! isset( $duplicate ) || $is_settings_pod ) {
 	$duplicate = false;
 } else {
-	$duplicate = (boolean) $duplicate;
+	$duplicate = (bool) $duplicate;
 }
 
 $groups = PodsInit::$meta->groups_get( $pod->pod_data['type'], $pod->pod_data['name'], $fields );


### PR DESCRIPTION
## Summary

PHP 8.5 deprecates the `(boolean)` cast and will make it a fatal error in PHP 9.0. This PR swaps every `(boolean)` occurrence in the Pods codebase to the canonical `(bool)` form. The change is backward compatible because `(bool)` has been valid PHP since the beginning.

Fixes #7528

## Changes

Replaced `(boolean)` with `(bool)` in 25 files, 139 occurrences total. Files touched:

- `classes/Pods.php`
- `classes/PodsData.php`
- `classes/PodsInit.php`
- `classes/PodsAPI.php`
- `classes/PodsMeta.php`
- `classes/PodsArray.php`
- `classes/PodsComponents.php`
- `classes/PodsForm.php`
- `classes/PodsRESTHandlers.php`
- `classes/fields/file.php`
- `classes/fields/link.php`
- `classes/fields/pick.php`
- `components/Pages.php`
- `components/Templates.php`
- `components/Roles/Roles.php`
- `components/Migrate-CPTUI/Migrate-CPTUI.php`
- `components/Migrate-PHP/Migrate-PHP.php`
- `components/Migrate-ACF/Migrate-ACF.php`
- `includes/general.php`
- `ui/forms/form.php`
- `sql/upgrade/PodsUpgrade.php`
- `src/Pods/Whatsit/Block_Field.php`
- `src/Pods/Whatsit/Storage.php`
- `src/Pods/Whatsit/Store.php`
- `src/Pods/Whatsit/Storage/Post_Type.php`

**Before:**
```php
$params->single = (boolean) $params->single;
```

**After:**
```php
$params->single = (bool) $params->single;
```

**Why:** PHP 8.5 emits a deprecation notice on every `(boolean)` cast and the change is a one-to-one swap with the same runtime behavior. No logic changes, no API changes, no new tests needed.

## Testing

1. Grep the repo for `(boolean)` in PHP files. Result: zero hits.
2. PHP syntax check (`php -l`) on all 25 changed files. Result: all pass.
3. PHPCS on `classes/Pods.php` baseline 246 errors, after fix 240 errors. No new errors.
4. PHPStan level 0 on changed files. The 3 `cast.deprecated` errors for `(boolean)` are gone. Remaining 3 errors are pre-existing `WP_CLI` unknown class warnings, unrelated to this change.
5. CodeRabbit review on the full diff. No findings.

## Build
[pods-fix-7528.zip](https://github.com/user-attachments/files/28669686/pods-fix-7528.zip) is attached for manual install testing. WP Admin -> Plugins -> Upload -> Activate. Test by loading any Pods admin page on PHP 8.5+ with debug logging enabled and confirming no `Non-canonical cast (boolean) is deprecated` lines in `wp-content/debug.log`.