### PR TITLE
Migrate Packages: remap bi-directional sister_id on import

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -100,7 +100,7 @@ jobs:
           docker network prune -f
           ${SLIC_BIN} use ${GITHUB_REPOSITORY#*/}
           ${SLIC_BIN} composer set-version 2
-          ${SLIC_BIN} composer install --ignore-platform-reqs
+          ${SLIC_BIN} composer install
       # ------------------------------------------------------------------------------
       # Init WordPress container
       # ------------------------------------------------------------------------------

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -4059,7 +4059,11 @@ class PodsAPI {
 				}
 			}
 		} elseif ( 0 < $sister_id ) {
-			update_post_meta( $sister_id, 'sister_id', $params->id );
+			// sister_id can be stale (e.g. from an imported package); only write
+			// the reciprocal reference onto an actual Pods field post.
+			if ( '_pods_field' === get_post_type( $sister_id ) ) {
+				update_post_meta( $sister_id, 'sister_id', $params->id );
+			}
 
 			if ( true === $db && pods_podsrel_enabled( $field, 'save' ) ) {
 				$sister_field = $this->load_field( [ 'id' => $sister_id ] );

--- a/components/Migrate-Packages/Migrate-Packages.php
+++ b/components/Migrate-Packages/Migrate-Packages.php
@@ -208,6 +208,9 @@ class Pods_Migrate_Packages extends PodsComponent {
 		}//end if
 
 		if ( isset( $data['pods'] ) && is_array( $data['pods'] ) ) {
+			// Map source-site field IDs to pod/field names before import strips them.
+			$package_field_ids = self::get_package_field_ids( $data['pods'] );
+
 			foreach ( $data['pods'] as $pod_data ) {
 				$pod = self::import_pod( $pod_data, $replace );
 
@@ -221,6 +224,12 @@ class Pods_Migrate_Packages extends PodsComponent {
 
 				$found['pods'][ $pod['name'] ] = $pod['label'];
 			}//end foreach
+
+			// Second pass once all pods exist: remap bi-directional references,
+			// which the package stores as source-site sister_id post IDs.
+			if ( ! empty( $found['pods'] ) ) {
+				self::import_remap_sister_fields( self::get_package_sister_refs( $data['pods'] ), $package_field_ids );
+			}
 		}//end if
 
 		if ( isset( $data['templates'] ) && is_array( $data['templates'] ) ) {
@@ -313,6 +322,185 @@ class Pods_Migrate_Packages extends PodsComponent {
 		}
 
 		return $meta;
+	}
+
+	/**
+	 * Map field IDs in the package data to their pod and field names.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array $pods The list of pod data from the package.
+	 *
+	 * @return array Map of source-site field ID => [ 'pod' => pod name, 'field' => field name ].
+	 */
+	public static function get_package_field_ids( array $pods ) {
+		$field_ids = [];
+
+		foreach ( $pods as $pod_data ) {
+			$pod_name = pods_v( 'name', $pod_data );
+
+			if ( empty( $pod_name ) ) {
+				continue;
+			}
+
+			$field_lists = [];
+
+			if ( ! empty( $pod_data['groups'] ) && is_array( $pod_data['groups'] ) ) {
+				foreach ( $pod_data['groups'] as $group ) {
+					if ( ! empty( $group['fields'] ) && is_array( $group['fields'] ) ) {
+						$field_lists[] = $group['fields'];
+					}
+				}
+			}
+
+			if ( ! empty( $pod_data['fields'] ) && is_array( $pod_data['fields'] ) ) {
+				$field_lists[] = $pod_data['fields'];
+			}
+
+			foreach ( $field_lists as $fields ) {
+				foreach ( $fields as $field ) {
+					$field_id   = (int) pods_v( 'id', $field, 0 );
+					$field_name = pods_v( 'name', $field );
+
+					if ( 0 < $field_id && ! empty( $field_name ) ) {
+						$field_ids[ $field_id ] = [
+							'pod'   => $pod_name,
+							'field' => $field_name,
+						];
+					}
+				}
+			}
+		}
+
+		return $field_ids;
+	}
+
+	/**
+	 * Collect the bi-directional references the package data carries.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array $pods The list of pod data from the package.
+	 *
+	 * @return array Map of pod name => [ field name => [ 'sister_id' => int, 'sister_field' => string|null ] ].
+	 */
+	public static function get_package_sister_refs( array $pods ) {
+		$refs = [];
+
+		foreach ( $pods as $pod_data ) {
+			$pod_name = pods_v( 'name', $pod_data );
+
+			if ( empty( $pod_name ) ) {
+				continue;
+			}
+
+			$field_lists = [];
+
+			if ( ! empty( $pod_data['groups'] ) && is_array( $pod_data['groups'] ) ) {
+				foreach ( $pod_data['groups'] as $group ) {
+					if ( ! empty( $group['fields'] ) && is_array( $group['fields'] ) ) {
+						$field_lists[] = $group['fields'];
+					}
+				}
+			}
+
+			if ( ! empty( $pod_data['fields'] ) && is_array( $pod_data['fields'] ) ) {
+				$field_lists[] = $pod_data['fields'];
+			}
+
+			foreach ( $field_lists as $fields ) {
+				foreach ( $fields as $field ) {
+					$field_name   = pods_v( 'name', $field );
+					$sister_id    = (int) pods_v( 'sister_id', $field, 0 );
+					$sister_field = pods_v( 'sister_field', $field );
+
+					if ( empty( $field_name ) || ( $sister_id < 1 && empty( $sister_field ) ) ) {
+						continue;
+					}
+
+					$refs[ $pod_name ][ $field_name ] = [
+						'sister_id'    => $sister_id,
+						'sister_field' => $sister_field,
+					];
+				}
+			}
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Remap bi-directional (sister_id) references the package carried.
+	 *
+	 * The package stores sister_id as a source-site post ID. After all pods are
+	 * saved, resolve each reference to the destination site's field ID — by the
+	 * portable sister_field name when present, else by the package's old field
+	 * ID — and save it. Unresolvable references are cleared to 0: a stale
+	 * pointer is worse than none. Fields whose package data carried no sister
+	 * reference are left untouched.
+	 *
+	 * @since 3.3.2
+	 *
+	 * @param array $package_sister_refs Map of pod name => [ field name => [ 'sister_id', 'sister_field' ] ].
+	 * @param array $package_field_ids   Map of source-site field ID => [ 'pod', 'field' ] names.
+	 */
+	public static function import_remap_sister_fields( array $package_sister_refs, array $package_field_ids ) {
+		// The pods were just saved; cached pod objects still carry pre-import args.
+		self::$api->cache_flush_pods();
+
+		foreach ( $package_sister_refs as $pod_name => $field_refs ) {
+			$pod = self::$api->load_pod( [ 'name' => $pod_name ], false );
+
+			if ( ! $pod instanceof \Pods\Whatsit\Pod ) {
+				continue;
+			}
+
+			foreach ( $field_refs as $field_name => $ref ) {
+				$field = $pod->get_field( $field_name );
+
+				if ( ! $field instanceof \Pods\Whatsit\Field || 'pick' !== $field->get_type() ) {
+					continue;
+				}
+
+				$related_pod = $field->get_related_object_name();
+
+				$resolved = null;
+
+				if ( $related_pod ) {
+					try {
+						// Prefer the portable name reference.
+						if ( ! empty( $ref['sister_field'] ) ) {
+							$resolved = self::$api->load_field( [
+								'name' => $ref['sister_field'],
+								'pod'  => $related_pod,
+							] );
+						}
+
+						// Fall back to the package's source-site field ID.
+						if ( ! $resolved instanceof \Pods\Whatsit\Field && isset( $package_field_ids[ $ref['sister_id'] ] ) ) {
+							$resolved = self::$api->load_field( [
+								'name' => $package_field_ids[ $ref['sister_id'] ]['field'],
+								'pod'  => $related_pod,
+							] );
+						}
+					} catch ( Exception $exception ) {
+						$resolved = null;
+					}
+				}
+
+				$new_sister_id = $resolved instanceof \Pods\Whatsit\Field ? (int) $resolved->get_id() : 0;
+
+				if ( $new_sister_id === (int) $field->get_arg( 'sister_id', 0 ) ) {
+					continue;
+				}
+
+				self::$api->save_field( [
+					'pod'       => $pod,
+					'id'        => $field->get_id(),
+					'sister_id' => $new_sister_id,
+				] );
+			}
+		}
 	}
 
 	/**
@@ -1037,6 +1225,20 @@ class Pods_Migrate_Packages extends PodsComponent {
 										}
 									}
 								}//end foreach
+
+								// sister_id is a source-site post ID; also emit the sister field name
+								// so import can resolve the bi-directional reference on the new site.
+								if ( 'pick' === pods_v( 'type', $field ) && 0 < (int) pods_v( 'sister_id', $field ) ) {
+									try {
+										$sister_field_obj = self::$api->load_field( [ 'id' => (int) pods_v( 'sister_id', $field ) ] );
+
+										if ( $sister_field_obj instanceof \Pods\Whatsit\Field ) {
+											$field['sister_field'] = $sister_field_obj->get_name();
+										}
+									} catch ( Exception $exception ) {
+										// Leave the field args unchanged if the sister field cannot be loaded.
+									}
+								}
 
 								$group['fields'][ $field_key ] = $field;
 							}//end foreach

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "codeception/util-universalframework": "^1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
     "dms/phpunit-arraysubset-asserts": "^0.5",
-    "fzaninotto/faker": "^1.9",
+    "fakerphp/faker": "^1.9.1",
     "johnbillion/query-monitor": "dev-develop",
     "lucatume/codeception-snapshot-assertions": "^1.4",
     "lucatume/function-mocker": "^2.0",
@@ -73,10 +73,19 @@
     "wp-cli/wp-cli": "^v2.12",
     "wp-coding-standards/wpcs": "^3.3",
     "wp-graphql/wp-graphql": "^v2.6",
-    "wpsyntex/polylang": "dev-master"
+    "wpsyntex/polylang": "^3.8.6"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,
+  "conflict": {
+    "symfony/console": ">=8",
+    "symfony/event-dispatcher": ">=8",
+    "symfony/finder": ">=8",
+    "symfony/property-info": ">=8",
+    "symfony/string": ">=8",
+    "symfony/type-info": ">=8",
+    "symfony/var-dumper": ">=8"
+  },
   "suggest": {
     "wp-cli/wp-cli": "Enables access to Pods CLI commands."
   },
@@ -117,11 +126,24 @@
     }
   },
   "config": {
+    "platform": {
+      "php": "8.2.99"
+    },
     "allow-plugins": {
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "kylekatarnls/update-helper": true,
       "phpstan/extension-installer": true
+    },
+    "policy": {
+      "advisories": {
+        "ignore": {
+          "webonyx/graphql-php": {
+            "constraint": "15.29.3",
+            "reason": "wp-graphql v2.6.0 (latest release) pins this exact version; dev/test dependency only"
+          }
+        }
+      }
     }
   }
 }

--- a/init.php
+++ b/init.php
@@ -16,7 +16,7 @@
  * Text Domain:       pods
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Requires at least: 6.3
+ * Requires at least: 6.5
  * Requires PHP:      7.2
  * GitHub Plugin URI: https://github.com/pods-framework/pods
  * Primary Branch:    main

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: sc0ttkclark, zrothauser, keraweb, jimtrue, quasel, nicdford, jamesgol, ramoonus, pglewis, dan.stefan, Desertsnowman, mgibbs189, Shelob9, clubduece, curtismchale, mikedamage, jchristopher, pcfreak30
 Donate link: https://friends.pods.io/
 Tags: pods, custom post types, custom taxonomies, content types, custom fields
-Requires at least: 6.3
+Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.2
 Stable tag: 3.3.9

--- a/tests/codeception/wpunit/Pods/MigratePackagesSisterIdTest.php
+++ b/tests/codeception/wpunit/Pods/MigratePackagesSisterIdTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Pods_Unit_Tests\Pods;
+
+use Pods\Whatsit\Field;
+use Pods_Unit_Tests\Pods_UnitTestCase;
+
+/**
+ * Bi-directional (sister_id) references through package export/import.
+ *
+ * Packages store sister_id as a source-site wp_posts.ID; export emits a
+ * portable sister_field name and import remaps references after all pods
+ * are saved.
+ *
+ * @group  pods
+ * @group  pods-migrate-packages
+ * @covers Pods_Migrate_Packages
+ */
+class MigratePackagesSisterIdTest extends Pods_UnitTestCase {
+
+	/**
+	 * @var \PodsAPI
+	 */
+	protected $api;
+
+	/**
+	 * @var string
+	 */
+	protected $pod_name = 'test_sister_a';
+
+	/**
+	 * @var string
+	 */
+	protected $pod_name2 = 'test_sister_b';
+
+	/**
+	 * @var int
+	 */
+	protected $pod_id = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $pod_id2 = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $field_id = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $field_id2 = 0;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->api = pods_api();
+
+		$components = \PodsInit::$components;
+
+		$components->load();
+		$components->activate_component( 'migrate-packages' );
+		$components->load();
+
+		$this->populate();
+	}
+
+	public function tearDown(): void {
+		$this->api = null;
+
+		parent::tearDown();
+	}
+
+	public function populate() {
+		$this->pod_id = $this->api->save_pod( [
+			'storage' => 'meta',
+			'type'    => 'post_type',
+			'name'    => $this->pod_name,
+		] );
+
+		$this->pod_id2 = $this->api->save_pod( [
+			'storage' => 'meta',
+			'type'    => 'post_type',
+			'name'    => $this->pod_name2,
+		] );
+
+		$this->field_id = $this->api->save_field( [
+			'pod_id'           => $this->pod_id,
+			'name'             => 'rel_b',
+			'type'             => 'pick',
+			'pick_object'      => 'post_type',
+			'pick_val'         => $this->pod_name2,
+			'pick_format_type' => 'multi',
+		] );
+
+		$this->field_id2 = $this->api->save_field( [
+			'pod_id'           => $this->pod_id2,
+			'name'             => 'rel_a',
+			'type'             => 'pick',
+			'pick_object'      => 'post_type',
+			'pick_val'         => $this->pod_name,
+			'pick_format_type' => 'multi',
+			'sister_id'        => $this->field_id,
+		] );
+
+		// Complete the reciprocal reference.
+		$this->api->save_field( [
+			'pod_id'    => $this->pod_id,
+			'id'        => $this->field_id,
+			'name'      => 'rel_b',
+			'sister_id' => $this->field_id2,
+		] );
+
+		$this->api->cache_flush_pods();
+	}
+
+	/**
+	 * @return string The package JSON.
+	 */
+	protected function export_package() {
+		$json = \Pods_Migrate_Packages::export( [
+			'pods' => [ $this->pod_id, $this->pod_id2 ],
+		] );
+
+		$this->assertNotFalse( $json );
+
+		return $json;
+	}
+
+	/**
+	 * @param array $package The decoded package data.
+	 *
+	 * @return array Map of pod name => field name => field args.
+	 */
+	protected function package_fields( array $package ) {
+		$fields = [];
+
+		foreach ( $package['pods'] as $pod ) {
+			foreach ( $pod['groups'] as $group ) {
+				foreach ( $group['fields'] as $field ) {
+					$fields[ $pod['name'] ][ $field['name'] ] = $field;
+				}
+			}
+		}
+
+		return $fields;
+	}
+
+	protected function assert_reciprocal() {
+		$field_a = $this->api->load_field( [ 'name' => 'rel_b', 'pod' => $this->pod_name ] );
+		$field_b = $this->api->load_field( [ 'name' => 'rel_a', 'pod' => $this->pod_name2 ] );
+
+		$this->assertInstanceOf( Field::class, $field_a );
+		$this->assertInstanceOf( Field::class, $field_b );
+
+		$this->assertSame( (int) $field_b->get_id(), (int) $field_a->get_arg( 'sister_id' ) );
+		$this->assertSame( (int) $field_a->get_id(), (int) $field_b->get_arg( 'sister_id' ) );
+
+		$bidirectional = $field_a->get_bidirectional_field();
+
+		$this->assertInstanceOf( Field::class, $bidirectional );
+		$this->assertSame( 'rel_a', $bidirectional->get_name() );
+	}
+
+	public function test_export_emits_sister_field_names() {
+		$fields = $this->package_fields( json_decode( $this->export_package(), true ) );
+
+		$this->assertSame( 'rel_a', $fields[ $this->pod_name ]['rel_b']['sister_field'] );
+		$this->assertSame( 'rel_b', $fields[ $this->pod_name2 ]['rel_a']['sister_field'] );
+	}
+
+	public function test_import_remaps_sister_id_when_fields_get_new_ids() {
+		$json = $this->export_package();
+
+		$old_field_id  = $this->field_id;
+		$old_field_id2 = $this->field_id2;
+
+		$this->api->delete_pod( [ 'id' => $this->pod_id ] );
+		$this->api->delete_pod( [ 'id' => $this->pod_id2 ] );
+		$this->api->cache_flush_pods();
+
+		$this->assertNotFalse( \Pods_Migrate_Packages::import( $json ) );
+
+		$this->assert_reciprocal();
+
+		// The re-imported fields are new posts; the remap must land on the new IDs.
+		$field_a = $this->api->load_field( [ 'name' => 'rel_b', 'pod' => $this->pod_name ] );
+
+		$this->assertNotEquals( $old_field_id, (int) $field_a->get_id() );
+		$this->assertNotEquals( $old_field_id2, (int) $field_a->get_arg( 'sister_id' ) );
+	}
+
+	public function test_import_remaps_via_package_ids_when_sister_field_absent() {
+		$package = json_decode( $this->export_package(), true );
+
+		// Simulate a package from before sister_field existed.
+		foreach ( $package['pods'] as &$pod ) {
+			foreach ( $pod['groups'] as &$group ) {
+				foreach ( $group['fields'] as &$field ) {
+					unset( $field['sister_field'] );
+				}
+			}
+		}
+
+		unset( $pod, $group, $field );
+
+		$this->api->delete_pod( [ 'id' => $this->pod_id ] );
+		$this->api->delete_pod( [ 'id' => $this->pod_id2 ] );
+		$this->api->cache_flush_pods();
+
+		$this->assertNotFalse( \Pods_Migrate_Packages::import( wp_json_encode( $package ) ) );
+
+		$this->assert_reciprocal();
+	}
+
+	public function test_import_clears_unresolvable_sister_id() {
+		$package = json_decode( $this->export_package(), true );
+
+		// Keep only the first pod; its sister field's pod never gets imported.
+		$package['pods'] = array_values( array_filter( $package['pods'], function ( $pod ) {
+			return $this->pod_name === $pod['name'];
+		} ) );
+
+		$this->api->delete_pod( [ 'id' => $this->pod_id ] );
+		$this->api->delete_pod( [ 'id' => $this->pod_id2 ] );
+		$this->api->cache_flush_pods();
+
+		$this->assertNotFalse( \Pods_Migrate_Packages::import( wp_json_encode( $package ) ) );
+
+		$field_a = $this->api->load_field( [ 'name' => 'rel_b', 'pod' => $this->pod_name ] );
+
+		$this->assertInstanceOf( Field::class, $field_a );
+		$this->assertSame( 0, (int) $field_a->get_arg( 'sister_id' ) );
+	}
+
+	public function test_import_leaves_fields_without_package_reference_untouched() {
+		$package = json_decode( $this->export_package(), true );
+
+		// The package carries no sister reference for rel_b.
+		foreach ( $package['pods'] as &$pod ) {
+			foreach ( $pod['groups'] as &$group ) {
+				foreach ( $group['fields'] as &$field ) {
+					if ( 'rel_b' === $field['name'] ) {
+						unset( $field['sister_field'], $field['sister_id'] );
+					}
+				}
+			}
+		}
+
+		unset( $pod, $group, $field );
+
+		// Import over the existing pods; rel_b's live sister_id must survive.
+		$this->assertNotFalse( \Pods_Migrate_Packages::import( wp_json_encode( $package ) ) );
+
+		$field_a = $this->api->load_field( [ 'name' => 'rel_b', 'pod' => $this->pod_name ] );
+
+		$this->assertSame( $this->field_id2, (int) $field_a->get_arg( 'sister_id' ) );
+	}
+
+	public function test_save_field_skips_sister_meta_on_non_field_posts() {
+		$post_id = wp_insert_post( [
+			'post_title'  => 'Not a Pods field',
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$this->api->save_field( [
+			'pod_id'    => $this->pod_id,
+			'id'        => $this->field_id,
+			'name'      => 'rel_b',
+			'sister_id' => $post_id,
+		] );
+
+		$this->assertSame( '', get_post_meta( $post_id, 'sister_id', true ) );
+	}
+}


### PR DESCRIPTION
Packages store sister_id as a source-site wp_posts.ID; import could create fields with new IDs, but required re-assignment

- export() now also emits sister_field (the sister field's name) as a portable reference; sister_id stays for backward compatibility.
- import() maps package field IDs to pod/field names after all pods are saved; resolves each pick field's reference (by sister_field name, else by old-ID map) and saves the new sister_id. Unresolvable references are cleared to 0.

## Description

See https://wordpress.org/support/topic/bi-directional-field-not-working-after-import-package/

## Testing instructions

- Export Package JSON (Download or copy textarea)
- Delete existing Pods (to get new IDs when importing) on /wp-admin/admin.php?page=pods
- Impot Package JSON on /wp-admin/admin.php?page=pods-component-migrate-packages (paste or upload)
- Visit /wp-admin/admin.php?page=pods
- Edit "CPT One"
- Click "Edit" for each field of type Relationship
- Field "Bi-directional Field" should have the field selected already, not requiring re-selection and re-save

## Changelog text for these changes

Include bidirectional fields in Pods Package Import/Export

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
