### PR TITLE
Replace deprecated "boolean" with "bool" in PHP code

### DIFF
--- a/classes/Pods.php
+++ b/classes/Pods.php
@@ -284,7 +284,7 @@ class Pods implements Iterator {
 	/**
 	 * Get current Iterator row
 	 *
-	 * @return mixed|boolean
+	 * @return mixed|bool
 	 *
 	 * @since 2.3.4
 	 *
@@ -487,7 +487,7 @@ class Pods implements Iterator {
 	 * list of text such as "Rick, John, and Gary"
 	 *
 	 * @param string|array|object  $name   The field name, or an associative array of parameters.
-	 * @param boolean|array|object $single (optional) For tableless fields, to return an array or the first.
+	 * @param bool|array|object $single (optional) For tableless fields, to return an array or the first.
 	 *
 	 * @return string|null|false The output from the field, null if the field doesn't exist, false if no value returned
 	 *                           for tableless fields
@@ -542,7 +542,7 @@ class Pods implements Iterator {
 	 * list of text such as "Rick, John, and Gary"
 	 *
 	 * @param string|array|object  $name   The field name, or an associative array of parameters.
-	 * @param boolean|array|object $single (optional) For tableless fields, to return an array or the first.
+	 * @param bool|array|object $single (optional) For tableless fields, to return an array or the first.
 	 *
 	 * @return string|null|false The output from the field, null if the field doesn't exist, false if no value returned
 	 *                           for tableless fields
@@ -579,9 +579,9 @@ class Pods implements Iterator {
 	 * This function will return arrays for relationship and file fields.
 	 *
 	 * @param string|array|object  $name   The field name, or an associative array of parameters.
-	 * @param boolean|array|object $single For tableless fields, to return the whole array or the just the first item,
+	 * @param bool|array|object $single For tableless fields, to return the whole array or the just the first item,
 	 *                                     or an associative array of parameters.
-	 * @param boolean|array|object $raw    Whether to return the raw value, or to run through the field type's display
+	 * @param bool|array|object $raw    Whether to return the raw value, or to run through the field type's display
 	 *                                     method, or an associative array of parameters.
 	 *
 	 * @return mixed|null Value returned depends on the field type, null if the field doesn't exist, false if no value
@@ -673,7 +673,7 @@ class Pods implements Iterator {
 		}
 
 		if ( null !== $params->single ) {
-			$params->single = (boolean) $params->single;
+			$params->single = (bool) $params->single;
 		}
 
 		$params->name = trim( (string) $params->name );
@@ -2404,9 +2404,9 @@ class Pods implements Iterator {
 			'offset'              => null,
 			'page'                => (int) $this->page,
 			'page_var'            => $this->page_var,
-			'pagination'          => (boolean) $this->pagination,
+			'pagination'          => (bool) $this->pagination,
 			// Search parameters.
-			'search'              => (boolean) $this->search,
+			'search'              => (bool) $this->search,
 			'search_var'          => $this->search_var,
 			'search_query'        => null,
 			'search_mode'         => $this->search_mode,
@@ -2449,8 +2449,8 @@ class Pods implements Iterator {
 		$this->offset     = (int) $params->offset;
 		$this->page       = (int) $params->page;
 		$this->page_var   = $params->page_var;
-		$this->pagination = (boolean) $params->pagination;
-		$this->search     = (boolean) $params->search;
+		$this->pagination = (bool) $params->pagination;
+		$this->search     = (bool) $params->search;
 		$this->search_var = $params->search_var;
 		$this->filter_var = $params->filter_var;
 		$params->join     = (array) $params->join;
@@ -3637,7 +3637,7 @@ class Pods implements Iterator {
 		 *
 		 * @since 2.8.0
 		 */
-		$include_obj = (boolean) apply_filters( 'pods_helper_include_obj', false, $params );
+		$include_obj = (bool) apply_filters( 'pods_helper_include_obj', false, $params );
 
 		// Clean up helper callback (if string).
 		if ( is_string( $params['helper'] ) ) {

--- a/classes/PodsAPI.php
+++ b/classes/PodsAPI.php
@@ -793,7 +793,7 @@ class PodsAPI {
 	 *
 	 * @param string  $object  The pod type to look for, possible values: post_type, user, comment, taxonomy
 	 * @param array   $pod     Array of Pod data
-	 * @param boolean $refresh Whether to force refresh the information
+	 * @param bool    $refresh Whether to force refresh the information
 	 *
 	 * @return array Array of fields
 	 *
@@ -1808,7 +1808,7 @@ class PodsAPI {
 			$params->name = pods_clean_name( $params->name );
 		}
 
-		$params->overwrite = ! empty( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->overwrite = ! empty( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		$order_group_fields = null;
 
@@ -2621,7 +2621,7 @@ class PodsAPI {
 	 * @param array   $pod                    The pod configuration.
 	 * @param array   $fields                 The list of fields on the pod.
 	 * @param array   $old_info               The old information to reference.
-	 * @param boolean $overwrite_table_schema Whether to overwrite the table schema if it exists already.
+	 * @param bool    $overwrite_table_schema Whether to overwrite the table schema if it exists already.
 	 *
 	 * @return bool|WP_Error True if the schema changes were handled, false or an error if it failed to create/update.
 	 *
@@ -3250,8 +3250,8 @@ class PodsAPI {
 		$params->pod_id = $pod['id'];
 		$params->pod    = $pod['name'];
 
-		$params->is_new    = isset( $params->is_new ) ? (boolean) $params->is_new : false;
-		$params->overwrite = isset( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->is_new    = isset( $params->is_new ) ? (bool) $params->is_new : false;
+		$params->overwrite = isset( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		$reserved_keywords = pods_reserved_keywords( 'wp-post' );
 
@@ -4268,13 +4268,13 @@ class PodsAPI {
 		$id_required = false;
 
 		if ( isset( $params->id_required ) ) {
-			$id_required = (boolean) $params->id_required;
+			$id_required = (bool) $params->id_required;
 
 			unset( $params->id_required );
 		}
 
-		$params->is_new    = isset( $params->is_new ) ? (boolean) $params->is_new : false;
-		$params->overwrite = isset( $params->overwrite ) ? (boolean) $params->overwrite : false;
+		$params->is_new    = isset( $params->is_new ) ? (bool) $params->is_new : false;
+		$params->overwrite = isset( $params->overwrite ) ? (bool) $params->overwrite : false;
 
 		if ( ! $pod && ( ! isset( $params->pod ) || empty( $params->pod ) ) && ( ! isset( $params->pod_id ) || empty( $params->pod_id ) ) ) {
 			return pods_error( __( 'Pod ID or name is required', 'pods' ), $this );
@@ -4938,7 +4938,7 @@ class PodsAPI {
 		}
 
 		if ( isset( $params->is_new_item ) ) {
-			$is_new_item = (boolean) $params->is_new_item;
+			$is_new_item = (bool) $params->is_new_item;
 		}
 
 		// Allow Helpers to bypass subsequent helpers in recursive save_pod_item calls
@@ -5448,7 +5448,7 @@ class PodsAPI {
 						|| in_array( pods_v( 'pick_object', $field_data ), $simple_tableless_objects, true )
 					)
 				);
-				$simple = (boolean) $this->do_hook( 'tableless_custom', $simple, $field_data, $field, $fields, $pod, $params );
+				$simple = (bool) $this->do_hook( 'tableless_custom', $simple, $field_data, $field, $fields, $pod, $params );
 
 				$is_repeatable_field = (
 					(
@@ -7049,7 +7049,7 @@ class PodsAPI {
 		$params['fields']        = (array) pods_v( 'fields', $params, [], true );
 		$params['depth']         = (int) pods_v( 'depth', $params, 2, true );
 		$params['object_fields'] = (array) pods_v( 'object_fields', $pod->pod_data, [], true );
-		$params['flatten']       = (boolean) pods_v( 'flatten', $params, false, true );
+		$params['flatten']       = (bool) pods_v( 'flatten', $params, false, true );
 		$params['context']       = pods_v( 'context', $params, null, true );
 
 		if ( empty( $params['fields'] ) ) {
@@ -7526,7 +7526,7 @@ class PodsAPI {
 			$params->delete_all = $delete_all;
 		}
 
-		$params->delete_all = (boolean) $params->delete_all;
+		$params->delete_all = (bool) $params->delete_all;
 
 		// Reset content
 		if ( true === $params->delete_all ) {
@@ -7740,7 +7740,7 @@ class PodsAPI {
 		}
 
 		$simple = ( 'pick' === $field['type'] && in_array( pods_v( 'pick_object', $field ), $simple_tableless_objects, true ) );
-		$simple = (boolean) $this->do_hook( 'tableless_custom', $simple, $field, $pod, $params );
+		$simple = (bool) $this->do_hook( 'tableless_custom', $simple, $field, $pod, $params );
 
 		// @todo Push this logic into pods_object_storage_delete_pod action.
 		if ( $table_operation && $pod && 'table' === $pod['storage'] && ( ! in_array( $field['type'], $tableless_field_types, true ) || $simple ) ) {
@@ -7820,7 +7820,7 @@ class PodsAPI {
 		}
 
 		if ( ! isset( $params->delete_all ) ) {
-			$params->delete_all = (boolean) $delete_all;
+			$params->delete_all = (bool) $delete_all;
 		}
 
 		$group = $this->load_group( $params, false );
@@ -8542,7 +8542,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}
@@ -8583,7 +8583,7 @@ class PodsAPI {
 	 * $params['name'] string The field name
 	 *
 	 * @param array   $params   An associative array of parameters
-	 * @param boolean $allow_id Whether to allow the ID when checking if the group exists.
+	 * @param bool    $allow_id Whether to allow the ID when checking if the group exists.
 	 *
 	 * @return bool
 	 *
@@ -8613,7 +8613,7 @@ class PodsAPI {
 		}
 
 		try {
-			return (boolean) $this->load_field( $load_params );
+			return (bool) $this->load_field( $load_params );
 		} catch ( Exception $exception ) {
 			pods_debug_log( $exception );
 
@@ -8634,7 +8634,7 @@ class PodsAPI {
 	 * @type boolean    $bypass_cache Bypass the cache when getting data.
 	 *                                }
 	 *
-	 * @param boolean   $strict       Whether to require a field exist or not when loading the info.
+	 * @param bool      $strict       Whether to require a field exist or not when loading the info.
 	 *
 	 * @return Pods\Whatsit\Field|bool Field object or false if not found.
 	 *
@@ -8889,7 +8889,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}
@@ -8947,7 +8947,7 @@ class PodsAPI {
 	 * @type boolean            $bypass_cache        Bypass the cache when getting data.
 	 *                                               }
 	 *
-	 * @param boolean           $allow_id            Whether to allow the ID when checking if the group exists.
+	 * @param bool              $allow_id            Whether to allow the ID when checking if the group exists.
 	 *
 	 * @return bool
 	 *
@@ -8977,7 +8977,7 @@ class PodsAPI {
 		}
 
 		try {
-			return (boolean) $this->load_group( $load_params );
+			return (bool) $this->load_group( $load_params );
 		} catch ( Exception $exception ) {
 			pods_debug_log( $exception );
 
@@ -9121,7 +9121,7 @@ class PodsAPI {
 		$include_internal = false;
 
 		if ( isset( $params['include_internal'] ) ) {
-			$include_internal = (boolean) $params['include_internal'];
+			$include_internal = (bool) $params['include_internal'];
 
 			unset( $params['include_internal'] );
 		}
@@ -11824,7 +11824,7 @@ class PodsAPI {
 	 * @type boolean  $bypass_cache Bypass the cache when getting data.
 	 *                              }
 	 *
-	 * @param boolean $strict       Whether to require a field exist or not when loading the info.
+	 * @param bool    $strict       Whether to require a field exist or not when loading the info.
 	 *
 	 * @return Pods\Whatsit|false Object or false if not found.
 	 *

--- a/classes/PodsAdmin.php
+++ b/classes/PodsAdmin.php
@@ -2229,7 +2229,7 @@ class PodsAdmin {
 	/**
 	 * Get the edit page of an object
 	 *
-	 * @param boolean $duplicate Whether the screen is for duplicating.
+	 * @param bool    $duplicate Whether the screen is for duplicating.
 	 * @param PodsUI  $obj       PodsUI object.
 	 */
 	public function admin_setup_edit( $duplicate, $obj ) {

--- a/classes/PodsArray.php
+++ b/classes/PodsArray.php
@@ -154,7 +154,7 @@ class PodsArray implements ArrayAccess {
 				$value = abs( $value );
 			}
 		} elseif ( 'boolean' === $type || 'bool' === $type ) {
-			$value = (boolean) $value;
+			$value = (bool) $value;
 		} elseif ( 'in_array' === $type && is_array( $default ) ) {
 			if ( is_array( $value ) ) {
 				foreach ( $value as $k => $v ) {

--- a/classes/PodsComponents.php
+++ b/classes/PodsComponents.php
@@ -681,7 +681,7 @@ class PodsComponents {
 	 * Toggle a component on or off
 	 *
 	 * @param string  $component   The component name to toggle.
-	 * @param boolean $toggle_mode Force toggle on or off.
+	 * @param bool    $toggle_mode Force toggle on or off.
 	 *
 	 * @return bool
 	 *
@@ -691,7 +691,7 @@ class PodsComponents {
 
 		$toggled = null;
 
-		$toggle_mode = (boolean) pods_v( 'toggle', 'get', $toggle_mode );
+		$toggle_mode = (bool) pods_v( 'toggle', 'get', $toggle_mode );
 
 		if ( $toggle_mode ) {
 			$toggled = $this->activate_component( $component );
@@ -720,11 +720,11 @@ class PodsComponents {
 			}
 
 			if ( ! pods_developer() ) {
-				if ( true === (boolean) pods_v( 'DeveloperMode', $component_data, false ) ) {
+				if ( true === (bool) pods_v( 'DeveloperMode', $component_data, false ) ) {
 					continue;
 				}
 
-				if ( true === (boolean) pods_v( 'TablelessMode', $component_data, false ) ) {
+				if ( true === (bool) pods_v( 'TablelessMode', $component_data, false ) ) {
 					continue;
 				}
 			}

--- a/classes/PodsData.php
+++ b/classes/PodsData.php
@@ -836,7 +836,7 @@ class PodsData {
 		/**
 		 * Filters whether the total_found should be calculated right away or not.
 		 *
-		 * @param boolean  $auto_calculate_total_found Whether to auto calculate total_found.
+		 * @param bool     $auto_calculate_total_found Whether to auto calculate total_found.
 		 * @param object   $params                     Select parameters.
 		 * @param PodsData $instance                   The current PodsData instance.
 		 *
@@ -953,7 +953,7 @@ class PodsData {
 		// Validate.
 		$params->page = pods_absint( $params->page );
 
-		$params->pagination = (boolean) $params->pagination;
+		$params->pagination = (bool) $params->pagination;
 
 		if ( 0 === $params->page || ! $params->pagination ) {
 			$params->page = 1;
@@ -1167,7 +1167,7 @@ class PodsData {
 			$this->search_mode = $params->search_mode;
 		}
 
-		$params->search = (boolean) $params->search;
+		$params->search = (bool) $params->search;
 
 		if ( 1 === (int) pods_v( 'pods_debug_params_all', 'get', 0 ) && pods_is_admin( array( 'pods' ) ) ) {
 			pods_debug( __METHOD__ . ':' . __LINE__ );
@@ -1969,7 +1969,7 @@ class PodsData {
 	 *
 	 * @param string  $table         Table name.
 	 * @param string  $fields
-	 * @param boolean $if_not_exists Check if the table exists.
+	 * @param bool    $if_not_exists Check if the table exists.
 	 *
 	 * @return array|bool|mixed|null|void
 	 *
@@ -2641,8 +2641,8 @@ class PodsData {
 	 * Gets all tables in the WP database, optionally exclude WP core
 	 * tables, and/or Pods table by settings the parameters to false.
 	 *
-	 * @param boolean $wp_core
-	 * @param boolean $pods_tables restrict Pods 2x tables.
+	 * @param bool $wp_core
+	 * @param bool $pods_tables restrict Pods 2x tables.
 	 *
 	 * @return array
 	 *
@@ -2945,7 +2945,7 @@ class PodsData {
 		}
 
 		$field_compare         = strtoupper( trim( (string) pods_v( 'compare', $q, $field_compare, true ) ) );
-		$field_sanitize        = (boolean) pods_v( 'sanitize', $q, true );
+		$field_sanitize        = (bool) pods_v( 'sanitize', $q, true );
 		$field_sanitize_format = pods_v( 'sanitize_format', $q, null, true );
 		$field_cast            = pods_v( 'cast', $q, null, true );
 

--- a/classes/PodsField.php
+++ b/classes/PodsField.php
@@ -227,7 +227,7 @@ class PodsField {
 	 * Check if the field values are empty.
 	 *
 	 * @param array|mixed $values Field values.
-	 * @param boolean     $strict Whether to check if any of the values are non-empty in an array.
+	 * @param bool        $strict Whether to check if any of the values are non-empty in an array.
 	 *
 	 * @return bool
 	 *
@@ -686,7 +686,7 @@ class PodsField {
 	 * @param array|null      $options Field options.
 	 * @param array|null      $pod     Pod information.
 	 * @param int|string|null $id      Current item ID.
-	 * @param boolean         $in_form Whether we are in the form context.
+	 * @param bool            $in_form Whether we are in the form context.
 	 *
 	 * @return array Array of possible field data.
 	 *

--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -1407,7 +1407,7 @@ class PodsForm {
 		 * @since 2.0.0
 		 * @deprecated 2.8.0
 		 */
-		return (boolean) apply_filters( 'pods_form_field_permission', $permission, $type, $name, $options, $fields, $pod, $id, $params );
+		return (bool) apply_filters( 'pods_form_field_permission', $permission, $type, $name, $options, $fields, $pod, $id, $params );
 	}
 
 	/**

--- a/classes/PodsInit.php
+++ b/classes/PodsInit.php
@@ -1178,18 +1178,18 @@ class PodsInit {
 
 				// Supported
 				$cpt_supported = [
-					'title'           => (boolean) pods_v( 'supports_title', $post_type, false ),
-					'editor'          => (boolean) pods_v( 'supports_editor', $post_type, false ),
-					'author'          => (boolean) pods_v( 'supports_author', $post_type, false ),
-					'thumbnail'       => (boolean) pods_v( 'supports_thumbnail', $post_type, false ),
-					'excerpt'         => (boolean) pods_v( 'supports_excerpt', $post_type, false ),
-					'trackbacks'      => (boolean) pods_v( 'supports_trackbacks', $post_type, false ),
-					'custom-fields'   => (boolean) pods_v( 'supports_custom_fields', $post_type, false ),
-					'comments'        => (boolean) pods_v( 'supports_comments', $post_type, false ),
-					'revisions'       => (boolean) pods_v( 'supports_revisions', $post_type, false ),
-					'page-attributes' => (boolean) pods_v( 'supports_page_attributes', $post_type, false ),
-					'post-formats'    => (boolean) pods_v( 'supports_post_formats', $post_type, false ),
-					'quick-edit'      => (boolean) pods_v( 'supports_quick_edit', $post_type, true ),
+					'title'           => (bool) pods_v( 'supports_title', $post_type, false ),
+					'editor'          => (bool) pods_v( 'supports_editor', $post_type, false ),
+					'author'          => (bool) pods_v( 'supports_author', $post_type, false ),
+					'thumbnail'       => (bool) pods_v( 'supports_thumbnail', $post_type, false ),
+					'excerpt'         => (bool) pods_v( 'supports_excerpt', $post_type, false ),
+					'trackbacks'      => (bool) pods_v( 'supports_trackbacks', $post_type, false ),
+					'custom-fields'   => (bool) pods_v( 'supports_custom_fields', $post_type, false ),
+					'comments'        => (bool) pods_v( 'supports_comments', $post_type, false ),
+					'revisions'       => (bool) pods_v( 'supports_revisions', $post_type, false ),
+					'page-attributes' => (bool) pods_v( 'supports_page_attributes', $post_type, false ),
+					'post-formats'    => (bool) pods_v( 'supports_post_formats', $post_type, false ),
+					'quick-edit'      => (bool) pods_v( 'supports_quick_edit', $post_type, true ),
 				];
 
 				// Custom Supported
@@ -1206,20 +1206,20 @@ class PodsInit {
 
 				// Genesis Support
 				if ( function_exists( 'genesis' ) ) {
-					$cpt_supported['genesis-seo']             = (boolean) pods_v( 'supports_genesis_seo', $post_type, false );
-					$cpt_supported['genesis-layouts']         = (boolean) pods_v( 'supports_genesis_layouts', $post_type, false );
-					$cpt_supported['genesis-simple-sidebars'] = (boolean) pods_v( 'supports_genesis_simple_sidebars', $post_type, false );
+					$cpt_supported['genesis-seo']             = (bool) pods_v( 'supports_genesis_seo', $post_type, false );
+					$cpt_supported['genesis-layouts']         = (bool) pods_v( 'supports_genesis_layouts', $post_type, false );
+					$cpt_supported['genesis-simple-sidebars'] = (bool) pods_v( 'supports_genesis_simple_sidebars', $post_type, false );
 				}
 
 				// YARPP Support
 				if ( defined( 'YARPP_VERSION' ) ) {
-					$cpt_supported['yarpp_support'] = (boolean) pods_v( 'supports_yarpp_support', $post_type, false );
+					$cpt_supported['yarpp_support'] = (bool) pods_v( 'supports_yarpp_support', $post_type, false );
 				}
 
 				// Jetpack Support
 				if ( class_exists( 'Jetpack' ) ) {
-					$cpt_supported['supports_jetpack_publicize'] = (boolean) pods_v( 'supports_jetpack_publicize', $post_type, false );
-					$cpt_supported['supports_jetpack_markdown']  = (boolean) pods_v( 'supports_jetpack_markdown', $post_type, false );
+					$cpt_supported['supports_jetpack_publicize'] = (bool) pods_v( 'supports_jetpack_publicize', $post_type, false );
+					$cpt_supported['supports_jetpack_markdown']  = (bool) pods_v( 'supports_jetpack_markdown', $post_type, false );
 				}
 
 				$cpt_supports = [];
@@ -1239,12 +1239,12 @@ class PodsInit {
 				}
 
 				// Rewrite
-				$cpt_rewrite       = (boolean) pods_v( 'rewrite', $post_type, true );
+				$cpt_rewrite       = (bool) pods_v( 'rewrite', $post_type, true );
 				$cpt_rewrite_array = [
 					'slug'       => pods_v( 'rewrite_custom_slug', $post_type, str_replace( '_', '-', $post_type_name ), true ),
-					'with_front' => (boolean) pods_v( 'rewrite_with_front', $post_type, true ),
-					'feeds'      => (boolean) pods_v( 'rewrite_feeds', $post_type, (boolean) pods_v( 'has_archive', $post_type, false ) ),
-					'pages'      => (boolean) pods_v( 'rewrite_pages', $post_type, true ),
+					'with_front' => (bool) pods_v( 'rewrite_with_front', $post_type, true ),
+					'feeds'      => (bool) pods_v( 'rewrite_feeds', $post_type, (bool) pods_v( 'has_archive', $post_type, false ) ),
+					'pages'      => (bool) pods_v( 'rewrite_pages', $post_type, true ),
 				];
 
 				if ( false !== $cpt_rewrite ) {
@@ -1260,7 +1260,7 @@ class PodsInit {
 					$capability_type = pods_v( 'capability_type_custom', $post_type, pods_v( 'name', $post_type, 'post', true ), true );
 				}
 
-				$show_in_menu = (boolean) pods_v( 'show_in_menu', $post_type, true );
+				$show_in_menu = (bool) pods_v( 'show_in_menu', $post_type, true );
 
 				if ( $show_in_menu && 0 < strlen( (string) pods_v( 'menu_location_custom', $post_type ) ) ) {
 					$show_in_menu = (string) pods_v( 'menu_location_custom', $post_type );
@@ -1277,31 +1277,31 @@ class PodsInit {
 					'label'               => $cpt_label,
 					'labels'              => $cpt_labels,
 					'description'         => esc_html( pods_v( 'description', $post_type ) ),
-					'public'              => (boolean) pods_v( 'public', $post_type, true ),
-					'publicly_queryable'  => (boolean) pods_v( 'publicly_queryable', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
-					'exclude_from_search' => (boolean) pods_v( 'exclude_from_search', $post_type, ( (boolean) pods_v( 'public', $post_type, true ) ? false : true ) ),
-					'show_ui'             => (boolean) pods_v( 'show_ui', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
+					'public'              => (bool) pods_v( 'public', $post_type, true ),
+					'publicly_queryable'  => (bool) pods_v( 'publicly_queryable', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
+					'exclude_from_search' => (bool) pods_v( 'exclude_from_search', $post_type, ( (bool) pods_v( 'public', $post_type, true ) ? false : true ) ),
+					'show_ui'             => (bool) pods_v( 'show_ui', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
 					'show_in_menu'        => $show_in_menu,
-					'show_in_nav_menus'   => (boolean) pods_v( 'show_in_nav_menus', $post_type, (boolean) pods_v( 'public', $post_type, true ) ),
-					'show_in_admin_bar'   => (boolean) pods_v( 'show_in_admin_bar', $post_type, (boolean) pods_v( 'show_in_menu', $post_type, true ) ),
+					'show_in_nav_menus'   => (bool) pods_v( 'show_in_nav_menus', $post_type, (bool) pods_v( 'public', $post_type, true ) ),
+					'show_in_admin_bar'   => (bool) pods_v( 'show_in_admin_bar', $post_type, (bool) pods_v( 'show_in_menu', $post_type, true ) ),
 					'menu_position'       => (int) pods_v( 'menu_position', $post_type, 0, true ),
 					'menu_icon'           => $menu_icon,
 					'capability_type'     => $capability_type,
 					// 'capabilities' => $cpt_capabilities,
-					'map_meta_cap'        => (boolean) pods_v( 'capability_type_extra', $post_type, true ),
-					'hierarchical'        => (boolean) pods_v( 'hierarchical', $post_type, false ),
-					'can_export'          => (boolean) pods_v( 'can_export', $post_type, true ),
+					'map_meta_cap'        => (bool) pods_v( 'capability_type_extra', $post_type, true ),
+					'hierarchical'        => (bool) pods_v( 'hierarchical', $post_type, false ),
+					'can_export'          => (bool) pods_v( 'can_export', $post_type, true ),
 					'supports'            => $cpt_supports,
 					// 'register_meta_box_cb' => array($this, 'manage_meta_box'),
 					// 'permalink_epmask' => EP_PERMALINK,
-					'has_archive'         => ( (boolean) pods_v( 'has_archive', $post_type, false ) ) ? pods_v( 'has_archive_slug', $post_type, true, true ) : false,
+					'has_archive'         => ( (bool) pods_v( 'has_archive', $post_type, false ) ) ? pods_v( 'has_archive_slug', $post_type, true, true ) : false,
 					'rewrite'             => $cpt_rewrite,
-					'query_var'           => ( false !== (boolean) pods_v( 'query_var', $post_type, true ) ? pods_v( 'query_var_string', $post_type, $post_type_name, true ) : false ),
-					'delete_with_user'    => (boolean) pods_v( 'delete_with_user', $post_type, true ),
+					'query_var'           => ( false !== (bool) pods_v( 'query_var', $post_type, true ) ? pods_v( 'query_var_string', $post_type, $post_type_name, true ) : false ),
+					'delete_with_user'    => (bool) pods_v( 'delete_with_user', $post_type, true ),
 					'_provider'           => 'pods',
 				];
 
-				if ( (boolean) pods_v( 'disable_create_posts', $post_type, false ) ) {
+				if ( (bool) pods_v( 'disable_create_posts', $post_type, false ) ) {
 					$pods_post_types[ $post_type_name ]['capabilities'] = [
 						'create_posts' => false,
 					];
@@ -1314,7 +1314,7 @@ class PodsInit {
 				}
 
 				// REST API
-				$rest_enabled = (boolean) pods_v( 'rest_enable', $post_type, false );
+				$rest_enabled = (bool) pods_v( 'rest_enable', $post_type, false );
 
 				if ( $rest_enabled ) {
 					$rest_base = sanitize_title( pods_v( 'rest_base', $post_type, $post_type_name ) );
@@ -1375,7 +1375,7 @@ class PodsInit {
 						continue;
 					}
 
-					if ( false !== (boolean) pods_v( 'built_in_taxonomies_' . $taxonomy, $post_type, false ) ) {
+					if ( false !== (bool) pods_v( 'built_in_taxonomies_' . $taxonomy, $post_type, false ) ) {
 						$cpt_taxonomies[] = $taxonomy;
 
 						if ( isset( $supported_post_types[ $taxonomy ] ) && ! in_array( $post_type_name, $supported_post_types[ $taxonomy ], true ) ) {
@@ -1437,11 +1437,11 @@ class PodsInit {
 				$ct_labels['desc_field_description']     = pods_v( 'label_desc_field_description', $taxonomy, '', true );
 
 				// Rewrite
-				$ct_rewrite       = (boolean) pods_v( 'rewrite', $taxonomy, true );
+				$ct_rewrite       = (bool) pods_v( 'rewrite', $taxonomy, true );
 				$ct_rewrite_array = [
 					'slug'         => pods_v( 'rewrite_custom_slug', $taxonomy, str_replace( '_', '-', $taxonomy_name ), true ),
-					'with_front'   => (boolean) pods_v( 'rewrite_with_front', $taxonomy, true ),
-					'hierarchical' => (boolean) pods_v( 'rewrite_hierarchical', $taxonomy, (boolean) pods_v( 'hierarchical', $taxonomy, false ) ),
+					'with_front'   => (bool) pods_v( 'rewrite_with_front', $taxonomy, true ),
+					'hierarchical' => (bool) pods_v( 'rewrite_hierarchical', $taxonomy, (bool) pods_v( 'hierarchical', $taxonomy, false ) ),
 				];
 
 				if ( false !== $ct_rewrite ) {
@@ -1483,22 +1483,22 @@ class PodsInit {
 					'label'                 => $ct_label,
 					'labels'                => $ct_labels,
 					'description'           => esc_html( pods_v( 'description', $taxonomy ) ),
-					'public'                => (boolean) pods_v( 'public', $taxonomy, true ),
-					'publicly_queryable'    => (boolean) pods_v( 'publicly_queryable', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_ui'               => (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_in_menu'          => (boolean) pods_v( 'show_in_menu', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_in_nav_menus'     => (boolean) pods_v( 'show_in_nav_menus', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ),
-					'show_tagcloud'         => (boolean) pods_v( 'show_tagcloud', $taxonomy, (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ) ),
-					'show_in_quick_edit'    => (boolean) pods_v( 'show_in_quick_edit', $taxonomy, (boolean) pods_v( 'show_ui', $taxonomy, (boolean) pods_v( 'public', $taxonomy, true ) ) ),
-					'hierarchical'          => (boolean) pods_v( 'hierarchical', $taxonomy, false ),
+					'public'                => (bool) pods_v( 'public', $taxonomy, true ),
+					'publicly_queryable'    => (bool) pods_v( 'publicly_queryable', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_ui'               => (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_in_menu'          => (bool) pods_v( 'show_in_menu', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_in_nav_menus'     => (bool) pods_v( 'show_in_nav_menus', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ),
+					'show_tagcloud'         => (bool) pods_v( 'show_tagcloud', $taxonomy, (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ) ),
+					'show_in_quick_edit'    => (bool) pods_v( 'show_in_quick_edit', $taxonomy, (bool) pods_v( 'show_ui', $taxonomy, (bool) pods_v( 'public', $taxonomy, true ) ) ),
+					'hierarchical'          => (bool) pods_v( 'hierarchical', $taxonomy, false ),
 					// 'capability_type'       => $capability_type,
 					'capabilities'          => $tax_capabilities,
-					// 'map_meta_cap'          => (boolean) pods_v( 'capability_type_extra', $taxonomy, true ),
+					// 'map_meta_cap'          => (bool) pods_v( 'capability_type_extra', $taxonomy, true ),
 					'update_count_callback' => pods_v( 'update_count_callback', $taxonomy, null, true ),
-					'query_var'             => ( false !== (boolean) pods_v( 'query_var', $taxonomy, true ) ? pods_v( 'query_var_string', $taxonomy, $taxonomy_name, true ) : false ),
+					'query_var'             => ( false !== (bool) pods_v( 'query_var', $taxonomy, true ) ? pods_v( 'query_var_string', $taxonomy, $taxonomy_name, true ) : false ),
 					'rewrite'               => $ct_rewrite,
-					'show_admin_column'     => (boolean) pods_v( 'show_admin_column', $taxonomy, false ),
-					'sort'                  => (boolean) pods_v( 'sort', $taxonomy, false ),
+					'show_admin_column'     => (bool) pods_v( 'show_admin_column', $taxonomy, false ),
+					'sort'                  => (bool) pods_v( 'sort', $taxonomy, false ),
 					'_provider'             => 'pods',
 				];
 
@@ -1522,7 +1522,7 @@ class PodsInit {
 				}
 
 				// REST API
-				$rest_enabled = (boolean) pods_v( 'rest_enable', $taxonomy, false );
+				$rest_enabled = (bool) pods_v( 'rest_enable', $taxonomy, false );
 
 				if ( $rest_enabled ) {
 					$rest_base = sanitize_title( pods_v( 'rest_base', $taxonomy, $taxonomy_name ) );
@@ -1551,8 +1551,8 @@ class PodsInit {
 
 				// Integration for Single Value Taxonomy UI
 				if ( function_exists( 'tax_single_value_meta_box' ) ) {
-					$pods_taxonomies[ $taxonomy_name ]['single_value'] = (boolean) pods_v( 'single_value', $taxonomy, false );
-					$pods_taxonomies[ $taxonomy_name ]['required']     = (boolean) pods_v( 'single_value_required', $taxonomy, false );
+					$pods_taxonomies[ $taxonomy_name ]['single_value'] = (bool) pods_v( 'single_value', $taxonomy, false );
+					$pods_taxonomies[ $taxonomy_name ]['required']     = (bool) pods_v( 'single_value_required', $taxonomy, false );
 				}
 
 				// Post Types
@@ -1566,7 +1566,7 @@ class PodsInit {
 						continue;
 					}
 
-					if ( false !== (boolean) pods_v( 'built_in_post_types_' . $post_type, $taxonomy, false ) ) {
+					if ( false !== (bool) pods_v( 'built_in_post_types_' . $post_type, $taxonomy, false ) ) {
 						$ct_post_types[] = $post_type;
 
 						if ( isset( $supported_taxonomies[ $post_type ] ) && ! in_array( $taxonomy_name, $supported_taxonomies[ $post_type ], true ) ) {
@@ -1755,7 +1755,7 @@ class PodsInit {
 			$pod = $post_types[ $post_type_name ];
 
 			// REST API
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				if ( empty( $wp_post_types[ $post_type_name ]->show_in_rest ) ) {
@@ -1784,7 +1784,7 @@ class PodsInit {
 			$pod = $taxonomies[ $taxonomy_name ];
 
 			// REST API
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				if ( empty( $wp_taxonomies[ $taxonomy_name ]->show_in_rest ) ) {
@@ -1802,7 +1802,7 @@ class PodsInit {
 		if ( ! empty( PodsMeta::$user ) ) {
 			$pod = current( PodsMeta::$user );
 
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				new PodsRESTFields( $pod );
@@ -1812,7 +1812,7 @@ class PodsInit {
 		if ( ! empty( PodsMeta::$media ) ) {
 			$pod = current( PodsMeta::$media );
 
-			$rest_enabled = (boolean) pods_v( 'rest_enable', $pod, false );
+			$rest_enabled = (bool) pods_v( 'rest_enable', $pod, false );
 
 			if ( $rest_enabled ) {
 				new PodsRESTFields( $pod );
@@ -1857,7 +1857,7 @@ class PodsInit {
 			return $enable;
 		}
 
-		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$post_types[ $post_type ], true );
+		return (bool) pods_v( 'supports_quick_edit', PodsMeta::$post_types[ $post_type ], true );
 	}
 
 	/**
@@ -1879,7 +1879,7 @@ class PodsInit {
 			return $enable;
 		}
 
-		return (boolean) pods_v( 'supports_quick_edit', PodsMeta::$taxonomies[ $taxonomy ], true );
+		return (bool) pods_v( 'supports_quick_edit', PodsMeta::$taxonomies[ $taxonomy ], true );
 	}
 
 	/**
@@ -1983,7 +1983,7 @@ class PodsInit {
 				10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels['singular_name'], esc_url( $preview_post_link ), $labels['singular_name'] ),
 			];
 
-			if ( false === (boolean) $pods_cpt_ct['post_types'][ $post_type['name'] ]['public'] ) {
+			if ( false === (bool) $pods_cpt_ct['post_types'][ $post_type['name'] ]['public'] ) {
 				// translators: %s is the singular label.
 				$messages[ $post_type['name'] ][1] = sprintf( __( '%s updated.', 'pods' ), $labels['singular_name'] );
 				// translators: %s is the singular label.

--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1505,7 +1505,7 @@ class PodsMeta {
 		$data = [];
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -1796,7 +1796,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2045,7 +2045,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2283,7 +2283,7 @@ class PodsMeta {
 		$data = [];
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {
@@ -2758,7 +2758,7 @@ class PodsMeta {
 		}
 
 		if ( $pod ) {
-			$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+			$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 			// Block REST API saves, we handle those separately in PodsRESTHandlers
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && $rest_enable ) {

--- a/classes/PodsRESTHandlers.php
+++ b/classes/PodsRESTHandlers.php
@@ -282,7 +282,7 @@ class PodsRESTHandlers {
 
 		global $wp_rest_additional_fields;
 
-		$rest_enable = (boolean) pods_v( 'rest_enable', $pod->pod_data, false );
+		$rest_enable = (bool) pods_v( 'rest_enable', $pod->pod_data, false );
 
 		if ( $pod && $rest_enable && ! empty( $wp_rest_additional_fields[ $type ] ) ) {
 			$fields = $pod->fields();

--- a/classes/fields/datetime.php
+++ b/classes/fields/datetime.php
@@ -721,7 +721,7 @@ class PodsField_DateTime extends PodsField {
 	 *
 	 * @param string  $format           Format string.
 	 * @param string  $date             Defaults to time() if empty.
-	 * @param boolean $return_timestamp Whether to return the strtotime() or createFromFormat result or not.
+	 * @param bool    $return_timestamp Whether to return the strtotime() or createFromFormat result or not.
 	 *
 	 * @return DateTime|null|int|false
 	 */
@@ -809,9 +809,9 @@ class PodsField_DateTime extends PodsField {
 	 * @param string       $value            Field value.
 	 * @param string       $new_format       New format string.
 	 * @param string|array $original_format  Original format string(s) (if known).
-	 * @param boolean      $return_timestamp Whether to return the strtotime() or createFromFormat result or not.
+	 * @param bool         $return_timestamp Whether to return the strtotime() or createFromFormat result or not.
 	 *
-	 * @return string|int|boolean|DateTime
+	 * @return string|int|bool|DateTime
 	 */
 	public function convert_date( $value, $new_format, $original_format = '', $return_timestamp = false ) {
 

--- a/classes/fields/file.php
+++ b/classes/fields/file.php
@@ -994,8 +994,8 @@ class PodsField_File extends PodsField {
 			$link = '{{link}}';
 		}
 
-		$editable = (boolean) $editable;
-		$linked   = (boolean) $linked;
+		$editable = (bool) $editable;
+		$linked   = (bool) $linked;
 		?>
 		<li class="pods-file hidden" id="pods-file-<?php echo esc_attr( $id ); ?>">
 			<?php

--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -305,7 +305,7 @@ class PodsField_Link extends PodsField_Website {
 	 * Init the editor needed for WP Link modal to work
 	 */
 	public function validate_link_modal() {
-		$init = (boolean) pods_static_cache_get( 'init', __METHOD__ );
+		$init = (bool) pods_static_cache_get( 'init', __METHOD__ );
 
 		if ( $init ) {
 			return;

--- a/classes/fields/pick.php
+++ b/classes/fields/pick.php
@@ -527,7 +527,7 @@ class PodsField_Pick extends PodsField {
 	 * @param string $label   Object label.
 	 * @param array  $options Object options.
 	 *
-	 * @return array|boolean Object array or false if unsuccessful
+	 * @return array|bool Object array or false if unsuccessful
 	 * @since 2.3.0
 	 */
 	public function register_related_object( $name, $label, $options = null ) {
@@ -560,7 +560,7 @@ class PodsField_Pick extends PodsField {
 	/**
 	 * Setup related objects.
 	 *
-	 * @param boolean $force Whether to force refresh of related objects.
+	 * @param bool $force Whether to force refresh of related objects.
 	 *
 	 * @return bool True when data has been loaded
 	 * @since 2.3.0
@@ -886,7 +886,7 @@ class PodsField_Pick extends PodsField {
 	/**
 	 * Return available related objects
 	 *
-	 * @param boolean $force Whether to force refresh of related objects.
+	 * @param bool $force Whether to force refresh of related objects.
 	 *
 	 * @return array Field selection array
 	 * @since 2.3.0
@@ -1110,7 +1110,7 @@ class PodsField_Pick extends PodsField {
 			$field_data = pods_static_cache_get( $field_options['name'] . '/' . $field_options['id'], __CLASS__ . '/field_data' ) ?: [];
 
 			if ( isset( $field_data['autocomplete'] ) ) {
-				$ajax = (boolean) $field_data['autocomplete'];
+				$ajax = (bool) $field_data['autocomplete'];
 			}
 		}
 
@@ -1283,7 +1283,7 @@ class PodsField_Pick extends PodsField {
 		/**
 		 * Filter on whether to allow modals to be used on the front of the site (in an non-admin area).
 		 *
-		 * @param boolean $show_on_front
+		 * @param bool $show_on_front
 		 * @param array   $config
 		 * @param object  $args
 		 *
@@ -1294,7 +1294,7 @@ class PodsField_Pick extends PodsField {
 		/**
 		 * Filter on whether to allow nested modals to be used (modals within modals).
 		 *
-		 * @param boolean $allow_nested_modals
+		 * @param bool $allow_nested_modals
 		 * @param array   $config
 		 * @param object  $args
 		 *
@@ -1838,7 +1838,7 @@ class PodsField_Pick extends PodsField {
 
 					$related_data[ 'remove_ids_' . $id ] = $remove_ids;
 
-					$related_required   = (boolean) pods_v( 'required', $related_field, 0 );
+					$related_required   = (bool) pods_v( 'required', $related_field, 0 );
 					$related_pick_limit = (int) pods_v( static::$type . '_limit', $related_field, 0 );
 
 					if ( 'single' === pods_v( static::$type . '_format_type', $related_field ) ) {
@@ -2278,7 +2278,7 @@ class PodsField_Pick extends PodsField {
 	 * @param array|null        $options Field options.
 	 * @param array|null        $pod     Pod data.
 	 * @param int|null          $id      Item ID.
-	 * @param boolean           $raw     Whether to return the raw list of keys (true) or convert to key=>value (false).
+	 * @param bool              $raw     Whether to return the raw list of keys (true) or convert to key=>value (false).
 	 *
 	 * @return mixed Corrected value
 	 */

--- a/components/Migrate-ACF/Migrate-ACF.php
+++ b/components/Migrate-ACF/Migrate-ACF.php
@@ -120,7 +120,7 @@ class Pods_Migrate_ACF extends PodsComponent {
 
 		if ( isset( $params->post_type ) && ! empty( $params->post_type ) ) {
 			foreach ( $params->post_type as $post_type => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_post_types[] = $post_type;
 				}
 			}
@@ -130,7 +130,7 @@ class Pods_Migrate_ACF extends PodsComponent {
 
 		if ( isset( $params->taxonomy ) && ! empty( $params->taxonomy ) ) {
 			foreach ( $params->taxonomy as $taxonomy => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_taxonomies[] = $taxonomy;
 				}
 			}

--- a/components/Migrate-CPTUI/Migrate-CPTUI.php
+++ b/components/Migrate-CPTUI/Migrate-CPTUI.php
@@ -126,7 +126,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 
 		if ( isset( $params->post_type ) && ! empty( $params->post_type ) ) {
 			foreach ( $params->post_type as $post_type => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_post_types[] = $post_type;
 				}
 			}
@@ -136,7 +136,7 @@ class Pods_Migrate_CPTUI extends PodsComponent {
 
 		if ( isset( $params->taxonomy ) && ! empty( $params->taxonomy ) ) {
 			foreach ( $params->taxonomy as $taxonomy => $checked ) {
-				if ( true === (boolean) $checked ) {
+				if ( true === (bool) $checked ) {
 					$migrate_taxonomies[] = $taxonomy;
 				}
 			}

--- a/components/Migrate-PHP/Migrate-PHP.php
+++ b/components/Migrate-PHP/Migrate-PHP.php
@@ -159,13 +159,13 @@ class Pods_Migrate_PHP extends PodsComponent {
 		$has_objects_to_migrate = ! empty( $pod_templates_selected ) || ! empty( $pod_pages_selected );
 
 		foreach ( $pod_templates_selected as $object_id => $checked ) {
-			if ( true === (boolean) $checked && isset( $pod_templates_available_to_migrate[ (int) $object_id ] ) ) {
+			if ( true === (bool) $checked && isset( $pod_templates_available_to_migrate[ (int) $object_id ] ) ) {
 				$pod_templates[] = $object_id;
 			}
 		}
 
 		foreach ( $pod_pages_selected as $object_id => $checked ) {
-			if ( true === (boolean) $checked && isset( $pod_pages_available_to_migrate[ (int) $object_id ] ) ) {
+			if ( true === (bool) $checked && isset( $pod_pages_available_to_migrate[ (int) $object_id ] ) ) {
 				$pod_pages[] = $object_id;
 			}
 		}

--- a/components/Pages.php
+++ b/components/Pages.php
@@ -554,7 +554,7 @@ class Pods_Pages extends PodsComponent {
 			10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 		];
 
-		if ( false === (boolean) $post_type->public ) {
+		if ( false === (bool) $post_type->public ) {
 			// translators: %s is the singular label.
 			$messages[ $post_type->name ][1] = sprintf( __( '%s updated.', 'pods' ), $labels->singular_name );
 			// translators: %s is the singular label.
@@ -1045,13 +1045,13 @@ class Pods_Pages extends PodsComponent {
 				'page_template' => get_post_meta( $object['ID'], 'page_template', true ),
 				'title'         => get_post_meta( $object['ID'], 'page_title', true ),
 				'options'       => [
-					'admin_only'              => (boolean) get_post_meta( $object['ID'], 'admin_only', true ),
-					'restrict_role'           => (boolean) get_post_meta( $object['ID'], 'restrict_role', true ),
-					'restrict_capability'     => (boolean) get_post_meta( $object['ID'], 'restrict_capability', true ),
+					'admin_only'              => (bool) get_post_meta( $object['ID'], 'admin_only', true ),
+					'restrict_role'           => (bool) get_post_meta( $object['ID'], 'restrict_role', true ),
+					'restrict_capability'     => (bool) get_post_meta( $object['ID'], 'restrict_capability', true ),
 					'roles_allowed'           => get_post_meta( $object['ID'], 'roles_allowed', true ),
 					'capability_allowed'      => get_post_meta( $object['ID'], 'capability_allowed', true ),
-					'restrict_redirect'       => (boolean) get_post_meta( $object['ID'], 'restrict_redirect', true ),
-					'restrict_redirect_login' => (boolean) get_post_meta( $object['ID'], 'restrict_redirect_login', true ),
+					'restrict_redirect'       => (bool) get_post_meta( $object['ID'], 'restrict_redirect', true ),
+					'restrict_redirect_login' => (bool) get_post_meta( $object['ID'], 'restrict_redirect_login', true ),
 					'restrict_redirect_url'   => get_post_meta( $object['ID'], 'restrict_redirect_url', true ),
 					'pod'                     => get_post_meta( $object['ID'], 'pod', true ),
 					'pod_slug'                => get_post_meta( $object['ID'], 'pod_slug', true ),
@@ -1091,13 +1091,13 @@ class Pods_Pages extends PodsComponent {
 			'page_template' => get_post_meta( $id, 'page_template', true ),
 			'title'         => get_post_meta( $id, 'page_title', true ),
 			'options'       => [
-				'admin_only'              => (boolean) get_post_meta( $id, 'admin_only', true ),
-				'restrict_role'           => (boolean) get_post_meta( $id, 'restrict_role', true ),
-				'restrict_capability'     => (boolean) get_post_meta( $id, 'restrict_capability', true ),
+				'admin_only'              => (bool) get_post_meta( $id, 'admin_only', true ),
+				'restrict_role'           => (bool) get_post_meta( $id, 'restrict_role', true ),
+				'restrict_capability'     => (bool) get_post_meta( $id, 'restrict_capability', true ),
 				'roles_allowed'           => get_post_meta( $id, 'roles_allowed', true ),
 				'capability_allowed'      => get_post_meta( $id, 'capability_allowed', true ),
-				'restrict_redirect'       => (boolean) get_post_meta( $id, 'restrict_redirect', true ),
-				'restrict_redirect_login' => (boolean) get_post_meta( $id, 'restrict_redirect_login', true ),
+				'restrict_redirect'       => (bool) get_post_meta( $id, 'restrict_redirect', true ),
+				'restrict_redirect_login' => (bool) get_post_meta( $id, 'restrict_redirect_login', true ),
 				'restrict_redirect_url'   => get_post_meta( $id, 'restrict_redirect_url', true ),
 				'pod'                     => get_post_meta( $id, 'pod', true ),
 				'pod_slug'                => get_post_meta( $id, 'pod_slug', true ),
@@ -1281,7 +1281,7 @@ class Pods_Pages extends PodsComponent {
 		if ( false !== self::$exists ) {
 			$permission = pods_permission( self::$exists );
 
-			$permission = (boolean) apply_filters( 'pods_pages_permission', $permission, self::$exists );
+			$permission = (bool) apply_filters( 'pods_pages_permission', $permission, self::$exists );
 
 			if ( $permission ) {
 				$content = false;

--- a/components/Roles/Roles.php
+++ b/components/Roles/Roles.php
@@ -289,7 +289,7 @@ class Pods_Roles extends PodsComponent {
 		$capabilities = [];
 
 		foreach ( $params->capabilities as $capability => $x ) {
-			if ( empty( $capability ) || true !== (boolean) $x ) {
+			if ( empty( $capability ) || true !== (bool) $x ) {
 				continue;
 			}
 
@@ -354,7 +354,7 @@ class Pods_Roles extends PodsComponent {
 		$new_capabilities = [];
 
 		foreach ( $params->capabilities as $capability => $x ) {
-			if ( empty( $capability ) || true !== (boolean) $x ) {
+			if ( empty( $capability ) || true !== (bool) $x ) {
 				continue;
 			}
 

--- a/components/Templates/Templates.php
+++ b/components/Templates/Templates.php
@@ -303,7 +303,7 @@ class Pods_Templates extends PodsComponent {
 			10 => sprintf( __( '%1$s draft updated. <a target="_blank" rel="noopener noreferrer" href="%2$s">Preview %3$s</a>', 'pods' ), $labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $labels->singular_name ),
 		];
 
-		if ( false === (boolean) $post_type->public ) {
+		if ( false === (bool) $post_type->public ) {
 			// translators: %s is the singular label.
 			$messages[ $post_type->name ][1] = sprintf( __( '%s updated.', 'pods' ), $labels->singular_name );
 			// translators: %s is the singular label.
@@ -621,7 +621,7 @@ class Pods_Templates extends PodsComponent {
 
 				$permission = pods_permission( $template );
 
-				$permission = (boolean) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
+				$permission = (bool) apply_filters( 'pods_templates_permission', $permission, $code, $template, $obj );
 
 				if ( ! $permission ) {
 					if ( 1 === (int) pods_v( 'show_restrict_message', $options, 1 ) ) {

--- a/components/Templates/includes/functions-view_template.php
+++ b/components/Templates/includes/functions-view_template.php
@@ -603,7 +603,7 @@ function frontier_do_subtemplate( $atts, $content ) {
  * @param Pod     $pod
  * @param string  $template
  * @param array   $data
- * @param boolean $skip_unknown If true then values not in $data will not be touched
+ * @param bool    $skip_unknown If true then values not in $data will not be touched
  *
  * @return string
  * @since 2.7.0

--- a/includes/classes.php
+++ b/includes/classes.php
@@ -107,7 +107,7 @@ function pods_get_instance( $type = null, $id = null, $strict = null ) {
  * @see   PodsUI
  *
  * @param array|string|Pods $obj        (optional) Configuration options for the UI
- * @param boolean           $deprecated (optional) Whether to enable deprecated options (used by pods_ui_manage)
+ * @param bool              $deprecated (optional) Whether to enable deprecated options (used by pods_ui_manage)
  *
  * @return PodsUI
  *

--- a/includes/data.php
+++ b/includes/data.php
@@ -1474,8 +1474,8 @@ function pods_unique_slug( $slug, $column_name, $pod, $pod_id = 0, $id = 0, $obj
  * Return a lowercase alphanumeric name (use pods_js_name if you want "_" instead of "-" )
  *
  * @param string  $orig             Input string to clean
- * @param boolean $lower            Force lowercase
- * @param boolean $trim_underscores Whether to trim off underscores
+ * @param bool    $lower            Force lowercase
+ * @param bool    $trim_underscores Whether to trim off underscores
  *
  * @return string Sanitized name
  *
@@ -1508,7 +1508,7 @@ function pods_clean_name( $orig, $lower = true, $trim_underscores = false ) {
  * Return a lowercase alphanumeric name (with underscores) for safe JavaScript variable names.
  *
  * @param string  $orig  Input string to clean.
- * @param boolean $lower Whether to force lowercase.
+ * @param bool    $lower Whether to force lowercase.
  *
  * @return string The sanitized name.
  *

--- a/includes/general.php
+++ b/includes/general.php
@@ -249,7 +249,7 @@ function pods_error_exception( $error ) {
  * Error Handling which throws / displays errors
  *
  * @param string|array        $error The error message(s) to be thrown / displayed.
- * @param object|boolean|null $obj   If $obj->display_errors is set and is set to true it will display errors,
+ * @param object|bool|null $obj   If $obj->display_errors is set and is set to true it will display errors,
  *                                   if boolean and is set to true it will display errors.
  *
  * @return mixed
@@ -308,7 +308,7 @@ function pods_error( $error, $obj = null ) {
 	 *
 	 * @param string                     $error_mode Error mode
 	 * @param string|array               $error      Error message(s)
-	 * @param object|boolean|string|null $obj
+	 * @param object|bool|string|null $obj
 	 */
 	$error_mode = apply_filters( 'pods_error_mode', $error_mode, $error, $obj );
 
@@ -954,7 +954,7 @@ function pods_strict( $include_debug = true ) {
 	/**
 	 * Allow filtering of whether strict mode is enabled.
 	 *
-	 * @param boolean $strict Whether strict mode is enabled.
+	 * @param bool $strict Whether strict mode is enabled.
 	 *
 	 * @since 2.8.0
 	 */
@@ -995,7 +995,7 @@ function pods_api_cache() {
 	/**
 	 * Filter whether to use the Pods API cache.
 	 *
-	 * @param boolean $use_cache Whether to use the Pods API cache.
+	 * @param bool $use_cache Whether to use the Pods API cache.
 	 *
 	 * @since 2.8.0
 	 */
@@ -2796,7 +2796,7 @@ function pods_function_or_file( $function_or_file, $function_name = null, $file_
  *
  * @param string|null $location The path to redirect to.
  * @param int         $status   Status code to use.
- * @param boolean     $die      If true, PHP code execution will stop.
+ * @param bool        $die      If true, PHP code execution will stop.
  */
 function pods_redirect( $location = null, $status = 302, $die = true ) {
 	if ( empty( $location ) ) {
@@ -2915,7 +2915,7 @@ function pods_by_title( $title, $output = OBJECT, $type = 'page', $status = null
  * @param string|null  $pod    The pod name, or if you are in The Loop then you can just provide the field name to auto-detect pod/id using loop information.
  * @param mixed|null   $id     The ID or slug of the item.
  * @param string|array $name   The field name, or an associative array of parameters.
- * @param boolean      $single For tableless fields, to return the whole array or the just the first item.
+ * @param bool         $single For tableless fields, to return the whole array or the just the first item.
  *
  * @return mixed Field value.
  *
@@ -2925,7 +2925,7 @@ function pods_field( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;
@@ -3001,7 +3001,7 @@ function pods_data_field( $obj, $field_name ) {
  * @param string|null  $pod    The pod name, or if you are in The Loop then you can just provide the field name to auto-detect pod/id using loop information.
  * @param mixed|null   $id     The ID or slug of the item.
  * @param string|array $name   The field name, or an associative array of parameters.
- * @param boolean      $single For tableless fields, to return the whole array or the just the first item.
+ * @param bool         $single For tableless fields, to return the whole array or the just the first item.
  *
  * @return mixed Field value.
  *
@@ -3011,7 +3011,7 @@ function pods_field_display( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field_display( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;
@@ -3037,7 +3037,7 @@ function pods_field_display( $pod, $id = null, $name = null, $single = false ) {
  * @param string|null  $pod    The pod name.
  * @param mixed|null   $id     The ID or slug of the item.
  * @param string|array $name   The field name, or an associative array of parameters.
- * @param boolean      $single For tableless fields, to return the whole array or the just the first item.
+ * @param bool         $single For tableless fields, to return the whole array or the just the first item.
  *
  * @return mixed Field value.
  *
@@ -3047,7 +3047,7 @@ function pods_field_raw( $pod, $id = null, $name = null, $single = false ) {
 	// allow for pods_field_raw( 'field_name' );
 	if ( null === $name ) {
 		$name   = $pod;
-		$single = (boolean) $id;
+		$single = (bool) $id;
 
 		$pod = null;
 		$id  = null;
@@ -3074,7 +3074,7 @@ function pods_field_raw( $pod, $id = null, $name = null, $single = false ) {
  * @param string|null  $pod   The pod name.
  * @param mixed|null   $id    The ID or slug of the item.
  * @param string|array $name  The field name, or an associative array of parameters.
- * @param boolean      $value Value to save.
+ * @param bool         $value Value to save.
  *
  * @return int|false The item ID or false if not saved.
  *
@@ -3438,9 +3438,9 @@ function pods_template_part( $template, $data = null, $return = false ) {
  * @param string $type The pod type ('post_type', 'taxonomy', 'media', 'user', 'comment')
  * @param string $name The pod name
  *
- * @return array|boolean|WP_Error Field data or WP_Error if unsuccessful.
+ * @return array|bool|WP_Error Field data or WP_Error if unsuccessful.
  *
- * @return array|boolean Pod data or false if unsuccessful
+ * @return array|bool Pod data or false if unsuccessful
  * @since 2.1.0
  */
 function pods_register_type( $type, $name, $object = null ) {
@@ -3545,7 +3545,7 @@ function pods_register_type( $type, $name, $object = null ) {
  * @param string       $name   The name of the Pod
  * @param array        $object (optional) Pod array, including any 'fields' arrays
  *
- * @return array|boolean|WP_Error Field data or WP_Error if unsuccessful.
+ * @return array|bool|WP_Error Field data or WP_Error if unsuccessful.
  * @since 2.1.0
  */
 function pods_register_field( $pod, $name, $field = null ) {
@@ -3586,7 +3586,7 @@ function pods_register_field_type( $type, $file = null ) {
  * @param string $label   Object label
  * @param array  $options Object options
  *
- * @return array|boolean Object array or false if unsuccessful
+ * @return array|bool Object array or false if unsuccessful
  * @since 2.3.0
  */
 function pods_register_related_object( $name, $label, $options = null ) {

--- a/includes/media.php
+++ b/includes/media.php
@@ -126,7 +126,7 @@ function pods_is_image_size( $size ) {
  * @param int              $default    Default image to show if image not found, can be field array, ID, or guid.
  *                                     Passing `-1` prevents default filter.
  * @param string|array     $attributes <img> Attributes array or string (passed to wp_get_attachment_image).
- * @param boolean          $force      Force generation of image (if custom size array provided).
+ * @param bool             $force      Force generation of image (if custom size array provided).
  *
  * @return string <img> HTML or empty if image not found.
  *
@@ -173,7 +173,7 @@ function pods_image( $image, $size = 'thumbnail', $default = 0, $attributes = ''
  * @param string|array     $size    Image size to use.
  * @param int              $default Default image to show if image not found, can be field array, ID, or guid.
  *                                  Passing `-1` prevents default filter.
- * @param boolean          $force   Force generation of image (if custom size array provided).
+ * @param bool             $force   Force generation of image (if custom size array provided).
  *
  * @return string Image URL or empty if image not found.
  *
@@ -229,8 +229,8 @@ function pods_image_url( $image, $size = 'thumbnail', $default = 0, $force = fal
  *
  * @param string  $url         URL to media for import.
  * @param int     $post_parent ID of post parent, default none.
- * @param boolean $featured    Whether to set it as the featured (post thumbnail) of the post parent.
- * @param boolean $strict      Whether to return errors upon failure.
+ * @param bool    $featured    Whether to set it as the featured (post thumbnail) of the post parent.
+ * @param bool    $strict      Whether to return errors upon failure.
  *
  * @return int Attachment ID.
  *

--- a/sql/upgrade/PodsUpgrade.php
+++ b/sql/upgrade/PodsUpgrade.php
@@ -252,7 +252,7 @@ class PodsUpgrade {
 		$method = str_replace( 'migrate_', '', $method );
 
 		if ( null !== $x ) {
-			$this->progress[ $method ][ $x ] = (boolean) $v;
+			$this->progress[ $method ][ $x ] = (bool) $v;
 		} else {
 			$this->progress[ $method ] = $v;
 		}
@@ -273,7 +273,7 @@ class PodsUpgrade {
 			if ( null === $x ) {
 				return $this->progress[ $method ];
 			} elseif ( isset( $this->progress[ $method ][ $x ] ) ) {
-				return (boolean) $this->progress[ $method ][ $x ];
+				return (bool) $this->progress[ $method ][ $x ];
 			}
 		}
 

--- a/src/Pods/Whatsit.php
+++ b/src/Pods/Whatsit.php
@@ -122,7 +122,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	 * Setup object from a serialized string.
 	 *
 	 * @param string  $serialized Serialized representation of the object.
-	 * @param boolean $to_args    Return as arguments array.
+	 * @param bool    $to_args    Return as arguments array.
 	 *
 	 * @return Whatsit|array|null
 	 */
@@ -157,7 +157,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	 * Setup object from a JSON string.
 	 *
 	 * @param string  $json    JSON representation of the object.
-	 * @param boolean $to_args Return as arguments array.
+	 * @param bool    $to_args Return as arguments array.
 	 *
 	 * @return Whatsit|array|null
 	 */
@@ -176,7 +176,7 @@ abstract class Whatsit implements \ArrayAccess, \JsonSerializable, \Iterator {
 	 * Setup object from an array configuration.
 	 *
 	 * @param array   $array   Array configuration.
-	 * @param boolean $to_args Return as arguments array.
+	 * @param bool    $to_args Return as arguments array.
 	 *
 	 * @return Whatsit|array|null
 	 */

--- a/src/Pods/Whatsit/Block_Field.php
+++ b/src/Pods/Whatsit/Block_Field.php
@@ -307,7 +307,7 @@ class Block_Field extends Field {
 		];
 
 		$label   = $this->get_arg( 'label' );
-		$default = (boolean) $this->get_arg( 'default', 0 );
+		$default = (bool) $this->get_arg( 'default', 0 );
 
 		if ( 'radio' === $format_type ) {
 			return [

--- a/src/Pods/Whatsit/Pod.php
+++ b/src/Pods/Whatsit/Pod.php
@@ -27,7 +27,7 @@ class Pod extends Whatsit {
 	 *
 	 * @since 2.8.1
 	 *
-	 * @param boolean $strict Whether to only get the argument, otherwise the default will be returned.
+	 * @param bool $strict Whether to only get the argument, otherwise the default will be returned.
 	 *
 	 * @return string The storage used for the Pod data (meta, table, etc).
 	 */

--- a/src/Pods/Whatsit/Storage.php
+++ b/src/Pods/Whatsit/Storage.php
@@ -486,7 +486,7 @@ abstract class Storage {
 	 * @param bool $enabled Whether to enable fallback mode.
 	 */
 	public function fallback_mode( $enabled = true ) {
-		$this->fallback_mode = (boolean) $enabled;
+		$this->fallback_mode = (bool) $enabled;
 	}
 
 	/**

--- a/src/Pods/Whatsit/Storage/Post_Type.php
+++ b/src/Pods/Whatsit/Storage/Post_Type.php
@@ -194,7 +194,7 @@ class Post_Type extends Collection {
 		$fallback_mode = $this->fallback_mode;
 
 		if ( isset( $args['fallback_mode'] ) ) {
-			$fallback_mode = (boolean) $args['fallback_mode'];
+			$fallback_mode = (bool) $args['fallback_mode'];
 		}
 
 		$meta_query = [];

--- a/src/Pods/Whatsit/Store.php
+++ b/src/Pods/Whatsit/Store.php
@@ -714,7 +714,7 @@ class Store {
 
 		// Filter objects by internal.
 		if ( isset( $args['internal'] ) ) {
-			$args['internal'] = (boolean) $args['internal'];
+			$args['internal'] = (bool) $args['internal'];
 
 			$objects = array_filter( $objects, static function( $object ) use ( $args ) {
 				$internal = false;
@@ -725,7 +725,7 @@ class Store {
 					$internal = $object['internal'];
 				}
 
-				return $args['internal'] === (boolean) $internal;
+				return $args['internal'] === (bool) $internal;
 			} );
 		}
 

--- a/tests/codeception/wpunit-traversal/Pods/Field/TraversalTest.php
+++ b/tests/codeception/wpunit-traversal/Pods/Field/TraversalTest.php
@@ -194,7 +194,7 @@ class TraversalTest extends Pods_TraversalTestCase {
 	 * @param string  $variant_id Testing variant identification
 	 * @param array   $options    Data config to test
 	 * @param string  $method     Method to test
-	 * @param boolean $deep       Whether to test deep traversal
+	 * @param bool    $deep       Whether to test deep traversal
 	 */
 	private function _test_field_traversal( $variant_id, $options, $method, $deep ) {
 		pods_debug( $variant_id );

--- a/tests/codeception/wpunit-traversal/Pods/Fields/TraversalTest.php
+++ b/tests/codeception/wpunit-traversal/Pods/Fields/TraversalTest.php
@@ -129,7 +129,7 @@ class TraversalTest extends Pods_TraversalTestCase {
 	 *
 	 * @param string  $variant_id Testing variant identification
 	 * @param array   $options    Data config to test
-	 * @param boolean $deep       Whether to test deep traversal
+	 * @param bool    $deep       Whether to test deep traversal
 	 */
 	private function _test_fields_traversal( $variant_id, $options, $deep ) {
 		pods_debug( $variant_id );

--- a/tests/codeception/wpunit-traversal/Pods/Find/TraversalTest.php
+++ b/tests/codeception/wpunit-traversal/Pods/Find/TraversalTest.php
@@ -195,7 +195,7 @@ class TraversalTest extends Pods_TraversalTestCase {
 	 *
 	 * @param string  $variant_id   Testing variant identification
 	 * @param array   $options      Data config to test
-	 * @param boolean $query_fields Whether to test query_fields WHERE syntax
+	 * @param bool    $query_fields Whether to test query_fields WHERE syntax
 	 */
 	private function _test_find_base( $variant_id, $options, $query_fields = false ) {
 		pods_debug( $variant_id );
@@ -289,8 +289,8 @@ class TraversalTest extends Pods_TraversalTestCase {
 	 *
 	 * @param string  $variant_id   Testing variant identification
 	 * @param array   $options      Data config to test
-	 * @param boolean $deep         Whether to test deep traversal
-	 * @param boolean $query_fields Whether to test query_fields WHERE syntax
+	 * @param bool    $deep         Whether to test deep traversal
+	 * @param bool    $query_fields Whether to test query_fields WHERE syntax
 	 */
 	private function _test_find_traversal( $variant_id, $options, $deep = false, $query_fields = false ) {
 		pods_debug( $variant_id );

--- a/ui/forms/form.php
+++ b/ui/forms/form.php
@@ -31,7 +31,7 @@ if ( empty( $fields ) || ! is_array( $fields ) ) {
 if ( ! isset( $duplicate ) || $is_settings_pod ) {
 	$duplicate = false;
 } else {
-	$duplicate = (boolean) $duplicate;
+	$duplicate = (bool) $duplicate;
 }
 
 $groups = PodsInit::$meta->groups_get( $pod->pod_data['type'], $pod->pod_data['name'], $fields );


### PR DESCRIPTION
## Description

Since PHP 8.5 using non-canonical type variations, like `boolean`, in casts is deprecated. Also see https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated.

## Related GitHub issue(s)

#7587

## Testing instructions

1. Install PODS
2. Use it
3. Verify that there are no warnings about deprecated non-canonical casts

## Screenshots / screencast

<!-- If you have any screenshot(s) or screencast(s) to show your PR off, these can help us review things more quickly. -->

## Changelog text for these changes

All type PHP casts in the form `$x = (boolean)$y` have been replaced by `$x = (bool)$y`.

All PHP annotations using `boolean` as type have been replaced by `bool`.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [x] My code includes automated tests for PHP and/or JS (if applicable).
