### PR TITLE
fix(metabox): build %-free metabox IDs for non-ASCII group labels

### DIFF
--- a/classes/PodsMeta.php
+++ b/classes/PodsMeta.php
@@ -1115,6 +1115,54 @@ class PodsMeta {
 	}
 
 	/**
+	 * Build a safe metabox slug for a Pods group.
+	 *
+	 * Sanitize_title() percent-encodes non-ASCII labels (e.g. Cyrillic),
+	 * and WP 7.1 passes metabox IDs through wp_get_tooltip()/sprintf()
+	 * where %d, %b, etc. become format placeholders. This helper produces
+	 * a %-free, HTML-valid slug. See #7615.
+	 *
+	 * @param array $group      Group data with optional keys `name` and `label`.
+	 * @param array $used_slugs Slugs already used on the screen, passed by
+	 *                          reference so every group gets a unique ID.
+	 *
+	 * @return string
+	 */
+	public static function get_meta_box_slug( array $group, array &$used_slugs = [] ): string {
+		$slug = '';
+
+		if ( ! empty( $group['name'] ) ) {
+			$slug = sanitize_key( $group['name'] );
+		}
+
+		if ( '' === $slug && ! empty( $group['label'] ) ) {
+			$slug = pods_create_slug( $group['label'], true );
+		}
+
+		$slug = trim( (string) preg_replace( '/-+/', '-', $slug ), '-' );
+
+		if ( '' === $slug ) {
+			$slug = 'more-fields';
+		}
+
+		$slug = str_replace( '%', '', $slug );
+
+		// Make sure each group on the screen gets a unique metabox ID.
+		$base_slug = $slug;
+		$suffix    = 2;
+
+		while ( isset( $used_slugs[ $slug ] ) ) {
+			$slug = $base_slug . '-' . $suffix;
+			++$suffix;
+		}
+
+
+		$used_slugs[ $slug ] = true;
+
+		return $slug;
+	}
+
+	/**
 	 * @param      $post_type
 	 * @param null $post
 	 */
@@ -1133,6 +1181,7 @@ class PodsMeta {
 
 		$groups           = $this->groups_get( 'post_type', $post_type, null, false, $post_id );
 		$pods_field_found = false;
+		$used_slugs       = [];
 
 		foreach ( $groups as $group ) {
 			if ( empty( $group['fields'] ) ) {
@@ -1165,7 +1214,7 @@ class PodsMeta {
 
 			if ( $field_found ) {
 				$pods_field_found = true;
-				add_meta_box( 'pods-meta-' . sanitize_title( $group['label'] ), wp_kses_post( $group['label'] ), [
+				add_meta_box( 'pods-meta-' . self::get_meta_box_slug( $group, $used_slugs ), wp_kses_post( $group['label'] ), [
 					$this,
 					'meta_post',
 				], $post_type, $group['context'], $group['priority'], [ 'group' => $group ] );
@@ -2547,7 +2596,8 @@ class PodsMeta {
 			$comment_type = 'comment';
 		}
 
-		$groups = $this->groups_get( 'comment', $comment_type );
+		$groups     = $this->groups_get( 'comment', $comment_type );
+		$used_slugs = [];
 
 		foreach ( $groups as $group ) {
 			if ( empty( $group['fields'] ) ) {
@@ -2575,7 +2625,7 @@ class PodsMeta {
 			}
 
 			if ( $field_found ) {
-				add_meta_box( 'pods-meta-' . sanitize_title( $group['label'] ), wp_kses_post( $group['label'] ), [
+				add_meta_box( 'pods-meta-' . self::get_meta_box_slug( $group, $used_slugs ), wp_kses_post( $group['label'] ), [
 					$this,
 					'meta_comment',
 				], $comment_type, $group['context'], $group['priority'], [ 'group' => $group ] );

--- a/ui/forms/type/post.php
+++ b/ui/forms/type/post.php
@@ -443,6 +443,8 @@ do_action( 'pods_meta_box_pre', $pod, $obj );
 			}//end if
 
 			if ( 0 < count( $groups ) ) {
+				$used_slugs = [];
+
 				if ( $more && 1 == count( $groups ) ) {
 					$first_group = current( $groups );
 
@@ -480,7 +482,7 @@ do_action( 'pods_meta_box_pre', $pod, $obj );
 							/** This filter is documented in classes/PodsMeta.php */
 							$title = apply_filters( 'pods_meta_default_box_title', $title, $pod->pod_data, $fields, $pod->pod_data['type'], $pod->pod );
 							?>
-							<div id="pods-meta-box-<?php echo esc_attr( sanitize_title( $group['label'] ) ); ?>"
+							<div id="pods-meta-box-<?php echo esc_attr( PodsMeta::get_meta_box_slug( $group, $used_slugs ) ); ?>"
 								class="postbox">
 								<?php PodsForm::render_postbox_header( $title ); ?>
 


### PR DESCRIPTION
## Description

Pods builds metabox IDs as `pods-meta-` + `sanitize_title( $group['label'] )`. For non-ASCII labels, `sanitize_title()` percent-encodes the label, so a Cyrillic group labeled `Игра` produces an ID like `pods-meta-%d0%b8%d0%b3%d1%80%d0%b0`.

WordPress 7.1 passes metabox IDs through `wp_get_tooltip()`, which feeds the ID into `sprintf()`. The `%d`, `%b` sequences in that ID are then parsed as format placeholders and PHP throws:

```
Uncaught Error: 9 arguments are required, 6 given in wp-includes/general-template.php
```

This breaks the post editor with a fatal error whenever a Pods group has a non-ASCII label.

This PR introduces a shared helper, `PodsMeta::get_meta_box_slug()`, that produces metabox slugs guaranteed to be free of `%` characters. It prefers the group's machine name via `sanitize_key()`, falls back to `pods_create_slug()` in strict mode for the label (which transliterates accents and strips everything outside `[0-9a-z-]`, so `Игра` becomes `igra`), uses a `more-fields` fallback when nothing survives sanitizing, and appends `-2`/`-3` suffixes to keep IDs unique per screen.

Both `add_meta_box()` call sites (post types and comments) now use the helper, and the Advanced Content Type editor postbox template uses it too, so all three places that previously called `sanitize_title()` on group labels are covered.

AI disclosure: this PR was written with Claude assistance, reviewed and tested by me.

## Related GitHub issue(s)

Fixes #7615

## Testing instructions

1. Install Pods on WordPress 7.1 (or any version where the tooltip sprintf issue applies).
2. Create a Pod extending Posts with a group labeled `Игра` containing at least one field.
3. Open any post of that post type in the block editor.
4. Before this fix: the editor fails to load with `Uncaught Error: 9 arguments are required, 6 given`. After this fix: the editor loads normally.
5. Inspect the page source or DOM: the metabox wrapper has ID `pods-meta-igra`, no `%` characters anywhere.
6. Regression: repeat with an ASCII-labeled group (e.g. `Game`). The box renders with ID `pods-meta-game`.
7. Add two groups whose labels produce the same slug (e.g. `Игра` and `игра!`). Both boxes render; the second gets ID `pods-meta-igra-2`.
8. Add a group whose label produces no slug characters (e.g. `***`). The box renders with ID `pods-meta-more-fields`.
9. Toggle the Pods metaboxes in Screen Options and reload. Hidden state persists for the new IDs.
10. Optional: check a comment edit screen with Pods comment fields, and an ACT item editor with a non-ASCII group label. Metabox IDs there are also `%`-free.

Tested manually: confirmed this resolves the reported issue.

## Screenshots / screencast

No UI change beyond corrected behavior; the editor loads instead of throwing a fatal error.

## Changelog text for these changes

Bug: Fixed a fatal error on WordPress 7.1 when editing items of a Pod whose field group labels contain non-ASCII characters like Cyrillic letters. #7615 (@faisalahammad)

## Backward compatibility

Backward compatible: yes, no breaking changes. One visible side effect: metabox IDs change from percent-encoded forms (`pods-meta-%d0%b8...`) to transliterated slugs (`pods-meta-igra`). Users who had hidden such boxes will see them reappear once and can re-hide them; ASCII-labeled groups keep stable IDs via the group name.

## Tests

Tests: no new automated test added — Codeception wpunit coverage requires a live WP + database environment which is not part of this repo's standard local setup, and the existing `tests/codeception/wpunit/Pods/MetaTest.php` covers save hooks rather than metabox registration. The fix is verified through the manual steps above covering the reported case, ASCII regression, slug collisions, empty-slug fallback, comment screens, and ACT editors.

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).